### PR TITLE
chore: replace <img> with Next.js <Image> and add dimensions (fix @ne…

### DIFF
--- a/src/components/find-workers/talent-detail-dialog.tsx
+++ b/src/components/find-workers/talent-detail-dialog.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState } from "react"
+import Image from "next/image"
 import { VALIDATION_LIMITS } from "@/constants/magic-numbers"
 import { Dialog, DialogContent } from "@/components/ui/dialog"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
@@ -266,9 +267,11 @@ export default function TalentDetailDialog({
                       {portfolio.slice(0, VALIDATION_LIMITS.MAX_PORTFOLIO_ITEMS_DISPLAY).map((item) => (
                         <div key={item.id} className="border rounded-lg overflow-hidden">
                           <div className="h-40 bg-gray-100 flex items-center justify-center">
-                            <img
+                            <Image
                               src={item.image || "/placeholder.svg"}
                               alt={item.title}
+                              width={400}
+                              height={160}
                               className="w-full h-full object-cover"
                             />
                           </div>
@@ -294,9 +297,11 @@ export default function TalentDetailDialog({
                     {portfolio.map((item) => (
                       <div key={item.id} className="border rounded-lg overflow-hidden">
                         <div className="h-48 bg-gray-100 flex items-center justify-center">
-                          <img
+                          <Image
                             src={item.image || "/placeholder.svg"}
                             alt={item.title}
+                            width={500}
+                            height={192}
                             className="w-full h-full object-cover"
                           />
                         </div>

--- a/src/components/layout/OnboardingHeader.tsx
+++ b/src/components/layout/OnboardingHeader.tsx
@@ -1,5 +1,6 @@
 "use client";
 import React from 'react';
+import Image from 'next/image';
 
 interface OnboardingHeaderProps {
   onSignUp?: () => void;
@@ -17,9 +18,11 @@ const OnboardingHeader: React.FC<OnboardingHeaderProps> = ({
   return (
     <header className="flex items-center justify-between px-6 py-4 bg-white">
       <div className="flex items-center space-x-2">
-        <img 
+        <Image 
           src="/dark_logo.svg" 
           alt="OfferHub Logo" 
+          width={112}
+          height={56}
           className="h-14 w-auto"
         />
         <span className="text-gray-800 font-semibold text-2xl">OfferHub</span>

--- a/src/components/talent/TalentLayout.tsx
+++ b/src/components/talent/TalentLayout.tsx
@@ -14,6 +14,7 @@ import {
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
+import Image from "next/image";
 
 interface TalentLayoutProps {
   children: ReactNode;
@@ -62,7 +63,7 @@ export default function TalentLayout({ children }: TalentLayoutProps) {
         {/* Logo */}
         <div className="p-6 border-b border-gray-200">
           <div className="flex items-center gap-2">
-            <img src="/logo.svg" alt="Offer Hub Logo" className="w-8 h-8" />
+            <Image src="/logo.svg" alt="Offer Hub Logo" width={32} height={32} className="w-8 h-8" />
             <span className="text-xl font-bold text-gray-900">Offer Hub</span>
           </div>
         </div>


### PR DESCRIPTION
### 📝 Pull Request Title
chore: replace <img> with Next.js Image and add dimensions (fix @next/next/no-img-element)

### 🛠️ Issue
- Closes #554

### 📚 Description
- Replaced standard HTML `img` tags with Next.js `Image` component to leverage built-in image optimization for performance and SEO benefits.
- Added required `width` and `height` props to each `Image`.
- Preserved existing `alt` attributes and all styling classes.
- Resolved ESLint warnings for `@next/next/no-img-element`.

### ✅ Changes applied
- Updated `src/components/find-workers/talent-detail-dialog.tsx`
  - Replaced two `img` elements (portfolio sections) with `Image`.
  - Added `width={400} height={160}` and `width={500} height={192}` respectively.
  - Kept `alt` and `className` intact.
- Updated `src/components/layout/OnboardingHeader.tsx`
  - Replaced logo `img` with `Image` and added `width={112} height={56}`.
- Updated `src/components/talent/TalentLayout.tsx`
  - Replaced sidebar logo `img` with `Image` and added `width={32} height={32}`.
- Added `import Image from 'next/image'` where needed.

### 🔍 Evidence/Media (screenshots/videos)
- Linting passes with no `@next/next/no-img-element` warnings.
- Visual appearance preserved (same classes and dimensions).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Header supports configurable visibility for action buttons, including an option to hide the “Sign in” button.
  * Added a search icon action in the header actions area.

* Refactor
  * Replaced standard images with optimized images across portfolio sections and headers for better loading and consistency.

* Performance
  * Improved image rendering with explicit dimensions to enhance page load stability and responsiveness.

* UI
  * Updated header and talent layout logos to use optimized images without altering existing styles or layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->