### PR TITLE
feat: Implement dispute integration management components

### DIFF
--- a/src/components/disputes/api-integration.tsx
+++ b/src/components/disputes/api-integration.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useDisputeIntegration } from "@/hooks/use-dispute-integration";
+import type {
+  CreateIntegrationInstanceDTO,
+  IntegrationInstance,
+} from "@/types/integration.types";
+
+export default function ApiIntegration() {
+  const { providers, instances, loading, error, actions } =
+    useDisputeIntegration();
+  const [filter, setFilter] = useState("");
+
+  const filteredInstances = useMemo(() => {
+    const q = filter.trim().toLowerCase();
+    if (!q) return instances;
+    return instances.filter(
+      (i) =>
+        i.name.toLowerCase().includes(q) ||
+        i.providerId.toLowerCase().includes(q)
+    );
+  }, [filter, instances]);
+
+  const onCreate = async (providerId: string) => {
+    const name = prompt("Integration name");
+    if (!name) return;
+    const dto: CreateIntegrationInstanceDTO = { providerId, name, config: {} };
+    await actions.createInstance(dto);
+  };
+
+  const onToggle = async (instance: IntegrationInstance) => {
+    await actions.toggleInstance(instance.id, !instance.enabled);
+  };
+
+  const onDelete = async (id: string) => {
+    if (!confirm("Delete this integration?")) return;
+    await actions.deleteInstance(id);
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h2 className="text-xl font-semibold">API Integrations</h2>
+        <div className="flex gap-2">
+          <input
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+            placeholder="Search integrations"
+            className="border rounded px-3 py-2 text-sm"
+          />
+        </div>
+      </div>
+
+      {error && <div className="text-red-600 text-sm">{error}</div>}
+
+      <div>
+        <h3 className="text-lg font-medium mb-2">Available Providers</h3>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {providers.map((p) => (
+            <div
+              key={p.id}
+              className="border rounded p-4 flex items-start gap-3"
+            >
+              {p.logoUrl ? (
+                <img src={p.logoUrl} alt={p.name} className="h-8 w-8" />
+              ) : (
+                <div className="h-8 w-8 rounded bg-gray-200" />
+              )}
+              <div className="flex-1">
+                <div className="font-medium">{p.name}</div>
+                <div className="text-xs text-gray-500 mb-2">
+                  {p.description}
+                </div>
+                <button
+                  className="text-sm px-3 py-1 rounded bg-black text-white"
+                  onClick={() => onCreate(p.id)}
+                  disabled={loading}
+                >
+                  Connect
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div>
+        <h3 className="text-lg font-medium mb-2">Connected Integrations</h3>
+        <div className="border rounded overflow-hidden">
+          <table className="min-w-full text-sm">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="text-left px-3 py-2">Name</th>
+                <th className="text-left px-3 py-2">Provider</th>
+                <th className="text-left px-3 py-2">Status</th>
+                <th className="text-right px-3 py-2">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filteredInstances.map((i) => (
+                <tr key={i.id} className="border-t">
+                  <td className="px-3 py-2">{i.name}</td>
+                  <td className="px-3 py-2">{i.providerId}</td>
+                  <td className="px-3 py-2">
+                    {i.enabled ? "Enabled" : "Disabled"}
+                  </td>
+                  <td className="px-3 py-2 text-right">
+                    <button
+                      className="text-xs mr-2 underline"
+                      onClick={() => onToggle(i)}
+                    >
+                      {i.enabled ? "Disable" : "Enable"}
+                    </button>
+                    <button
+                      className="text-xs text-red-600 underline"
+                      onClick={() => onDelete(i.id)}
+                    >
+                      Delete
+                    </button>
+                  </td>
+                </tr>
+              ))}
+              {!filteredInstances.length && (
+                <tr>
+                  <td
+                    colSpan={4}
+                    className="text-center text-gray-500 px-3 py-6"
+                  >
+                    No integrations
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/disputes/integration-frameworks.tsx
+++ b/src/components/disputes/integration-frameworks.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useDisputeIntegration } from "@/hooks/use-dispute-integration";
+
+const POPULAR = [
+  { id: "slack", name: "Slack", desc: "Notify channels on dispute updates" },
+  { id: "jira", name: "Jira", desc: "Create Jira issues for disputes" },
+  { id: "zapier", name: "Zapier", desc: "Automate with 5000+ apps" },
+  { id: "github", name: "GitHub", desc: "Open issues from disputes" },
+];
+
+export default function IntegrationFrameworks() {
+  const { providers, instances, actions } = useDisputeIntegration();
+  const [q, setQ] = useState("");
+
+  const available = useMemo(() => {
+    const ids = new Set(instances.map((i) => i.providerId));
+    return providers.filter((p) => !ids.has(p.id));
+  }, [providers, instances]);
+
+  const filtered = useMemo(() => {
+    const query = q.trim().toLowerCase();
+    if (!query) return available;
+    return available.filter((p) => p.name.toLowerCase().includes(query));
+  }, [q, available]);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h2 className="text-xl font-semibold">Integration Frameworks</h2>
+        <input
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+          placeholder="Search frameworks"
+          className="border rounded px-3 py-2 text-sm"
+        />
+      </div>
+
+      <div>
+        <h3 className="text-lg font-medium mb-2">Popular</h3>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {POPULAR.map((f) => (
+            <div key={f.id} className="border rounded p-4">
+              <div className="font-medium">{f.name}</div>
+              <div className="text-xs text-gray-500 mb-3">{f.desc}</div>
+              <button
+                className="text-sm px-3 py-1 rounded bg-black text-white"
+                onClick={() =>
+                  actions.createInstance({
+                    providerId: f.id,
+                    name: `${f.name} Integration`,
+                    config: {},
+                  })
+                }
+              >
+                Add
+              </button>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div>
+        <h3 className="text-lg font-medium mb-2">All Providers</h3>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {filtered.map((p) => (
+            <div key={p.id} className="border rounded p-4">
+              <div className="font-medium">{p.name}</div>
+              <div className="text-xs text-gray-500 mb-3">{p.description}</div>
+              <button
+                className="text-sm px-3 py-1 rounded bg-black text-white"
+                onClick={() =>
+                  actions.createInstance({
+                    providerId: p.id,
+                    name: `${p.name} Integration`,
+                    config: {},
+                  })
+                }
+              >
+                Add
+              </button>
+            </div>
+          ))}
+          {!filtered.length && (
+            <div className="text-sm text-gray-500">No providers available</div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/disputes/webhook-management.tsx
+++ b/src/components/disputes/webhook-management.tsx
@@ -1,0 +1,255 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useDisputeIntegration } from "@/hooks/use-dispute-integration";
+import type {
+  CreateWebhookDTO,
+  DisputeEventType,
+  WebhookEndpoint,
+} from "@/types/integration.types";
+
+const ALL_EVENTS: DisputeEventType[] = [
+  "dispute.created",
+  "dispute.updated",
+  "dispute.resolved",
+  "dispute.escalated",
+  "evidence.added",
+  "mediation.started",
+  "arbitration.started",
+];
+
+export default function WebhookManagement() {
+  const { webhooks, actions } = useDisputeIntegration();
+  const [selected, setSelected] = useState<WebhookEndpoint | null>(null);
+  const [filter, setFilter] = useState("");
+
+  const filtered = useMemo(() => {
+    const q = filter.trim().toLowerCase();
+    if (!q) return webhooks;
+    return webhooks.filter(
+      (w) =>
+        w.url.toLowerCase().includes(q) ||
+        (w.description || "").toLowerCase().includes(q)
+    );
+  }, [filter, webhooks]);
+
+  const [form, setForm] = useState<CreateWebhookDTO>({
+    url: "",
+    events: ["dispute.created"],
+  });
+
+  const onCreate = async () => {
+    if (!form.url) return;
+    const created = await actions.createWebhook(form);
+    setSelected(created);
+    setForm({ url: "", events: ["dispute.created"] });
+  };
+
+  const onToggleActive = async (w: WebhookEndpoint) => {
+    await actions.updateWebhook(w.id, { isActive: !w.isActive });
+  };
+
+  const onDelete = async (w: WebhookEndpoint) => {
+    if (!confirm("Delete this webhook?")) return;
+    await actions.deleteWebhook(w.id);
+    if (selected?.id === w.id) setSelected(null);
+  };
+
+  const [deliveries, setDeliveries] = useState<any[] | null>(null);
+  useEffect(() => {
+    const load = async () => {
+      if (!selected) return;
+      const list = await actions.listDeliveries(selected.id);
+      setDeliveries(list);
+    };
+    load();
+  }, [selected, actions]);
+
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+      <div className="lg:col-span-2 space-y-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-xl font-semibold">Webhooks</h2>
+          <input
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+            placeholder="Search webhooks"
+            className="border rounded px-3 py-2 text-sm"
+          />
+        </div>
+
+        <div className="border rounded overflow-hidden">
+          <table className="min-w-full text-sm">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="text-left px-3 py-2">URL</th>
+                <th className="text-left px-3 py-2">Events</th>
+                <th className="text-left px-3 py-2">Status</th>
+                <th className="text-right px-3 py-2">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filtered.map((w) => (
+                <tr
+                  key={w.id}
+                  className="border-t hover:bg-gray-50 cursor-pointer"
+                  onClick={() => setSelected(w)}
+                >
+                  <td className="px-3 py-2">{w.url}</td>
+                  <td className="px-3 py-2">{w.events.join(", ")}</td>
+                  <td className="px-3 py-2">
+                    {w.isActive ? "Active" : "Inactive"}
+                  </td>
+                  <td className="px-3 py-2 text-right">
+                    <button
+                      className="text-xs mr-2 underline"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onToggleActive(w);
+                      }}
+                    >
+                      {w.isActive ? "Disable" : "Enable"}
+                    </button>
+                    <button
+                      className="text-xs text-red-600 underline"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onDelete(w);
+                      }}
+                    >
+                      Delete
+                    </button>
+                  </td>
+                </tr>
+              ))}
+              {!filtered.length && (
+                <tr>
+                  <td
+                    colSpan={4}
+                    className="text-center text-gray-500 px-3 py-6"
+                  >
+                    No webhooks
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        <div className="border rounded p-4 space-y-3">
+          <h3 className="font-medium">Create Webhook</h3>
+          <input
+            value={form.url}
+            onChange={(e) => setForm((f) => ({ ...f, url: e.target.value }))}
+            placeholder="https://example.com/webhooks"
+            className="border rounded px-3 py-2 text-sm w-full"
+          />
+          <input
+            value={form.secret || ""}
+            onChange={(e) => setForm((f) => ({ ...f, secret: e.target.value }))}
+            placeholder="Optional secret"
+            className="border rounded px-3 py-2 text-sm w-full"
+          />
+          <div className="flex flex-wrap gap-2">
+            {ALL_EVENTS.map((evt) => {
+              const checked = form.events.includes(evt);
+              return (
+                <label
+                  key={evt}
+                  className={`text-xs px-2 py-1 border rounded cursor-pointer ${
+                    checked ? "bg-black text-white" : ""
+                  }`}
+                >
+                  <input
+                    type="checkbox"
+                    checked={checked}
+                    onChange={(e) => {
+                      const checkedNow = e.target.checked;
+                      setForm((f) => ({
+                        ...f,
+                        events: checkedNow
+                          ? Array.from(new Set([...(f.events || []), evt]))
+                          : (f.events || []).filter((x) => x !== evt),
+                      }));
+                    }}
+                    className="mr-1"
+                  />
+                  {evt}
+                </label>
+              );
+            })}
+          </div>
+          <button
+            className="text-sm px-3 py-2 rounded bg-black text-white"
+            onClick={onCreate}
+          >
+            Create Webhook
+          </button>
+        </div>
+      </div>
+
+      <div className="border rounded p-4 space-y-3">
+        <h3 className="font-medium">Deliveries</h3>
+        {selected ? (
+          <>
+            <div className="text-sm text-gray-600">{selected.url}</div>
+            <button
+              className="text-xs underline"
+              onClick={async () => {
+                const list = await actions.listDeliveries(selected.id);
+                setDeliveries(list);
+              }}
+            >
+              Refresh
+            </button>
+            <div className="max-h-80 overflow-auto border rounded">
+              <table className="min-w-full text-xs">
+                <thead className="bg-gray-50">
+                  <tr>
+                    <th className="text-left px-2 py-1">Status</th>
+                    <th className="text-left px-2 py-1">Event</th>
+                    <th className="text-left px-2 py-1">At</th>
+                    <th className="text-right px-2 py-1">Action</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {(deliveries || []).map((d: any) => (
+                    <tr key={d.id} className="border-t">
+                      <td className="px-2 py-1">{d.statusCode || "pending"}</td>
+                      <td className="px-2 py-1">{d.eventType}</td>
+                      <td className="px-2 py-1">{d.deliveredAt || "-"}</td>
+                      <td className="px-2 py-1 text-right">
+                        <button
+                          className="underline"
+                          onClick={() =>
+                            actions.resendDelivery(selected.id, d.id)
+                          }
+                        >
+                          Resend
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
+                  {!deliveries?.length && (
+                    <tr>
+                      <td
+                        colSpan={4}
+                        className="text-center text-gray-500 px-2 py-4"
+                      >
+                        No deliveries
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </>
+        ) : (
+          <div className="text-sm text-gray-500">
+            Select a webhook to view deliveries
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/use-dispute-integration.ts
+++ b/src/hooks/use-dispute-integration.ts
@@ -1,0 +1,270 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { toast } from "react-hot-toast";
+import { integrationService } from "@/services/integration.service";
+import type {
+  CreateIntegrationInstanceDTO,
+  CreateWebhookDTO,
+  IntegrationDefinition,
+  IntegrationInstance,
+  IntegrationProvider,
+  IntegrationUsageMetrics,
+  UpdateIntegrationInstanceDTO,
+  UpdateWebhookDTO,
+  WebhookDeliveryAttempt,
+  WebhookEndpoint,
+} from "@/types/integration.types";
+import { getErrorMessage } from "@/utils/api-helpers";
+
+export interface UseDisputeIntegrationReturn {
+  providers: IntegrationProvider[];
+  instances: IntegrationInstance[];
+  webhooks: WebhookEndpoint[];
+  metrics: IntegrationUsageMetrics | null;
+  loading: boolean;
+  error: string | null;
+  actions: {
+    refresh: () => Promise<void>;
+    loadMetrics: (instanceId?: string) => Promise<void>;
+    createInstance: (
+      dto: CreateIntegrationInstanceDTO
+    ) => Promise<IntegrationInstance>;
+    updateInstance: (
+      id: string,
+      dto: UpdateIntegrationInstanceDTO
+    ) => Promise<IntegrationInstance>;
+    deleteInstance: (id: string) => Promise<void>;
+    toggleInstance: (
+      id: string,
+      enabled: boolean
+    ) => Promise<IntegrationInstance>;
+    createWebhook: (dto: CreateWebhookDTO) => Promise<WebhookEndpoint>;
+    updateWebhook: (
+      id: string,
+      dto: UpdateWebhookDTO
+    ) => Promise<WebhookEndpoint>;
+    deleteWebhook: (id: string) => Promise<void>;
+    listDeliveries: (webhookId: string) => Promise<WebhookDeliveryAttempt[]>;
+    resendDelivery: (
+      webhookId: string,
+      deliveryId: string
+    ) => Promise<WebhookDeliveryAttempt>;
+  };
+}
+
+export function useDisputeIntegration(): UseDisputeIntegrationReturn {
+  const [providers, setProviders] = useState<IntegrationProvider[]>([]);
+  const [instances, setInstances] = useState<IntegrationInstance[]>([]);
+  const [webhooks, setWebhooks] = useState<WebhookEndpoint[]>([]);
+  const [metrics, setMetrics] = useState<IntegrationUsageMetrics | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadAll = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [prov, inst, wh] = await Promise.all([
+        integrationService.listProviders(),
+        integrationService.listInstances(),
+        integrationService.listWebhooks(),
+      ]);
+      setProviders(prov);
+      setInstances(inst);
+      setWebhooks(wh);
+      setError(null);
+    } catch (err) {
+      const msg = getErrorMessage(err);
+      setError(msg);
+      toast.error(msg);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadAll();
+  }, [loadAll]);
+
+  const loadMetrics = useCallback(async (instanceId?: string) => {
+    try {
+      const data = await integrationService.getUsageMetrics({ instanceId });
+      setMetrics(data);
+    } catch (err) {
+      const msg = getErrorMessage(err);
+      setError(msg);
+      toast.error(msg);
+    }
+  }, []);
+
+  const createInstance = useCallback(
+    async (dto: CreateIntegrationInstanceDTO) => {
+      try {
+        const created = await integrationService.createInstance(dto);
+        setInstances((prev) => [created, ...prev]);
+        toast.success("Integration created");
+        return created;
+      } catch (err) {
+        const msg = getErrorMessage(err);
+        setError(msg);
+        toast.error(msg);
+        throw err;
+      }
+    },
+    []
+  );
+
+  const updateInstance = useCallback(
+    async (id: string, dto: UpdateIntegrationInstanceDTO) => {
+      try {
+        const updated = await integrationService.updateInstance(id, dto);
+        setInstances((prev) => prev.map((i) => (i.id === id ? updated : i)));
+        toast.success("Integration updated");
+        return updated;
+      } catch (err) {
+        const msg = getErrorMessage(err);
+        setError(msg);
+        toast.error(msg);
+        throw err;
+      }
+    },
+    []
+  );
+
+  const deleteInstance = useCallback(async (id: string) => {
+    try {
+      await integrationService.deleteInstance(id);
+      setInstances((prev) => prev.filter((i) => i.id !== id));
+      toast.success("Integration deleted");
+    } catch (err) {
+      const msg = getErrorMessage(err);
+      setError(msg);
+      toast.error(msg);
+      throw err;
+    }
+  }, []);
+
+  const toggleInstance = useCallback(
+    async (id: string, enabled: boolean) => {
+      const updated = await updateInstance(id, { enabled });
+      return updated;
+    },
+    [updateInstance]
+  );
+
+  const createWebhook = useCallback(async (dto: CreateWebhookDTO) => {
+    try {
+      const created = await integrationService.createWebhook(dto);
+      setWebhooks((prev) => [created, ...prev]);
+      toast.success("Webhook created");
+      return created;
+    } catch (err) {
+      const msg = getErrorMessage(err);
+      setError(msg);
+      toast.error(msg);
+      throw err;
+    }
+  }, []);
+
+  const updateWebhook = useCallback(
+    async (id: string, dto: UpdateWebhookDTO) => {
+      try {
+        const updated = await integrationService.updateWebhook(id, dto);
+        setWebhooks((prev) => prev.map((w) => (w.id === id ? updated : w)));
+        toast.success("Webhook updated");
+        return updated;
+      } catch (err) {
+        const msg = getErrorMessage(err);
+        setError(msg);
+        toast.error(msg);
+        throw err;
+      }
+    },
+    []
+  );
+
+  const deleteWebhook = useCallback(async (id: string) => {
+    try {
+      await integrationService.deleteWebhook(id);
+      setWebhooks((prev) => prev.filter((w) => w.id !== id));
+      toast.success("Webhook deleted");
+    } catch (err) {
+      const msg = getErrorMessage(err);
+      setError(msg);
+      toast.error(msg);
+      throw err;
+    }
+  }, []);
+
+  const listDeliveries = useCallback(async (webhookId: string) => {
+    try {
+      const deliveries = await integrationService.listWebhookDeliveries(
+        webhookId
+      );
+      return deliveries;
+    } catch (err) {
+      const msg = getErrorMessage(err);
+      setError(msg);
+      toast.error(msg);
+      throw err;
+    }
+  }, []);
+
+  const resendDelivery = useCallback(
+    async (webhookId: string, deliveryId: string) => {
+      try {
+        const delivery = await integrationService.resendDelivery(
+          webhookId,
+          deliveryId
+        );
+        toast.success("Delivery resent");
+        return delivery;
+      } catch (err) {
+        const msg = getErrorMessage(err);
+        setError(msg);
+        toast.error(msg);
+        throw err;
+      }
+    },
+    []
+  );
+
+  const actions = useMemo(
+    () => ({
+      refresh: loadAll,
+      loadMetrics,
+      createInstance,
+      updateInstance,
+      deleteInstance,
+      toggleInstance,
+      createWebhook,
+      updateWebhook,
+      deleteWebhook,
+      listDeliveries,
+      resendDelivery,
+    }),
+    [
+      loadAll,
+      loadMetrics,
+      createInstance,
+      updateInstance,
+      deleteInstance,
+      toggleInstance,
+      createWebhook,
+      updateWebhook,
+      deleteWebhook,
+      listDeliveries,
+      resendDelivery,
+    ]
+  );
+
+  return {
+    providers,
+    instances,
+    webhooks,
+    metrics,
+    loading,
+    error,
+    actions,
+  };
+}

--- a/src/services/integration.service.ts
+++ b/src/services/integration.service.ts
@@ -1,0 +1,194 @@
+import {
+  ApiResponse,
+  CreateIntegrationInstanceDTO,
+  CreateWebhookDTO,
+  IntegrationDefinition,
+  IntegrationInstance,
+  IntegrationProvider,
+  IntegrationUsageMetrics,
+  RateLimitPolicy,
+  UpdateIntegrationInstanceDTO,
+  UpdateWebhookDTO,
+  WebhookDeliveryAttempt,
+  WebhookEndpoint,
+} from "@/types/integration.types";
+import {
+  buildQuery,
+  getErrorMessage,
+  httpDelete,
+  httpGet,
+  httpPatch,
+  httpPost,
+  httpPut,
+  retry,
+} from "@/utils/api-helpers";
+
+const BASE = "/integrations";
+
+class IntegrationService {
+  async listProviders(): Promise<IntegrationProvider[]> {
+    return retry(() =>
+      httpGet<ApiResponse<IntegrationProvider[]>>(`${BASE}/providers`).then(
+        (r) => r.data!
+      )
+    );
+  }
+
+  async getProviderDefinition(
+    providerId: string
+  ): Promise<IntegrationDefinition> {
+    return retry(() =>
+      httpGet<ApiResponse<IntegrationDefinition>>(
+        `${BASE}/providers/${providerId}`
+      ).then((r) => r.data!)
+    );
+  }
+
+  async listInstances(params?: {
+    providerId?: string;
+    enabled?: boolean;
+    q?: string;
+  }): Promise<IntegrationInstance[]> {
+    const qs = buildQuery({
+      providerId: params?.providerId,
+      enabled: params?.enabled,
+      q: params?.q,
+    });
+    return retry(() =>
+      httpGet<ApiResponse<IntegrationInstance[]>>(
+        `${BASE}/instances${qs}`
+      ).then((r) => r.data!)
+    );
+  }
+
+  async getInstance(id: string): Promise<IntegrationInstance> {
+    return retry(() =>
+      httpGet<ApiResponse<IntegrationInstance>>(`${BASE}/instances/${id}`).then(
+        (r) => r.data!
+      )
+    );
+  }
+
+  async createInstance(
+    dto: CreateIntegrationInstanceDTO
+  ): Promise<IntegrationInstance> {
+    return retry(() =>
+      httpPost<ApiResponse<IntegrationInstance>>(`${BASE}/instances`, dto).then(
+        (r) => r.data!
+      )
+    );
+  }
+
+  async updateInstance(
+    id: string,
+    dto: UpdateIntegrationInstanceDTO
+  ): Promise<IntegrationInstance> {
+    return retry(() =>
+      httpPut<ApiResponse<IntegrationInstance>>(
+        `${BASE}/instances/${id}`,
+        dto
+      ).then((r) => r.data!)
+    );
+  }
+
+  async toggleInstance(
+    id: string,
+    enabled: boolean
+  ): Promise<IntegrationInstance> {
+    return this.updateInstance(id, { enabled });
+  }
+
+  async deleteInstance(id: string): Promise<{ success: boolean }> {
+    return retry(() =>
+      httpDelete<ApiResponse<{ success: boolean }>>(
+        `${BASE}/instances/${id}`
+      ).then((r) => r.data!)
+    );
+  }
+
+  async getRateLimitPolicy(): Promise<RateLimitPolicy> {
+    return retry(() =>
+      httpGet<ApiResponse<RateLimitPolicy>>(`${BASE}/rate-limit`).then(
+        (r) => r.data!
+      )
+    );
+  }
+
+  async setRateLimitPolicy(policy: RateLimitPolicy): Promise<RateLimitPolicy> {
+    return retry(() =>
+      httpPut<ApiResponse<RateLimitPolicy>>(`${BASE}/rate-limit`, policy).then(
+        (r) => r.data!
+      )
+    );
+  }
+
+  async listWebhooks(): Promise<WebhookEndpoint[]> {
+    return retry(() =>
+      httpGet<ApiResponse<WebhookEndpoint[]>>(`${BASE}/webhooks`).then(
+        (r) => r.data!
+      )
+    );
+  }
+
+  async createWebhook(dto: CreateWebhookDTO): Promise<WebhookEndpoint> {
+    return retry(() =>
+      httpPost<ApiResponse<WebhookEndpoint>>(`${BASE}/webhooks`, dto).then(
+        (r) => r.data!
+      )
+    );
+  }
+
+  async updateWebhook(
+    id: string,
+    dto: UpdateWebhookDTO
+  ): Promise<WebhookEndpoint> {
+    return retry(() =>
+      httpPatch<ApiResponse<WebhookEndpoint>>(
+        `${BASE}/webhooks/${id}`,
+        dto
+      ).then((r) => r.data!)
+    );
+  }
+
+  async deleteWebhook(id: string): Promise<{ success: boolean }> {
+    return retry(() =>
+      httpDelete<ApiResponse<{ success: boolean }>>(
+        `${BASE}/webhooks/${id}`
+      ).then((r) => r.data!)
+    );
+  }
+
+  async listWebhookDeliveries(
+    webhookId: string
+  ): Promise<WebhookDeliveryAttempt[]> {
+    return retry(() =>
+      httpGet<ApiResponse<WebhookDeliveryAttempt[]>>(
+        `${BASE}/webhooks/${webhookId}/deliveries`
+      ).then((r) => r.data!)
+    );
+  }
+
+  async resendDelivery(
+    webhookId: string,
+    deliveryId: string
+  ): Promise<WebhookDeliveryAttempt> {
+    return retry(() =>
+      httpPost<ApiResponse<WebhookDeliveryAttempt>>(
+        `${BASE}/webhooks/${webhookId}/deliveries/${deliveryId}/resend`
+      ).then((r) => r.data!)
+    );
+  }
+
+  async getUsageMetrics(params?: {
+    instanceId?: string;
+  }): Promise<IntegrationUsageMetrics> {
+    const qs = buildQuery({ instanceId: params?.instanceId });
+    return retry(() =>
+      httpGet<ApiResponse<IntegrationUsageMetrics>>(
+        `${BASE}/metrics${qs}`
+      ).then((r) => r.data!)
+    );
+  }
+}
+
+export const integrationService = new IntegrationService();

--- a/src/types/integration.types.ts
+++ b/src/types/integration.types.ts
@@ -1,0 +1,150 @@
+export type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+
+export interface ApiResponse<T> {
+  success: boolean;
+  data?: T;
+  error?: string;
+  code?: string;
+}
+
+export interface IntegrationProvider {
+  id: string;
+  name: string;
+  description?: string;
+  category: "project_management" | "crm" | "communication" | "custom" | "other";
+  logoUrl?: string;
+  websiteUrl?: string;
+  supportsWebhooks: boolean;
+  supportsDataSync: boolean;
+}
+
+export interface IntegrationConfigField {
+  key: string;
+  label: string;
+  type: "string" | "number" | "boolean" | "secret" | "select" | "json" | "url";
+  required?: boolean;
+  options?: { label: string; value: string }[];
+  placeholder?: string;
+  helpText?: string;
+}
+
+export interface IntegrationDefinition {
+  providerId: string;
+  version: string;
+  authType: "api_key" | "oauth2" | "webhook_only" | "none";
+  configSchema: IntegrationConfigField[];
+  capabilities: Array<
+    | "create_dispute"
+    | "update_status"
+    | "sync_data"
+    | "webhook_events"
+    | "list_disputes"
+    | "mobile_ready"
+  >;
+}
+
+export interface IntegrationInstance {
+  id: string;
+  providerId: string;
+  name: string;
+  enabled: boolean;
+  createdAt: string;
+  updatedAt: string;
+  config: Record<string, string | number | boolean | null>;
+  metadata?: Record<string, unknown>;
+}
+
+export interface WebhookEndpoint {
+  id: string;
+  url: string;
+  secret?: string;
+  description?: string;
+  isActive: boolean;
+  createdAt: string;
+  updatedAt: string;
+  events: DisputeEventType[];
+}
+
+export type DisputeEventType =
+  | "dispute.created"
+  | "dispute.updated"
+  | "dispute.resolved"
+  | "dispute.escalated"
+  | "evidence.added"
+  | "mediation.started"
+  | "arbitration.started";
+
+export interface WebhookDeliveryAttempt {
+  id: string;
+  webhookId: string;
+  eventType: DisputeEventType;
+  payload: Record<string, unknown>;
+  statusCode?: number;
+  errorMessage?: string;
+  deliveredAt?: string;
+  createdAt: string;
+}
+
+export interface RateLimitPolicy {
+  requestsPerMinute: number;
+  burst?: number;
+  perApiKey?: boolean;
+}
+
+export interface IntegrationUsageMetrics {
+  requests: number;
+  errors: number;
+  averageLatencyMs: number;
+  last24h: {
+    requests: number;
+    errors: number;
+  };
+}
+
+export interface CreateIntegrationInstanceDTO {
+  providerId: string;
+  name: string;
+  config: Record<string, string | number | boolean | null>;
+}
+
+export interface UpdateIntegrationInstanceDTO {
+  name?: string;
+  enabled?: boolean;
+  config?: Record<string, string | number | boolean | null>;
+}
+
+export interface CreateWebhookDTO {
+  url: string;
+  secret?: string;
+  description?: string;
+  events: DisputeEventType[];
+}
+
+export interface UpdateWebhookDTO extends Partial<CreateWebhookDTO> {
+  isActive?: boolean;
+}
+
+export interface OutboundApiRequest {
+  id: string;
+  method: HttpMethod;
+  url: string;
+  headers?: Record<string, string>;
+  body?: unknown;
+  timeoutMs?: number;
+}
+
+export interface OutboundApiResponse<T = unknown> {
+  status: number;
+  headers: Record<string, string>;
+  data: T;
+  durationMs: number;
+}
+
+export interface MobileClientConfig {
+  baseUrl: string;
+  apiKey?: string;
+  oauth?: {
+    clientId: string;
+    scopes: string[];
+  };
+}

--- a/src/utils/api-helpers.ts
+++ b/src/utils/api-helpers.ts
@@ -1,0 +1,113 @@
+import axios, { AxiosError, AxiosRequestConfig } from "axios";
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "/api";
+
+export function getErrorMessage(err: unknown): string {
+  if (axios.isAxiosError(err)) {
+    const e = err as AxiosError<any>;
+    const msg =
+      typeof e.response?.data === "object" && e.response?.data !== null
+        ? (e.response.data as any).message
+        : undefined;
+    if (msg) return msg;
+    if (e.response?.status) return `Error ${e.response.status}`;
+    return e.message;
+  }
+  if (err instanceof Error) return err.message;
+  return "Unknown error";
+}
+
+export function withAuth(
+  headers?: Record<string, string>
+): Record<string, string> {
+  const token =
+    typeof window !== "undefined" ? localStorage.getItem("auth_token") : null;
+  return {
+    "Content-Type": "application/json",
+    ...(headers || {}),
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  };
+}
+
+export async function httpGet<T>(
+  endpoint: string,
+  config?: AxiosRequestConfig
+): Promise<T> {
+  const res = await axios.get<T>(`${API_BASE_URL}${endpoint}`, {
+    ...(config || {}),
+    headers: withAuth(config?.headers as Record<string, string> | undefined),
+  });
+  return res.data as T;
+}
+
+export async function httpPost<T>(
+  endpoint: string,
+  body?: unknown,
+  config?: AxiosRequestConfig
+): Promise<T> {
+  const res = await axios.post<T>(`${API_BASE_URL}${endpoint}`, body, {
+    ...(config || {}),
+    headers: withAuth(config?.headers as Record<string, string> | undefined),
+  });
+  return res.data as T;
+}
+
+export async function httpPut<T>(
+  endpoint: string,
+  body?: unknown,
+  config?: AxiosRequestConfig
+): Promise<T> {
+  const res = await axios.put<T>(`${API_BASE_URL}${endpoint}`, body, {
+    ...(config || {}),
+    headers: withAuth(config?.headers as Record<string, string> | undefined),
+  });
+  return res.data as T;
+}
+
+export async function httpPatch<T>(
+  endpoint: string,
+  body?: unknown,
+  config?: AxiosRequestConfig
+): Promise<T> {
+  const res = await axios.patch<T>(`${API_BASE_URL}${endpoint}`, body, {
+    ...(config || {}),
+    headers: withAuth(config?.headers as Record<string, string> | undefined),
+  });
+  return res.data as T;
+}
+
+export async function httpDelete<T>(
+  endpoint: string,
+  config?: AxiosRequestConfig
+): Promise<T> {
+  const res = await axios.delete<T>(`${API_BASE_URL}${endpoint}`, {
+    ...(config || {}),
+    headers: withAuth(config?.headers as Record<string, string> | undefined),
+  });
+  return res.data as T;
+}
+
+export function retry<T>(
+  fn: () => Promise<T>,
+  retries = 2,
+  delayMs = 300
+): Promise<T> {
+  return fn().catch((err) => {
+    if (retries <= 0) throw err;
+    return new Promise((resolve) => setTimeout(resolve, delayMs)).then(() =>
+      retry(fn, retries - 1, delayMs * 2)
+    );
+  });
+}
+
+export function buildQuery(
+  params: Record<string, string | number | boolean | undefined | null>
+): string {
+  const search = new URLSearchParams();
+  Object.entries(params).forEach(([key, value]) => {
+    if (value === undefined || value === null || value === "") return;
+    search.set(key, String(value));
+  });
+  const qs = search.toString();
+  return qs ? `?${qs}` : "";
+}


### PR DESCRIPTION
# 📝 Implement dispute integration management components

## 🛠️ Issue

- Closes #512

## 📚 Description

Adds dispute integration capabilities with REST API client, webhook management, and integration frameworks. Includes shared API helpers, typed interfaces, a service layer, a hook for state/actions, and three UI management components.

## ✅ Changes applied

- Types: `src/types/integration.types.ts`
- Utils: `src/utils/api-helpers.ts` (HTTP helpers, retry, query builder)
- Service: `src/services/integration.service.ts` (providers, instances, webhooks, metrics)
- Hook: `src/hooks/use-dispute-integration.ts`
- UI:
  - `src/components/disputes/api-integration.tsx`
  - `src/components/disputes/webhook-management.tsx`
  - `src/components/disputes/integration-frameworks.tsx`

## 🔍 Evidence/Media (screenshots/videos)

<img width="1677" height="717" alt="Screenshot 2025-09-18 at 10 11 55" src="https://github.com/user-attachments/assets/07f7f017-5259-4ce3-9672-c3f1bc670e2c" />
