### PR TITLE
Add JSDoc comments to MobileWorkflow component props

### DIFF
--- a/src/types/workflow.types.ts
+++ b/src/types/workflow.types.ts
@@ -408,10 +408,38 @@ export interface NotificationCenterProps {
   compact?: boolean;
 }
 
+/**
+ * Props for the MobileWorkflow component
+ * 
+ * This interface defines the properties for the mobile-optimized dispute workflow component
+ * that provides a touch-friendly interface for managing dispute resolution processes.
+ */
 export interface MobileWorkflowProps {
+  /** 
+   * Unique identifier for the dispute being managed
+   * @example "dispute_12345"
+   */
   disputeId: string;
+  
+  /** 
+   * Callback function called when a pending action is completed
+   * @param action - The completed action object containing id, type, title, etc.
+   * @example onActionComplete={(action) => console.log('Action completed:', action.title)}
+   */
   onActionComplete?: (action: PendingAction) => void;
+  
+  /** 
+   * Whether to show the offline/online status indicator in the header
+   * @default true
+   * @example showOfflineIndicator={false}
+   */
   showOfflineIndicator?: boolean;
+  
+  /** 
+   * Whether to enable swipe gestures for navigating between pending actions
+   * @default true
+   * @example enableGestures={false}
+   */
   enableGestures?: boolean;
 }
 


### PR DESCRIPTION
# 📝 Pull Request Title

Add JSDoc comments to MobileWorkflow component props

## 🛠️ Issue

- Closes #599

## 📚 Description

Added comprehensive JSDoc documentation to the `MobileWorkflowProps` interface in `src/types/workflow.types.ts`. This improves developer experience by providing clear documentation for each prop including types, purposes, default values, and usage examples.

## ✅ Changes applied

- Added JSDoc comment block for `MobileWorkflowProps` interface
- Documented `disputeId` prop with type and example
- Documented `onActionComplete` callback with parameter details and usage example
- Documented `showOfflineIndicator` prop with default value and example
- Documented `enableGestures` prop with default value and example
- All comments follow JSDoc standards with proper formatting

## 🔍 Evidence/Media (screenshots/videos)

- No visual changes (documentation only)
- Code changes can be reviewed in the diff