### PR TITLE
Added pause/unpause and emergency withdraw functionality

### DIFF
--- a/contracts-offerhub/contracts/dispute-contract/src/access.rs
+++ b/contracts-offerhub/contracts/dispute-contract/src/access.rs
@@ -1,7 +1,7 @@
 use soroban_sdk::{panic_with_error, Address, Env, Map, String, Vec};
 
 use crate::{
-    storage::{ARBITRATORS, MEDIATORS},
+    storage::{ARBITRATORS, MEDIATORS, PAUSED},
     types::{ArbitratorData},
     error::{ Error},
 };
@@ -13,6 +13,10 @@ pub fn add_arbitrator(
     name: String,
 ) -> Result<(), Error> {
     admin.require_auth();
+
+    if env.storage().instance().get(&PAUSED).unwrap_or(false) {
+        return Err(Error::ContractPaused);
+    }
 
     let mut arbitrators: Map<Address, ArbitratorData> = env
         .storage()
@@ -46,6 +50,10 @@ pub fn add_arbitrator(
 
 pub fn remove_arbitrator(env: &Env, admin: Address, arbitrator: Address) -> Result<(), Error> {
     admin.require_auth();
+
+    if env.storage().instance().get(&PAUSED).unwrap_or(false) {
+        return Err(Error::ContractPaused);
+    }
 
     let mut arbitrators: Map<Address, ArbitratorData> = env
         .storage()
@@ -87,6 +95,10 @@ pub fn is_valid_arbitrator(env: &Env, arbitrator: &Address) -> bool {
 pub fn add_mediator(env: &Env, admin: Address, mediator: Address) -> Result<(), Error> {
     admin.require_auth();
 
+    if env.storage().instance().get(&PAUSED).unwrap_or(false) {
+        return Err(Error::ContractPaused);
+    }
+
     let mut mediators: Vec<Address> = env
         .storage()
         .instance()
@@ -110,6 +122,10 @@ pub fn add_mediator(env: &Env, admin: Address, mediator: Address) -> Result<(), 
 
 pub fn remove_mediator(env: &Env, admin: Address, mediator: Address) -> Result<(), Error> {
     admin.require_auth();
+
+    if env.storage().instance().get(&PAUSED).unwrap_or(false) {
+        return Err(Error::ContractPaused);
+    }
 
     let mediators: Vec<Address> = env
         .storage()

--- a/contracts-offerhub/contracts/dispute-contract/src/error.rs
+++ b/contracts-offerhub/contracts/dispute-contract/src/error.rs
@@ -22,6 +22,9 @@ pub enum Error {
     InvalidAddress = 16,            // InvalidAddress
     InvalidMediator = 17,           // InvalidMediator
     InvalidOutcome = 18,            // InvalidOutcome
+    AlreadyPaused = 19,
+    NotPaused = 20,
+    ContractPaused = 21,
 }
 
 pub fn handle_error(env: &Env, error: Error) -> ! {

--- a/contracts-offerhub/contracts/dispute-contract/src/lib.rs
+++ b/contracts-offerhub/contracts/dispute-contract/src/lib.rs
@@ -32,6 +32,18 @@ impl DisputeResolutionContract {
         Ok(())
     }
 
+    pub fn pause(env: Env, admin: Address) -> Result<(), Error> {
+        contract::pause(&env, admin)
+    }
+
+    pub fn is_paused(env: Env) -> bool {
+        contract::is_paused(&env)
+    }
+
+    pub fn unpause(env: Env, admin: Address) -> Result<(), Error> {
+        contract::unpause(&env, admin)
+    }
+
     pub fn open_dispute(
         env: Env,
         job_id: u32,

--- a/contracts-offerhub/contracts/dispute-contract/src/storage.rs
+++ b/contracts-offerhub/contracts/dispute-contract/src/storage.rs
@@ -13,6 +13,8 @@ pub const RATE_BYPASS: Symbol = symbol_short!("RLBYP");
 
 pub const CONTRACT_CONFIG: Symbol = symbol_short!("CONFIG");
 
+pub const PAUSED: Symbol = symbol_short!("PAUSED");
+
 // Default configuration values
 pub const DEFAULT_TIMEOUT_HOURS: u32 = 168;           // 7 days (168 hours)
 pub const DEFAULT_MAX_EVIDENCE: u32 = 10;             // Maximum 10 evidence submissions

--- a/contracts-offerhub/contracts/dispute-contract/test_snapshots/test/test_add_evidence.1.json
+++ b/contracts-offerhub/contracts/dispute-contract/test_snapshots/test/test_add_evidence.1.json
@@ -507,6 +507,14 @@
                       },
                       {
                         "key": {
+                          "symbol": "PAUSED"
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "TIMEOUT"
                         },
                         "val": {

--- a/contracts-offerhub/contracts/dispute-contract/test_snapshots/test/test_arbitrator_management.1.json
+++ b/contracts-offerhub/contracts/dispute-contract/test_snapshots/test/test_arbitrator_management.1.json
@@ -312,6 +312,14 @@
                       },
                       {
                         "key": {
+                          "symbol": "PAUSED"
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "TIMEOUT"
                         },
                         "val": {

--- a/contracts-offerhub/contracts/dispute-contract/test_snapshots/test/test_assign_mediator.1.json
+++ b/contracts-offerhub/contracts/dispute-contract/test_snapshots/test/test_assign_mediator.1.json
@@ -510,6 +510,14 @@
                       },
                       {
                         "key": {
+                          "symbol": "PAUSED"
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "TIMEOUT"
                         },
                         "val": {

--- a/contracts-offerhub/contracts/dispute-contract/test_snapshots/test/test_check_timeout.1.json
+++ b/contracts-offerhub/contracts/dispute-contract/test_snapshots/test/test_check_timeout.1.json
@@ -443,6 +443,14 @@
                       },
                       {
                         "key": {
+                          "symbol": "PAUSED"
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "TIMEOUT"
                         },
                         "val": {

--- a/contracts-offerhub/contracts/dispute-contract/test_snapshots/test/test_escalate_to_arbitration.1.json
+++ b/contracts-offerhub/contracts/dispute-contract/test_snapshots/test/test_escalate_to_arbitration.1.json
@@ -628,6 +628,14 @@
                       },
                       {
                         "key": {
+                          "symbol": "PAUSED"
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "TIMEOUT"
                         },
                         "val": {

--- a/contracts-offerhub/contracts/dispute-contract/test_snapshots/test/test_initialize.1.json
+++ b/contracts-offerhub/contracts/dispute-contract/test_snapshots/test/test_initialize.1.json
@@ -198,6 +198,14 @@
                       },
                       {
                         "key": {
+                          "symbol": "PAUSED"
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "TIMEOUT"
                         },
                         "val": {

--- a/contracts-offerhub/contracts/dispute-contract/test_snapshots/test/test_initialize_already_initialized.1.json
+++ b/contracts-offerhub/contracts/dispute-contract/test_snapshots/test/test_initialize_already_initialized.1.json
@@ -199,6 +199,14 @@
                       },
                       {
                         "key": {
+                          "symbol": "PAUSED"
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "TIMEOUT"
                         },
                         "val": {

--- a/contracts-offerhub/contracts/dispute-contract/test_snapshots/test/test_mediator_management.1.json
+++ b/contracts-offerhub/contracts/dispute-contract/test_snapshots/test/test_mediator_management.1.json
@@ -252,6 +252,14 @@
                       },
                       {
                         "key": {
+                          "symbol": "PAUSED"
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "TIMEOUT"
                         },
                         "val": {

--- a/contracts-offerhub/contracts/dispute-contract/test_snapshots/test/test_open_dispute.1.json
+++ b/contracts-offerhub/contracts/dispute-contract/test_snapshots/test/test_open_dispute.1.json
@@ -442,6 +442,14 @@
                       },
                       {
                         "key": {
+                          "symbol": "PAUSED"
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "TIMEOUT"
                         },
                         "val": {

--- a/contracts-offerhub/contracts/dispute-contract/test_snapshots/test/test_open_dispute_already_exists.1.json
+++ b/contracts-offerhub/contracts/dispute-contract/test_snapshots/test/test_open_dispute_already_exists.1.json
@@ -442,6 +442,14 @@
                       },
                       {
                         "key": {
+                          "symbol": "PAUSED"
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "TIMEOUT"
                         },
                         "val": {

--- a/contracts-offerhub/contracts/dispute-contract/test_snapshots/test/test_resolve_dispute.1.json
+++ b/contracts-offerhub/contracts/dispute-contract/test_snapshots/test/test_resolve_dispute.1.json
@@ -502,6 +502,14 @@
                       },
                       {
                         "key": {
+                          "symbol": "PAUSED"
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "TIMEOUT"
                         },
                         "val": {

--- a/contracts-offerhub/contracts/dispute-contract/test_snapshots/test/test_resolve_dispute_already_resolved.1.json
+++ b/contracts-offerhub/contracts/dispute-contract/test_snapshots/test/test_resolve_dispute_already_resolved.1.json
@@ -502,6 +502,14 @@
                       },
                       {
                         "key": {
+                          "symbol": "PAUSED"
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "TIMEOUT"
                         },
                         "val": {

--- a/contracts-offerhub/contracts/dispute-contract/test_snapshots/test/test_set_dispute_timeout.1.json
+++ b/contracts-offerhub/contracts/dispute-contract/test_snapshots/test/test_set_dispute_timeout.1.json
@@ -220,6 +220,14 @@
                       },
                       {
                         "key": {
+                          "symbol": "PAUSED"
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "TIMEOUT"
                         },
                         "val": {

--- a/contracts-offerhub/contracts/escrow-contract/src/error.rs
+++ b/contracts-offerhub/contracts/escrow-contract/src/error.rs
@@ -17,6 +17,10 @@ pub enum Error {
     UnexpectedError = 11,
     InvalidTimestamp = 12,
     TimestampTooOld = 13,
+    AlreadyPaused = 14,
+    NotPaused = 15,
+    ContractPaused = 16,
+    
 }
 
 pub fn handle_error(env: &Env, error: Error) -> ! {

--- a/contracts-offerhub/contracts/escrow-contract/src/lib.rs
+++ b/contracts-offerhub/contracts/escrow-contract/src/lib.rs
@@ -27,6 +27,22 @@ impl EscrowContract {
         contract::init_contract(&env, client, freelancer, amount, fee_manager);
     }
 
+    pub fn pause(env: Env, admin: Address) -> Result<(), Error> {
+        contract::pause(&env, admin)
+    }
+
+    pub fn is_paused(env: Env) -> bool {
+        contract::is_paused(&env)
+    }
+
+    pub fn unpause(env: Env, admin: Address) -> Result<(), Error> {
+        contract::unpause(&env, admin)
+    }
+
+    pub fn emergency_withdraw(env: &Env, admin: Address) -> Result<(), Error> {
+        contract::emergency_withdraw(&env, admin)
+    }
+
     pub fn deposit_funds(env: Env, client: Address) {
         contract::deposit_funds(&env, client);
     }

--- a/contracts-offerhub/contracts/escrow-contract/src/storage.rs
+++ b/contracts-offerhub/contracts/escrow-contract/src/storage.rs
@@ -5,6 +5,9 @@ pub const ESCROW_DATA: Symbol = symbol_short!("ESCROW");
 pub const INITIALIZED: Symbol = symbol_short!("INIT");
 pub const CONTRACT_CONFIG: Symbol = symbol_short!("CONFIG");
 
+pub const PAUSED: Symbol = symbol_short!("PAUSED");
+
+
 // Rate limit storage keys
 pub const RATE_LIMITS: Symbol = symbol_short!("RLIM");
 pub const RATE_BYPASS: Symbol = symbol_short!("RLBYP");

--- a/contracts-offerhub/contracts/escrow-factory/src/contract.rs
+++ b/contracts-offerhub/contracts/escrow-factory/src/contract.rs
@@ -5,16 +5,89 @@ use crate::types::{
 };
 
 use crate::{error::Error, types::DisputeParams};
-use soroban_sdk::{BytesN, Symbol};
+use soroban_sdk::{BytesN, Symbol, symbol_short};
 use soroban_sdk::{Address, Env, Vec};
 
 const MAX_BATCH_SIZE: u32 = 100;
+const PAUSED: Symbol = symbol_short!("PAUSED");
+const ADMIN: Symbol = symbol_short!("ADMIN");
+
+pub fn initialize(env: &Env, admin: Address) {
+    if env.storage().instance().has(&ADMIN) {
+        handle_error(env, Error::AlreadyInitialized);
+    }
+    
+    admin.require_auth();
+    
+    env.storage().instance().set(&ADMIN, &admin);
+    // Added: Initialize pause state as false
+    env.storage().instance().set(&PAUSED, &false);
+    
+    env.events().publish(
+        (Symbol::new(env, "contract_initialized"), admin),
+        env.ledger().timestamp(),
+    );
+}
+
+pub fn is_paused(env: &Env) -> bool {
+    env.storage().instance().get(&PAUSED).unwrap_or(false)
+}
+
+pub fn pause(env: &Env, admin: Address) -> Result<(), Error> {
+    admin.require_auth();
+    let stored_admin: Address = env.storage().instance().get(&ADMIN).unwrap_or_else(|| handle_error(env, Error::NotInitialized));
+    if stored_admin != admin {
+        return Err(Error::Unauthorized);
+    }
+    
+    if is_paused(env) {
+        return Err(Error::AlreadyPaused);
+    }
+    
+    env.storage().instance().set(&PAUSED, &true);
+    
+    env.events().publish(
+        (Symbol::new(env, "contract_paused"), admin),
+        env.ledger().timestamp(),
+    );
+    
+    Ok(())
+}
+
+pub fn unpause(env: &Env, admin: Address) -> Result<(), Error> {
+    admin.require_auth();
+    let stored_admin: Address = env.storage().instance().get(&ADMIN).unwrap_or_else(|| handle_error(env, Error::NotInitialized));
+    if stored_admin != admin {
+        return Err(Error::Unauthorized);
+    }
+    
+    if !is_paused(env) {
+        return Err(Error::NotPaused);
+    }
+    
+    env.storage().instance().set(&PAUSED, &false);
+    
+    env.events().publish(
+        (Symbol::new(env, "contract_unpaused"), admin),
+        env.ledger().timestamp(),
+    );
+    
+    Ok(())
+}
 
 pub fn upload_escrow_wasm(env: Env, wasm_hash: BytesN<32>) {
+    if is_paused(&env) {
+        handle_error(&env, Error::ContractPaused);
+    }
+
     storage::store_escrow_wasm(&env, wasm_hash);
 }
 
 pub fn deploy_new_escrow(env: Env, create_params: EscrowCreateParams) -> Address {
+    if is_paused(&env) {
+        handle_error(&env, Error::ContractPaused);
+    }
+
     // Validate amount is positive
     if create_params.amount <= 0 {
         handle_error(&env, Error::InvalidAmountSet)
@@ -57,6 +130,10 @@ pub fn deploy_new_escrow(env: Env, create_params: EscrowCreateParams) -> Address
 }
 
 pub fn batch_deploy(env: Env, params: Vec<EscrowCreateParams>) -> Vec<Address> {
+    if is_paused(&env) {
+        handle_error(&env, Error::ContractPaused);
+    }
+
     if params.len() > MAX_BATCH_SIZE {
         handle_error(&env, Error::BatchSizeExceeded)
     }
@@ -76,6 +153,10 @@ pub fn batch_deploy(env: Env, params: Vec<EscrowCreateParams>) -> Vec<Address> {
 pub fn batch_deposit_funds(env: Env, escrow_ids: Vec<u32>, client: Address) {
     client.require_auth();
 
+    if is_paused(&env) {
+        handle_error(&env, Error::ContractPaused);
+    }
+
     for escrow_id in escrow_ids.iter() {
         let escrow_address = storage::escrow_addr_by_id(&env, escrow_id);
 
@@ -93,6 +174,10 @@ pub fn batch_deposit_funds(env: Env, escrow_ids: Vec<u32>, client: Address) {
 
 pub fn batch_release_funds(env: Env, escrow_ids: Vec<u32>, freelancer: Address) {
     freelancer.require_auth();
+
+    if is_paused(&env) {
+        handle_error(&env, Error::ContractPaused);
+    }
 
     for escrow_id in escrow_ids.iter() {
         let escrow_address = storage::escrow_addr_by_id(&env, escrow_id);
@@ -112,6 +197,10 @@ pub fn batch_release_funds(env: Env, escrow_ids: Vec<u32>, freelancer: Address) 
 pub fn batch_create_disputes(env: Env, escrow_ids: Vec<u32>, caller: Address) {
     caller.require_auth();
 
+    if is_paused(&env) {
+        handle_error(&env, Error::ContractPaused);
+    }
+
     for escrow_id in escrow_ids.iter() {
         let escrow_address = storage::escrow_addr_by_id(&env, escrow_id);
 
@@ -129,6 +218,10 @@ pub fn batch_create_disputes(env: Env, escrow_ids: Vec<u32>, caller: Address) {
 
 pub fn batch_resolve_disputes(env: Env, caller: Address, dispute_params: Vec<DisputeParams>) {
     caller.require_auth();
+
+    if is_paused(&env) {
+        handle_error(&env, Error::ContractPaused);
+    }
 
     for param in dispute_params.iter() {
         let escrow_address = storage::escrow_addr_by_id(&env, param.escrow_id);
@@ -151,6 +244,10 @@ pub fn batch_add_milestones(
     client: Address,
 ) -> Vec<MilestoneCreateResult> {
     client.require_auth();
+
+    if is_paused(&env) {
+        handle_error(&env, Error::ContractPaused);
+    }
 
     let mut milestone_create_results = Vec::new(&env);
 
@@ -184,6 +281,10 @@ pub fn batch_add_milestones(
 pub fn batch_approve_milestones(env: Env, milestone_params: Vec<MilestoneParams>, client: Address) {
     client.require_auth();
 
+    if is_paused(&env) {
+        handle_error(&env, Error::ContractPaused);
+    }
+
     for param in milestone_params.iter() {
         let escrow_address = storage::escrow_addr_by_id(&env, param.escrow_id);
 
@@ -206,6 +307,10 @@ pub fn batch_release_milestones(
 ) {
     freelancer.require_auth();
 
+    if is_paused(&env) {
+        handle_error(&env, Error::ContractPaused);
+    }
+
     for param in milestone_params.iter() {
         let escrow_address = storage::escrow_addr_by_id(&env, param.escrow_id);
 
@@ -222,6 +327,10 @@ pub fn batch_release_milestones(
 }
 
 pub fn batch_archive_escrows(env: Env, escrow_ids: Vec<u32>) -> Vec<u32> {
+    if is_paused(&env) {
+        handle_error(&env, Error::ContractPaused);
+    }
+
     let mut archived_escrows = Vec::new(&env);
 
     for escrow_id in escrow_ids.iter() {
@@ -249,6 +358,9 @@ pub fn batch_check_escrow_status(
     env: Env,
     _escrow_ids: Vec<u32>,
 ) -> Vec<crate::types::EscrowStatus> {
+    if is_paused(&env) {
+        handle_error(&env, Error::ContractPaused);
+    }
     // TODO: Implement proper conversion from WASM types
     // For now, return empty vector to allow compilation
     Vec::new(&env)
@@ -258,6 +370,9 @@ pub fn batch_get_escrow_information(
     env: Env,
     _escrow_ids: Vec<u32>,
 ) -> Vec<crate::types::EscrowData> {
+    if is_paused(&env) {
+        handle_error(&env, Error::ContractPaused);
+    }
     // TODO: Implement proper conversion from WASM types
     // For now, return empty vector to allow compilation
     Vec::new(&env)

--- a/contracts-offerhub/contracts/escrow-factory/src/error.rs
+++ b/contracts-offerhub/contracts/escrow-factory/src/error.rs
@@ -10,6 +10,12 @@ pub enum Error {
     InvalidAmountSet = 5,
     AddressesShouldNotMatch = 6,
     BatchSizeExceeded = 7,
+    AlreadyInitialized = 8,
+    Unauthorized = 9,
+    NotInitialized = 10, 
+    ContractPaused = 11,
+    AlreadyPaused = 12,
+    NotPaused = 13,
 }
 
 pub fn handle_error(env: &Env, error: Error) -> ! {

--- a/contracts-offerhub/contracts/escrow-factory/src/test.rs
+++ b/contracts-offerhub/contracts/escrow-factory/src/test.rs
@@ -107,3 +107,17 @@ fn test_batch_operations_structure() {
     assert_eq!(batch_params.get(1).unwrap().amount, 1100);
     assert_eq!(batch_params.get(2).unwrap().amount, 1200);
 }
+
+// Helper function to setup test environment
+fn setup_env() -> (Env, Address, Address, Address, Address, BytesN<32>) {
+    let env = Env::default();
+    env.mock_all_auths();
+    
+    let admin = Address::generate(&env);
+    let client = Address::generate(&env);
+    let freelancer = Address::generate(&env);
+    let fee_manager = Address::generate(&env);
+    let wasm_hash = BytesN::from_array(&env, &[0; 32]);
+    
+    (env, admin, client, freelancer, fee_manager, wasm_hash)
+}

--- a/contracts-offerhub/contracts/fee-manager-contract/src/contract.rs
+++ b/contracts-offerhub/contracts/fee-manager-contract/src/contract.rs
@@ -7,7 +7,7 @@ use crate::{
         DEFAULT_ESCROW_FEE_PERCENTAGE, FEE_CONFIG, FEE_HISTORY, FEE_STATS, PLATFORM_BALANCE, PREMIUM_USERS,
         CONTRACT_CONFIG, DEFAULT_PLATFORM_FEE_PERCENTAGE, DEFAULT_ESCROW_TIMEOUT_DAYS, DEFAULT_MAX_RATING_PER_DAY,
         DEFAULT_MIN_ESCROW_AMOUNT, DEFAULT_MAX_ESCROW_AMOUNT, DEFAULT_DISPUTE_TIMEOUT_HOURS,
-        DEFAULT_RATE_LIMIT_WINDOW_HOURS, DEFAULT_MAX_RATE_LIMIT_CALLS, TOTAL_FESS_COLLECTED
+        DEFAULT_RATE_LIMIT_WINDOW_HOURS, DEFAULT_MAX_RATE_LIMIT_CALLS, TOTAL_FESS_COLLECTED, PAUSED
     },
     types::{FeeCalculation, FeeConfig, FeeRecord, FeeStats, PremiumUser, FEE_TYPE_ESCROW, FEE_TYPE_DISPUTE, PlatformStats, ContractConfig},
     validation::{validate_initialization, validate_fee_rates, validate_fee_calculation, validate_withdrawal_amount, validate_fee_type, validate_address},
@@ -64,7 +64,7 @@ pub fn initialize(env: &Env, admin: Address, platform_wallet: Address) {
         .instance()
         .set(&PREMIUM_USERS, &Vec::<PremiumUser>::new(env));
     env.storage().instance().set(&TOTAL_FESS_COLLECTED, &0i128);
-
+    env.storage().instance().set(&PAUSED, &false);
 
     env.events().publish(
         (Symbol::new(env, "fee_manager_initialized"), admin.clone()),
@@ -72,12 +72,63 @@ pub fn initialize(env: &Env, admin: Address, platform_wallet: Address) {
     );
 }
 
+pub fn is_paused(env: &Env) -> bool {
+    env.storage().instance().get(&PAUSED).unwrap_or(false)
+}
+
+pub fn pause(env: &Env, admin: Address) -> Result<(), Error> {
+    admin.require_auth();
+    let fee_config: FeeConfig = env.storage().instance().get(&FEE_CONFIG).unwrap_or_else(|| handle_error(env, Error::NotInitialized));
+    if fee_config.admin != admin {
+        return Err(Error::Unauthorized);
+    }
+    
+    if is_paused(env) {
+        return Err(Error::AlreadyPaused);
+    }
+    
+    env.storage().instance().set(&PAUSED, &true);
+    
+    env.events().publish(
+        (Symbol::new(env, "contract_paused"), admin),
+        env.ledger().timestamp(),
+    );
+    
+    Ok(())
+}
+
+pub fn unpause(env: &Env, admin: Address) -> Result<(), Error> {
+    admin.require_auth();
+    let fee_config: FeeConfig = env.storage().instance().get(&FEE_CONFIG).unwrap_or_else(|| handle_error(env, Error::NotInitialized));
+    if fee_config.admin != admin {
+        return Err(Error::Unauthorized);
+    }
+    
+    if !is_paused(env) {
+        return Err(Error::NotPaused);
+    }
+    
+    env.storage().instance().set(&PAUSED, &false);
+    
+    env.events().publish(
+        (Symbol::new(env, "contract_unpaused"), admin),
+        env.ledger().timestamp(),
+    );
+    
+    Ok(())
+}
+
+
 pub fn set_fee_rates(
     env: &Env,
     escrow_fee_percentage: i128,
     dispute_fee_percentage: i128,
     arbitrator_fee_percentage: i128,
 ) {
+    if is_paused(env) {
+        handle_error(env, Error::ContractPaused);
+    }
+
     let mut fee_config: FeeConfig = env.storage().instance().get(&FEE_CONFIG).unwrap();
 
     // Only admin can set fee rates
@@ -112,6 +163,9 @@ pub fn set_fee_rates(
 }
 
 pub fn add_premium_user(env: &Env, user: Address) {
+    if is_paused(env) {
+        handle_error(env, Error::ContractPaused);
+    }
     let fee_config: FeeConfig = env.storage().instance().get(&FEE_CONFIG).unwrap();
     fee_config.admin.require_auth();
 
@@ -148,6 +202,9 @@ pub fn add_premium_user(env: &Env, user: Address) {
 }
 
 pub fn remove_premium_user(env: &Env, user: Address) {
+    if is_paused(env) {
+        handle_error(env, Error::ContractPaused);
+    }
     let fee_config: FeeConfig = env.storage().instance().get(&FEE_CONFIG).unwrap();
     fee_config.admin.require_auth();
 
@@ -178,6 +235,9 @@ pub fn remove_premium_user(env: &Env, user: Address) {
 }
 
 pub fn calculate_escrow_fee(env: &Env, amount: i128, user: Address) -> FeeCalculation {
+    if is_paused(env) {
+        handle_error(env, Error::ContractPaused);
+    }
     // Input validation
     if let Err(e) = validate_fee_calculation(amount, &user) {
         handle_error(env, e);
@@ -204,6 +264,9 @@ pub fn calculate_escrow_fee(env: &Env, amount: i128, user: Address) -> FeeCalcul
 }
 
 pub fn calculate_dispute_fee(env: &Env, amount: i128, user: Address) -> FeeCalculation {
+    if is_paused(env) {
+        handle_error(env, Error::ContractPaused);
+    }
     // Input validation
     if let Err(e) = validate_fee_calculation(amount, &user) {
         handle_error(env, e);
@@ -230,6 +293,9 @@ pub fn calculate_dispute_fee(env: &Env, amount: i128, user: Address) -> FeeCalcu
 }
 
 pub fn collect_fee(env: &Env, amount: i128, fee_type: u32, user: Address) -> i128 {
+    if is_paused(env) {
+        handle_error(env, Error::ContractPaused);
+    }
     // Input validation
     if let Err(e) = validate_fee_calculation(amount, &user) {
         handle_error(env, e);
@@ -321,6 +387,9 @@ pub fn collect_fee(env: &Env, amount: i128, fee_type: u32, user: Address) -> i12
 }
 
 pub fn withdraw_platform_fees(env: &Env, amount: i128) {
+    if is_paused(env) {
+        handle_error(env, Error::ContractPaused);
+    }
     let fee_config: FeeConfig = env.storage().instance().get(&FEE_CONFIG).unwrap();
     fee_config.admin.require_auth();
 
@@ -407,6 +476,9 @@ pub fn get_total_fees(env: &Env) -> i128 {
 
 pub fn reset_total_fees_collected(env: &Env, admin: Address) -> Result<(), Error> {
     admin.require_auth();
+    if is_paused(env) {
+        handle_error(env, Error::ContractPaused);
+    }
 
     let fee_config: FeeConfig = env.storage().instance().get(&FEE_CONFIG).unwrap();
     if fee_config.admin != admin {
@@ -486,6 +558,9 @@ fn calculate_fee_amount(amount: i128, fee_percentage: i128) -> i128 {
 
 
 pub fn set_config(env: &Env, caller: Address, config: ContractConfig) {
+    if is_paused(env) {
+        handle_error(env, Error::ContractPaused);
+    }
     let fee_config: FeeConfig = env.storage().instance().get(&FEE_CONFIG).unwrap();
     
     // Only admin can set config

--- a/contracts-offerhub/contracts/fee-manager-contract/src/error.rs
+++ b/contracts-offerhub/contracts/fee-manager-contract/src/error.rs
@@ -15,6 +15,9 @@ pub enum Error {
     InvalidFeeType = 9,           // Fee type provided is not supported
     FeeCalculationError = 10,     // Error occurred during fee calculation
     WithdrawalFailed = 11,        // Withdrawal operation failed
+    AlreadyPaused = 12,
+    NotPaused = 13,
+    ContractPaused = 14,
 }
 
 pub fn handle_error(env: &Env, error: Error) -> ! {

--- a/contracts-offerhub/contracts/fee-manager-contract/src/lib.rs
+++ b/contracts-offerhub/contracts/fee-manager-contract/src/lib.rs
@@ -19,6 +19,18 @@ impl FeeManagerContract {
         contract::initialize(&env, admin, platform_wallet);
     }
 
+    pub fn pause(env: Env, admin: Address) -> Result<(), Error> {
+        contract::pause(&env, admin)
+    }
+
+    pub fn is_paused(env: Env) -> bool {
+        contract::is_paused(&env)
+    }
+
+    pub fn unpause(env: Env, admin: Address) -> Result<(), Error> {
+        contract::unpause(&env, admin)
+    }
+
     pub fn set_fee_rates(
         env: Env,
         escrow_fee_percentage: i128,

--- a/contracts-offerhub/contracts/fee-manager-contract/src/storage.rs
+++ b/contracts-offerhub/contracts/fee-manager-contract/src/storage.rs
@@ -7,6 +7,8 @@ pub const FEE_HISTORY: Symbol = symbol_short!("FEE_HIST");
 pub const FEE_STATS: Symbol = symbol_short!("FEE_STAT");
 pub const TOTAL_FESS_COLLECTED: Symbol = symbol_short!("FEE_TOTAL");
 
+pub const PAUSED: Symbol = symbol_short!("PAUSED");
+
 // Storage keys for premium users
 pub const PREMIUM_USERS: Symbol = symbol_short!("PREM_USR");
 

--- a/contracts-offerhub/contracts/fee-manager-contract/test_snapshots/test/test_add_premium_user.1.json
+++ b/contracts-offerhub/contracts/fee-manager-contract/test_snapshots/test/test_add_premium_user.1.json
@@ -258,6 +258,14 @@
                       },
                       {
                         "key": {
+                          "symbol": "PAUSED"
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "PLAT_BAL"
                         },
                         "val": {

--- a/contracts-offerhub/contracts/fee-manager-contract/test_snapshots/test/test_calculate_dispute_fee.1.json
+++ b/contracts-offerhub/contracts/fee-manager-contract/test_snapshots/test/test_calculate_dispute_fee.1.json
@@ -239,6 +239,14 @@
                       },
                       {
                         "key": {
+                          "symbol": "PAUSED"
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "PLAT_BAL"
                         },
                         "val": {

--- a/contracts-offerhub/contracts/fee-manager-contract/test_snapshots/test/test_calculate_escrow_fee.1.json
+++ b/contracts-offerhub/contracts/fee-manager-contract/test_snapshots/test/test_calculate_escrow_fee.1.json
@@ -259,6 +259,14 @@
                       },
                       {
                         "key": {
+                          "symbol": "PAUSED"
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "PLAT_BAL"
                         },
                         "val": {

--- a/contracts-offerhub/contracts/fee-manager-contract/test_snapshots/test/test_collect_fee.1.json
+++ b/contracts-offerhub/contracts/fee-manager-contract/test_snapshots/test/test_collect_fee.1.json
@@ -239,6 +239,14 @@
                       },
                       {
                         "key": {
+                          "symbol": "PAUSED"
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "PLAT_BAL"
                         },
                         "val": {

--- a/contracts-offerhub/contracts/fee-manager-contract/test_snapshots/test/test_collect_fee_premium_user.1.json
+++ b/contracts-offerhub/contracts/fee-manager-contract/test_snapshots/test/test_collect_fee_premium_user.1.json
@@ -258,6 +258,14 @@
                       },
                       {
                         "key": {
+                          "symbol": "PAUSED"
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "PLAT_BAL"
                         },
                         "val": {

--- a/contracts-offerhub/contracts/fee-manager-contract/test_snapshots/test/test_fee_precision.1.json
+++ b/contracts-offerhub/contracts/fee-manager-contract/test_snapshots/test/test_fee_precision.1.json
@@ -239,6 +239,14 @@
                       },
                       {
                         "key": {
+                          "symbol": "PAUSED"
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "PLAT_BAL"
                         },
                         "val": {

--- a/contracts-offerhub/contracts/fee-manager-contract/test_snapshots/test/test_fee_transparency.1.json
+++ b/contracts-offerhub/contracts/fee-manager-contract/test_snapshots/test/test_fee_transparency.1.json
@@ -240,6 +240,14 @@
                       },
                       {
                         "key": {
+                          "symbol": "PAUSED"
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "PLAT_BAL"
                         },
                         "val": {

--- a/contracts-offerhub/contracts/fee-manager-contract/test_snapshots/test/test_get_fee_stats.1.json
+++ b/contracts-offerhub/contracts/fee-manager-contract/test_snapshots/test/test_get_fee_stats.1.json
@@ -239,6 +239,14 @@
                       },
                       {
                         "key": {
+                          "symbol": "PAUSED"
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "PLAT_BAL"
                         },
                         "val": {

--- a/contracts-offerhub/contracts/fee-manager-contract/test_snapshots/test/test_get_premium_users.1.json
+++ b/contracts-offerhub/contracts/fee-manager-contract/test_snapshots/test/test_get_premium_users.1.json
@@ -277,6 +277,14 @@
                       },
                       {
                         "key": {
+                          "symbol": "PAUSED"
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "PLAT_BAL"
                         },
                         "val": {

--- a/contracts-offerhub/contracts/fee-manager-contract/test_snapshots/test/test_initialize.1.json
+++ b/contracts-offerhub/contracts/fee-manager-contract/test_snapshots/test/test_initialize.1.json
@@ -239,6 +239,14 @@
                       },
                       {
                         "key": {
+                          "symbol": "PAUSED"
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "PLAT_BAL"
                         },
                         "val": {

--- a/contracts-offerhub/contracts/fee-manager-contract/test_snapshots/test/test_multiple_fee_collections.1.json
+++ b/contracts-offerhub/contracts/fee-manager-contract/test_snapshots/test/test_multiple_fee_collections.1.json
@@ -240,6 +240,14 @@
                       },
                       {
                         "key": {
+                          "symbol": "PAUSED"
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "PLAT_BAL"
                         },
                         "val": {

--- a/contracts-offerhub/contracts/fee-manager-contract/test_snapshots/test/test_remove_premium_user.1.json
+++ b/contracts-offerhub/contracts/fee-manager-contract/test_snapshots/test/test_remove_premium_user.1.json
@@ -278,6 +278,14 @@
                       },
                       {
                         "key": {
+                          "symbol": "PAUSED"
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "PLAT_BAL"
                         },
                         "val": {

--- a/contracts-offerhub/contracts/fee-manager-contract/test_snapshots/test/test_set_fee_rates.1.json
+++ b/contracts-offerhub/contracts/fee-manager-contract/test_snapshots/test/test_set_fee_rates.1.json
@@ -264,6 +264,14 @@
                       },
                       {
                         "key": {
+                          "symbol": "PAUSED"
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "PLAT_BAL"
                         },
                         "val": {

--- a/contracts-offerhub/contracts/fee-manager-contract/test_snapshots/test/test_set_fee_rates_unauthorized.1.json
+++ b/contracts-offerhub/contracts/fee-manager-contract/test_snapshots/test/test_set_fee_rates_unauthorized.1.json
@@ -239,6 +239,14 @@
                       },
                       {
                         "key": {
+                          "symbol": "PAUSED"
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "PLAT_BAL"
                         },
                         "val": {

--- a/contracts-offerhub/contracts/fee-manager-contract/test_snapshots/test/test_withdraw_platform_fees.1.json
+++ b/contracts-offerhub/contracts/fee-manager-contract/test_snapshots/test/test_withdraw_platform_fees.1.json
@@ -238,6 +238,14 @@
                       },
                       {
                         "key": {
+                          "symbol": "PAUSED"
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "PLAT_BAL"
                         },
                         "val": {

--- a/contracts-offerhub/contracts/fee-manager-contract/test_snapshots/test/test_withdraw_platform_fees_unauthorized.1.json
+++ b/contracts-offerhub/contracts/fee-manager-contract/test_snapshots/test/test_withdraw_platform_fees_unauthorized.1.json
@@ -239,6 +239,14 @@
                       },
                       {
                         "key": {
+                          "symbol": "PAUSED"
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "PLAT_BAL"
                         },
                         "val": {

--- a/contracts-offerhub/contracts/rating-contract/src/error.rs
+++ b/contracts-offerhub/contracts/rating-contract/src/error.rs
@@ -38,4 +38,7 @@ pub enum Error {
     
     TimestampTooOld = 17, 
     NoRatingsFound = 18,
+    AlreadyPaused = 19,
+    NotPaused = 20,
+    ContractPaused = 21,
 }

--- a/contracts-offerhub/contracts/rating-contract/src/lib.rs
+++ b/contracts-offerhub/contracts/rating-contract/src/lib.rs
@@ -54,6 +54,18 @@ impl Contract {
         )
     }
 
+    pub fn pause(env: Env, admin: Address) -> Result<(), Error> {
+        RatingContract::pause(&env, admin)
+    }
+
+    pub fn is_paused(env: Env) -> bool {
+        RatingContract::is_paused(&env)
+    }
+
+    pub fn unpause(env: Env, admin: Address) -> Result<(), Error> {
+        RatingContract::unpause(&env, admin)
+    }
+
     /// Get rating statistics for a user
     pub fn get_user_rating_stats(env: Env, user: Address) -> Result<RatingStats, Error> {
         RatingContract::get_user_rating_stats(env, user)

--- a/contracts-offerhub/contracts/rating-contract/src/types.rs
+++ b/contracts-offerhub/contracts/rating-contract/src/types.rs
@@ -156,6 +156,7 @@ pub const DEFAULT_TOP_RATED_THRESHOLD: u32 = 480; // 4.80 average rating
 pub const TOTAL_RATING_COUNT: Symbol = symbol_short!("TOTALRATE");
 
 pub const MAX_RATING_AGE: u64 = 30 * 24 * 60 * 60; // 30 days in seconds
+pub const PAUSED: Symbol = symbol_short!("PAUSED");
 
 pub fn require_auth(address: &Address) -> Result<(), Error> {
     address.require_auth();

--- a/contracts-offerhub/contracts/reputation-nft-contract/src/error.rs
+++ b/contracts-offerhub/contracts/reputation-nft-contract/src/error.rs
@@ -24,4 +24,7 @@ pub enum Error {
     NonTransferableToken = 7,
 
     InvalidInput = 8,
+    AlreadyPaused = 9,
+    NotPaused = 10,
+    ContractPaused = 11,
 }

--- a/contracts-offerhub/contracts/reputation-nft-contract/src/lib.rs
+++ b/contracts-offerhub/contracts/reputation-nft-contract/src/lib.rs
@@ -25,6 +25,18 @@ impl Contract {
         ReputationNFTContract::init(env, admin)
     }
 
+    pub fn pause(env: Env, admin: Address) -> Result<(), Error> {
+        ReputationNFTContract::pause(&env, admin)
+    }
+
+    pub fn is_paused(env: Env) -> bool {
+        ReputationNFTContract::is_paused(&env)
+    }
+
+    pub fn unpause(env: Env, admin: Address) -> Result<(), Error> {
+        ReputationNFTContract::unpause(&env, admin)
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub fn mint(
         env: Env,

--- a/contracts-offerhub/contracts/reputation-nft-contract/src/types.rs
+++ b/contracts-offerhub/contracts/reputation-nft-contract/src/types.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contracterror, contracttype, Address, Env, String};
+use soroban_sdk::{contracterror, contracttype, Address, Env, String, Symbol, symbol_short};
 use crate::error::Error;
 pub type TokenId = u64;
 
@@ -40,6 +40,7 @@ pub const ACHIEVEMENT_STATS: &[u8] = &[6];
 pub const ACHIEVEMENT_LEADERBOARD: &[u8] = &[7];
 pub const USER_REPUTATION: &[u8] = &[8];
 pub const ACHIEVEMENT_PREREQUISITES: &[u8] = &[9];
+pub const PAUSED: Symbol = symbol_short!("PAUSED");
 
 pub fn require_auth(_env: &Env, address: &Address) -> Result<(), Error> {
     address.require_auth();

--- a/contracts-offerhub/contracts/reputation-nft-contract/test_snapshots/test/test_admin_can_mint_without_being_minter.1.json
+++ b/contracts-offerhub/contracts/reputation-nft-contract/test_snapshots/test/test_admin_can_mint_without_being_minter.1.json
@@ -102,7 +102,16 @@
                     "executable": {
                       "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                     },
-                    "storage": null
+                    "storage": [
+                      {
+                        "key": {
+                          "symbol": "PAUSED"
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      }
+                    ]
                   }
                 }
               }

--- a/contracts-offerhub/contracts/reputation-nft-contract/test_snapshots/test/test_admin_transfer.1.json
+++ b/contracts-offerhub/contracts/reputation-nft-contract/test_snapshots/test/test_admin_transfer.1.json
@@ -127,7 +127,16 @@
                     "executable": {
                       "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                     },
-                    "storage": null
+                    "storage": [
+                      {
+                        "key": {
+                          "symbol": "PAUSED"
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      }
+                    ]
                   }
                 }
               }

--- a/contracts-offerhub/contracts/reputation-nft-contract/test_snapshots/test/test_batch_operations.1.json
+++ b/contracts-offerhub/contracts/reputation-nft-contract/test_snapshots/test/test_batch_operations.1.json
@@ -368,7 +368,16 @@
                     "executable": {
                       "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                     },
-                    "storage": null
+                    "storage": [
+                      {
+                        "key": {
+                          "symbol": "PAUSED"
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      }
+                    ]
                   }
                 }
               }

--- a/contracts-offerhub/contracts/reputation-nft-contract/test_snapshots/test/test_get_storage_functions.1.json
+++ b/contracts-offerhub/contracts/reputation-nft-contract/test_snapshots/test/test_get_storage_functions.1.json
@@ -71,7 +71,16 @@
                     "executable": {
                       "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                     },
-                    "storage": null
+                    "storage": [
+                      {
+                        "key": {
+                          "symbol": "PAUSED"
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      }
+                    ]
                   }
                 }
               }

--- a/contracts-offerhub/contracts/reputation-nft-contract/test_snapshots/test/test_init.1.json
+++ b/contracts-offerhub/contracts/reputation-nft-contract/test_snapshots/test/test_init.1.json
@@ -71,7 +71,16 @@
                     "executable": {
                       "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                     },
-                    "storage": null
+                    "storage": [
+                      {
+                        "key": {
+                          "symbol": "PAUSED"
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      }
+                    ]
                   }
                 }
               }

--- a/contracts-offerhub/contracts/reputation-nft-contract/test_snapshots/test/test_metadata_functionality.1.json
+++ b/contracts-offerhub/contracts/reputation-nft-contract/test_snapshots/test/test_metadata_functionality.1.json
@@ -139,7 +139,16 @@
                     "executable": {
                       "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                     },
-                    "storage": null
+                    "storage": [
+                      {
+                        "key": {
+                          "symbol": "PAUSED"
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      }
+                    ]
                   }
                 }
               }

--- a/contracts-offerhub/contracts/reputation-nft-contract/test_snapshots/test/test_mint_and_query.1.json
+++ b/contracts-offerhub/contracts/reputation-nft-contract/test_snapshots/test/test_mint_and_query.1.json
@@ -398,7 +398,16 @@
                     "executable": {
                       "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                     },
-                    "storage": null
+                    "storage": [
+                      {
+                        "key": {
+                          "symbol": "PAUSED"
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      }
+                    ]
                   }
                 }
               }

--- a/contracts-offerhub/contracts/reputation-nft-contract/test_snapshots/test/test_mint_for_achievement.1.json
+++ b/contracts-offerhub/contracts/reputation-nft-contract/test_snapshots/test/test_mint_for_achievement.1.json
@@ -484,7 +484,16 @@
                     "executable": {
                       "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                     },
-                    "storage": null
+                    "storage": [
+                      {
+                        "key": {
+                          "symbol": "PAUSED"
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      }
+                    ]
                   }
                 }
               }

--- a/contracts-offerhub/contracts/reputation-nft-contract/test_snapshots/test/test_minter_role.1.json
+++ b/contracts-offerhub/contracts/reputation-nft-contract/test_snapshots/test/test_minter_role.1.json
@@ -507,7 +507,16 @@
                     "executable": {
                       "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                     },
-                    "storage": null
+                    "storage": [
+                      {
+                        "key": {
+                          "symbol": "PAUSED"
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      }
+                    ]
                   }
                 }
               }

--- a/contracts-offerhub/contracts/reputation-nft-contract/test_snapshots/test/test_mock_mint_and_get_metadata.1.json
+++ b/contracts-offerhub/contracts/reputation-nft-contract/test_snapshots/test/test_mock_mint_and_get_metadata.1.json
@@ -171,7 +171,16 @@
                     "executable": {
                       "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                     },
-                    "storage": null
+                    "storage": [
+                      {
+                        "key": {
+                          "symbol": "PAUSED"
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      }
+                    ]
                   }
                 }
               }

--- a/contracts-offerhub/contracts/reputation-nft-contract/test_snapshots/test/test_mock_minter_role.1.json
+++ b/contracts-offerhub/contracts/reputation-nft-contract/test_snapshots/test/test_mock_minter_role.1.json
@@ -102,7 +102,16 @@
                     "executable": {
                       "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                     },
-                    "storage": null
+                    "storage": [
+                      {
+                        "key": {
+                          "symbol": "PAUSED"
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      }
+                    ]
                   }
                 }
               }

--- a/contracts-offerhub/contracts/reputation-nft-contract/test_snapshots/test/test_mock_transfer.1.json
+++ b/contracts-offerhub/contracts/reputation-nft-contract/test_snapshots/test/test_mock_transfer.1.json
@@ -102,7 +102,16 @@
                     "executable": {
                       "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                     },
-                    "storage": null
+                    "storage": [
+                      {
+                        "key": {
+                          "symbol": "PAUSED"
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      }
+                    ]
                   }
                 }
               }

--- a/contracts-offerhub/contracts/reputation-nft-contract/test_snapshots/test/test_multiple_tokens.1.json
+++ b/contracts-offerhub/contracts/reputation-nft-contract/test_snapshots/test/test_multiple_tokens.1.json
@@ -133,7 +133,16 @@
                     "executable": {
                       "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                     },
-                    "storage": null
+                    "storage": [
+                      {
+                        "key": {
+                          "symbol": "PAUSED"
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      }
+                    ]
                   }
                 }
               }

--- a/contracts-offerhub/contracts/reputation-nft-contract/test_snapshots/test/test_token_existence_error.1.json
+++ b/contracts-offerhub/contracts/reputation-nft-contract/test_snapshots/test/test_token_existence_error.1.json
@@ -71,7 +71,16 @@
                     "executable": {
                       "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                     },
-                    "storage": null
+                    "storage": [
+                      {
+                        "key": {
+                          "symbol": "PAUSED"
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      }
+                    ]
                   }
                 }
               }

--- a/contracts-offerhub/contracts/reputation-nft-contract/test_snapshots/test/test_token_uri_update.1.json
+++ b/contracts-offerhub/contracts/reputation-nft-contract/test_snapshots/test/test_token_uri_update.1.json
@@ -170,7 +170,16 @@
                     "executable": {
                       "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                     },
-                    "storage": null
+                    "storage": [
+                      {
+                        "key": {
+                          "symbol": "PAUSED"
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      }
+                    ]
                   }
                 }
               }

--- a/contracts-offerhub/contracts/reputation-nft-contract/test_snapshots/test/test_transfer.1.json
+++ b/contracts-offerhub/contracts/reputation-nft-contract/test_snapshots/test/test_transfer.1.json
@@ -439,7 +439,16 @@
                     "executable": {
                       "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                     },
-                    "storage": null
+                    "storage": [
+                      {
+                        "key": {
+                          "symbol": "PAUSED"
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      }
+                    ]
                   }
                 }
               }

--- a/contracts-offerhub/contracts/reputation-nft-contract/test_snapshots/test/test_transfer_admin_role.1.json
+++ b/contracts-offerhub/contracts/reputation-nft-contract/test_snapshots/test/test_transfer_admin_role.1.json
@@ -71,7 +71,16 @@
                     "executable": {
                       "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                     },
-                    "storage": null
+                    "storage": [
+                      {
+                        "key": {
+                          "symbol": "PAUSED"
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      }
+                    ]
                   }
                 }
               }

--- a/contracts-offerhub/contracts/reputation-nft-contract/test_snapshots/test/test_unauthorized_access.1.json
+++ b/contracts-offerhub/contracts/reputation-nft-contract/test_snapshots/test/test_unauthorized_access.1.json
@@ -103,7 +103,16 @@
                     "executable": {
                       "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                     },
-                    "storage": null
+                    "storage": [
+                      {
+                        "key": {
+                          "symbol": "PAUSED"
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      }
+                    ]
                   }
                 }
               }

--- a/contracts-offerhub/contracts/user-registry-contract/src/access.rs
+++ b/contracts-offerhub/contracts/user-registry-contract/src/access.rs
@@ -1,6 +1,6 @@
 use crate::storage::{get_admin, get_moderators, set_admin, set_moderators};
 use crate::error::Error;
-use soroban_sdk::{Address, Env, Vec};
+use soroban_sdk::{Address, Env, Vec, log};
 
 pub struct AccessControl;
 
@@ -22,9 +22,11 @@ impl AccessControl {
         caller.require_auth();
 
         let admin = get_admin(env).ok_or(Error::NotInitialized)?;
+
         if admin != *caller {
             return Err(Error::Unauthorized);
         }
+
         Ok(())
     }
 

--- a/contracts-offerhub/contracts/user-registry-contract/src/error.rs
+++ b/contracts-offerhub/contracts/user-registry-contract/src/error.rs
@@ -38,4 +38,7 @@ pub enum Error {
     InvalidValidationData = 16,
     /// An unexpected error occurred
     UnexpectedError = 17,
+    AlreadyPaused = 18,
+    NotPaused = 19,
+    ContractPaused = 20,
 }

--- a/contracts-offerhub/contracts/user-registry-contract/src/lib.rs
+++ b/contracts-offerhub/contracts/user-registry-contract/src/lib.rs
@@ -27,6 +27,18 @@ impl Contract {
         UserRegistryContract::initialize_admin(env, admin)
     }
 
+     pub fn pause(env: Env, admin: Address) -> Result<(), Error> {
+        UserRegistryContract::pause(&env, admin)
+    }
+
+    pub fn is_paused(env: Env) -> bool {
+        UserRegistryContract::is_paused(&env)
+    }
+
+    pub fn unpause(env: Env, admin: Address) -> Result<(), Error> {
+        UserRegistryContract::unpause(&env, admin)
+    }
+
     // ==================== LEGACY FUNCTIONS (for backward compatibility) ====================
 
     /// Legacy function for registering a verified user

--- a/contracts-offerhub/contracts/user-registry-contract/src/storage.rs
+++ b/contracts-offerhub/contracts/user-registry-contract/src/storage.rs
@@ -13,6 +13,7 @@ pub const TOTAL_USERS: Symbol = symbol_short!("TOTALUSER");
 pub const RATING_CONTRACT: Symbol = symbol_short!("RATING");
 pub const ESCROW_CONTRACTS: Symbol = symbol_short!("ESCROWS");
 pub const DISPUTE_CONTRACTS: Symbol = symbol_short!("DISPUTES");
+pub const PAUSED: Symbol = symbol_short!("PAUSED");
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[contracttype]


### PR DESCRIPTION
# 📝 Pull Request Title
feat: Add Pause/Unpause Functionality to Smart Contract

## 🛠️ Issue

- Closes #401 

## 📚 Description

- Pause Function 
- UnPause Function 
- is_paused Function 
- emergency withdraw function

## ✅ Changes applied

-

## 🔍 Evidence/Media (screenshots/videos)

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added platform-wide pause/unpause controls with is_paused status and events across Escrow, Dispute, Fee Manager, Rating, Reputation NFT, Escrow Factory, and User Registry contracts.
  - Core operations are now safely blocked while paused; authorized admins can resume.
  - Escrow: introduces emergency withdrawal available in paused state.

- Changes
  - Rating: submit_rating now accepts a wider rating type (u32).

- Tests
  - Extensive new tests for pause/unpause, authorization, blocked operations, emergency withdrawal, and updated snapshots reflecting the new paused state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->