### PR TITLE
feat(ui): add loading state to button component

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -38,17 +38,50 @@ export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
   asChild?: boolean
+  isLoading?: boolean // 1. Add isLoading prop
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, asChild = false, ...props }, ref) => {
+  (
+    {
+      className,
+      variant,
+      size,
+      asChild = false,
+      isLoading = false, // 2. Destructure isLoading and children
+      children,
+      ...props
+    },
+    ref
+  ) => {
     const Comp = asChild ? Slot : "button"
     return (
       <Comp
         className={cn(buttonVariants({ variant, size, className }))}
         ref={ref}
+        disabled={isLoading || props.disabled} // 3. Disable button while loading
         {...props}
-      />
+      >
+        {/* 4. Render spinner if loading, otherwise render children */}
+        {isLoading ? (
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="animate-spin" // This SVG is sized by the cva styles
+          >
+            <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+          </svg>
+        ) : (
+          children
+        )}
+      </Comp>
     )
   }
 )


### PR DESCRIPTION
# 📝 Add loading state to button component

## 🛠️ Add Loading States to Button Components #647

- Closes #647

📚 Description
This pull request introduces a loading state to the core Button component (src/components/ui/button.tsx). This is a key user experience enhancement for any asynchronous operation, such as form submissions or API calls.

When the new isLoading prop is set to true, the button provides clear visual feedback by displaying a spinner and disabling itself. This prevents accidental double-clicks and reassures the user that their action is being processed.

✅ Changes applied
Added isLoading Prop: An optional isLoading?: boolean prop has been added to the ButtonProps interface.

Automatic Disabling: The button is now automatically disabled (disabled={isLoading || props.disabled}) when the isLoading prop is true, preventing further interaction during the async operation.

Conditional Rendering: The button's content now conditionally renders:

An animated SVG spinner is displayed when isLoading is true.

The original children (text or icons) are displayed otherwise.

Maintained Flexibility: The implementation works seamlessly with the existing asChild prop and all cva variants.

🔍 Evidence/Media (Usage Example)
As this change only adds the capability to the component, visual evidence isn't practical.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Buttons now support a loading state via an isLoading prop.
  * While loading, buttons display a spinner, hide their usual content, and are disabled to prevent interaction.
  * Existing variants, sizes, and other passed props continue to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->