### PR TITLE
fix: improve useAutoSave hook reactivity with proper state management

### DIFF
--- a/src/hooks/use-auto-save.ts
+++ b/src/hooks/use-auto-save.ts
@@ -1,6 +1,6 @@
 "use client"
 
-import { useCallback, useEffect, useRef } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 
 interface UseAutoSaveOptions {
   delay?: number
@@ -18,8 +18,8 @@ export function useAutoSave({
   onSave
 }: UseAutoSaveOptions = {}): UseAutoSaveReturn {
   const timeoutRef = useRef<NodeJS.Timeout | null>(null)
-  const lastSavedRef = useRef<Date | null>(null)
-  const isSavingRef = useRef(false)
+  const [lastSaved, setLastSaved] = useState<Date | null>(null)
+  const [isSaving, setIsSaving] = useState(false)
 
   const saveData = useCallback((data: any) => {
     // Clear existing timeout
@@ -29,19 +29,19 @@ export function useAutoSave({
 
     // Set new timeout for auto-save
     timeoutRef.current = setTimeout(async () => {
-      if (onSave && !isSavingRef.current) {
-        isSavingRef.current = true
+      if (onSave && !isSaving) {
+        setIsSaving(true)
         try {
           await onSave(data)
-          lastSavedRef.current = new Date()
+          setLastSaved(new Date())
         } catch (error) {
           console.error("Auto-save failed:", error)
         } finally {
-          isSavingRef.current = false
+          setIsSaving(false)
         }
       }
     }, delay)
-  }, [delay, onSave])
+  }, [delay, onSave, isSaving])
 
   // Cleanup on unmount
   useEffect(() => {
@@ -54,7 +54,7 @@ export function useAutoSave({
 
   return {
     saveData,
-    isSaving: isSavingRef.current,
-    lastSaved: lastSavedRef.current
+    isSaving,
+    lastSaved
   }
 }


### PR DESCRIPTION

# 📝 Pull Request Title

**fix: improve useAutoSave hook reactivity with proper state management**

## 🛠️ Issue

- Closes #773

## 📚 Description

Fixed the `useAutoSave` hook to use proper React state management instead of refs for reactive values. The hook was using `useRef` for `isSaving` and `lastSaved` values, which prevented components from re-rendering when these states changed. This fix ensures that UI components can properly respond to auto-save state changes and display loading indicators and save timestamps correctly.

## ✅ Changes applied

- Replaced `useRef` with `useState` for `isSaving` and `lastSaved` values
- Updated `useCallback` dependencies to include `isSaving` for proper reactivity
- Maintained all existing functionality while improving React compatibility
- Added proper state setters (`setIsSaving`, `setLastSaved`) in the auto-save logic
- Updated return object to use state values instead of ref values

## 🔍 Evidence/Media (screenshots/videos)

- No visual changes as this is a backend hook improvement
- Hook now properly triggers re-renders when auto-save state changes
- Components using this hook will now correctly display loading states and save timestamps

**Technical Details:**
- File modified: `src/hooks/use-auto-save.ts`
- Lines changed: 10 insertions, 10 deletions
- No breaking changes to the hook API
- Maintains backward compatibility with existing implementations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Updated auto-save to use state-driven status and timestamps for more consistent UI updates.
- Bug Fixes
  - Resolved cases where the saving indicator could get stuck or not reflect progress accurately.
  - Ensured “Last saved” time updates reliably after successful saves.
  - Reduced chances of overlapping saves by respecting in-progress state.
  - Improved consistency of auto-save timing and behavior under rapid edits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->