### PR TITLE
refactor(ui): edited the modal component to use the showCloseButton prop properly

### DIFF
--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import * as React from "react";
-import { X } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { Dialog, DialogContent } from "./dialog";
+import { Dialog, DialogContent, DialogTitle } from "./dialog";
 
 export interface ModalProps {
   /** Whether the modal is open */
@@ -62,6 +61,7 @@ export const Modal: React.FC<ModalProps> = ({
     <Dialog open={isOpen} onOpenChange={handleOpenChange}>
       <DialogContent
         className={cn("relative w-full", sizeClasses[size], className)}
+        showCloseButton={showCloseButton}
         // Prevent closing via Escape when disabled
         onEscapeKeyDown={(e) => {
           if (!closeOnEscape) {
@@ -79,9 +79,9 @@ export const Modal: React.FC<ModalProps> = ({
           <div className="flex items-center justify-between border-b pb-4 mb-4">
             <div className="flex-1">
               {title && (
-                <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+                <DialogTitle className="text-lg font-semibold text-gray-900 dark:text-gray-100">
                   {title}
-                </h2>
+                </DialogTitle>
               )}
               {description && (
                 <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
@@ -89,15 +89,6 @@ export const Modal: React.FC<ModalProps> = ({
                 </p>
               )}
             </div>
-            {showCloseButton && (
-              <button
-                onClick={onClose}
-                className="ml-4 p-1 rounded-md text-gray-400 hover:text-gray-600 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
-                aria-label="Close modal"
-              >
-                <X className="h-5 w-5" />
-              </button>
-            )}
           </div>
         )}
 

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,18 +1,18 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import * as DialogPrimitive from "@radix-ui/react-dialog"
-import { X } from 'lucide-react'
+import * as React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
-const Dialog = DialogPrimitive.Root
+const Dialog = DialogPrimitive.Root;
 
-const DialogTrigger = DialogPrimitive.Trigger
+const DialogTrigger = DialogPrimitive.Trigger;
 
-const DialogPortal = DialogPrimitive.Portal
+const DialogPortal = DialogPrimitive.Portal;
 
-const DialogClose = DialogPrimitive.Close
+const DialogClose = DialogPrimitive.Close;
 
 const DialogOverlay = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Overlay>,
@@ -26,13 +26,15 @@ const DialogOverlay = React.forwardRef<
     )}
     {...props}
   />
-))
-DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
+    showCloseButton?: boolean;
+  }
+>(({ className, children, showCloseButton = true, ...props }, ref) => (
   <DialogPortal>
     <DialogOverlay />
     <DialogPrimitive.Content
@@ -44,14 +46,16 @@ const DialogContent = React.forwardRef<
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
-        <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
-      </DialogPrimitive.Close>
+      {showCloseButton && (
+        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+          <X className="h-4 w-4" />
+          <span className="sr-only">Close</span>
+        </DialogPrimitive.Close>
+      )}
     </DialogPrimitive.Content>
   </DialogPortal>
-))
-DialogContent.displayName = DialogPrimitive.Content.displayName
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
 
 const DialogHeader = ({
   className,
@@ -64,8 +68,8 @@ const DialogHeader = ({
     )}
     {...props}
   />
-)
-DialogHeader.displayName = "DialogHeader"
+);
+DialogHeader.displayName = "DialogHeader";
 
 const DialogFooter = ({
   className,
@@ -78,8 +82,8 @@ const DialogFooter = ({
     )}
     {...props}
   />
-)
-DialogFooter.displayName = "DialogFooter"
+);
+DialogFooter.displayName = "DialogFooter";
 
 const DialogTitle = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Title>,
@@ -93,8 +97,8 @@ const DialogTitle = React.forwardRef<
     )}
     {...props}
   />
-))
-DialogTitle.displayName = DialogPrimitive.Title.displayName
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
 
 const DialogDescription = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Description>,
@@ -105,8 +109,8 @@ const DialogDescription = React.forwardRef<
     className={cn("text-sm text-muted-foreground", className)}
     {...props}
   />
-))
-DialogDescription.displayName = DialogPrimitive.Description.displayName
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
 
 export {
   Dialog,
@@ -119,4 +123,4 @@ export {
   DialogFooter,
   DialogTitle,
   DialogDescription,
-}
+};


### PR DESCRIPTION
## Description
This pull request refactors how modals display their close button and title, moving the close button logic into the shared `DialogContent` component and ensuring consistent usage of the `DialogTitle` component. The changes simplify modal code and improve reusability and maintainability.

## Changes made
**Modal component improvements:**

* The close button logic has been removed from `Modal.tsx` and delegated to the `DialogContent` component, which now accepts a `showCloseButton` prop to control its visibility.

**Dialog component enhancements:**

* The `DialogContent` component in `dialog.tsx` now supports a `showCloseButton` prop and renders the close button internally, reducing duplicate code and ensuring consistency across dialogs.
* Minor formatting and code style updates were made throughout `dialog.tsx` for clarity and consistency.

## Linked Issue 
This PR closes issue #750 

## Video 
[Screencast from 2025-10-09 11-35-16.webm](https://github.com/user-attachments/assets/bf31c2a0-d232-4ce5-85d9-da02004a9533)

@KevinMB0220 @Josue19-08 
Please review. Thanks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an option to show or hide the dialog’s close button.
- Bug Fixes
  - Escape key now closes dialogs more reliably when enabled.
  - Overlay click-to-close behavior consistently respects configuration.
- Refactor
  - Improved dialog title semantics for better accessibility and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->