### PR TITLE
fix: add offer-hub-web.vercel.app to CORS origins

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -45,6 +45,7 @@ app.use(cors({
     'http://localhost:3000',
     'https://offer-hub-hpd4.vercel.app',
     'https://offer-hub.vercel.app',
+    'https://offer-hub-web.vercel.app',
     /https:\/\/.*\.vercel\.app$/
   ],
   credentials: true,


### PR DESCRIPTION
# 📝 Pull Request Title

## 🛠️ Issue

- Closes #issue-ID

## 📚 Description

-

## ✅ Changes applied

-

## 🔍 Evidence/Media (screenshots/videos)

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled access to the backend from an additional web domain, allowing users on that site to interact with the service without cross-origin issues.

* **Chores**
  * Updated CORS configuration to include a new allowed origin, improving compatibility for deployments accessing the API from that domain.
  * No changes to routes, behaviors, or public interfaces; existing functionality remains unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->