### PR TITLE
feat: add endpoint and tests for user account deletion

### DIFF
--- a/backend/src/routes/user.routes.ts
+++ b/backend/src/routes/user.routes.ts
@@ -5,6 +5,7 @@ import {
   updateUserHandler,
   updateAvatarHandler,
   getAllUsersHandler,
+  deleteOwnAccountHandler,
 } from "@/controllers/user.controller";
 import { authorizeRoles, verifyToken } from "@/middlewares/auth.middleware";
 import { UserRole } from "@/types/auth.types";
@@ -15,6 +16,9 @@ router.get("/", verifyToken, authorizeRoles(UserRole.ADMIN), getAllUsersHandler)
 
 // I added authorization here because the route for public registration is in /api/auth/register
 router.post("/", verifyToken, authorizeRoles(UserRole.ADMIN), createUserHandler);
+
+// DELETE /me - Delete own account (must be before /:id routes to avoid conflicts)
+router.delete("/me", verifyToken, deleteOwnAccountHandler);
 
 router.get("/:id", verifyToken, getUserByIdHandler);
 router.patch("/:id", verifyToken, updateUserHandler);

--- a/backend/src/services/email.service.ts
+++ b/backend/src/services/email.service.ts
@@ -177,3 +177,56 @@ export async function sendPasswordResetEmail(
   });
 }
 
+/**
+ * Send account deletion confirmation email
+ * @param email - Recipient email address (original email before anonymization)
+ */
+export async function sendAccountDeletionEmail(email: string): Promise<void> {
+  const frontendUrl = process.env.FRONTEND_URL || 'http://localhost:3000';
+  const supportEmail = process.env.SUPPORT_EMAIL || 'support@offer-hub.org';
+
+  const html = `
+    <!DOCTYPE html>
+    <html>
+    <head>
+      <meta charset="utf-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <title>Account Deletion Confirmation</title>
+    </head>
+    <body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
+      <div style="background-color: #f8f9fa; padding: 30px; border-radius: 8px; margin-bottom: 20px;">
+        <h1 style="color: #2c3e50; margin-top: 0;">Account Deletion Confirmation</h1>
+        <p>Hello,</p>
+        <p>We're writing to confirm that your Offer Hub account has been scheduled for deletion.</p>
+        <div style="background-color: #fff3cd; border: 1px solid #ffc107; border-radius: 5px; padding: 15px; margin: 20px 0;">
+          <p style="margin: 0; color: #856404;">
+            <strong>What this means:</strong>
+          </p>
+          <ul style="color: #856404; margin: 10px 0 0 0; padding-left: 20px;">
+            <li>Your account has been deactivated</li>
+            <li>Your personal data has been anonymized</li>
+            <li>All active sessions have been terminated</li>
+          </ul>
+        </div>
+        <p>If you did not request this deletion or believe this was done in error, please contact our support team immediately:</p>
+        <div style="text-align: center; margin: 30px 0;">
+          <a href="mailto:${supportEmail}" style="background-color: #dc3545; color: white; padding: 12px 30px; text-decoration: none; border-radius: 5px; display: inline-block; font-weight: bold;">Contact Support</a>
+        </div>
+        <p style="color: #666; font-size: 14px;">
+          We're sorry to see you go. If you'd like to share feedback about your experience, please reply to this email.
+        </p>
+        <hr style="border: none; border-top: 1px solid #eee; margin: 30px 0;">
+        <p style="color: #999; font-size: 12px; margin-bottom: 0;">
+          This is an automated message from Offer Hub. This email was sent to confirm account deletion.
+        </p>
+      </div>
+    </body>
+    </html>
+  `;
+
+  await sendEmail({
+    to: email,
+    subject: 'Offer Hub Account Deletion Confirmation',
+    html,
+  });
+}


### PR DESCRIPTION
# 📝 Pull Request Title

## 🛠️ Issue

- Closes #933 

## 📚 Description

This pull request introduces the ability for users to soft-delete their own accounts, including comprehensive backend logic, route handling, and integration tests. The new feature ensures secure account deletion with password verification, explicit confirmation, anonymization of personal data, revocation of sessions, and notification via email.

-

## ✅ Changes applied

**Account Deletion Feature Implementation**
* Added `deleteOwnAccountHandler` to `user.controller.ts`, which validates authentication, password, and confirmation string, then delegates to the service for account deletion. Handles Supabase errors and responds with a confirmation message.
* Implemented `deleteOwnAccount` method in `user.service.ts` to:
  - Verify password and confirmation,
  - Revoke all user refresh tokens,
  - Anonymize user data (email, username, etc.),
  - Soft-delete the account (`is_active=false`),
  - Send a confirmation email before anonymization,
  - Handle all relevant errors.
* Added `sendAccountDeletionEmail` to `email.service.ts` to notify users when their account is deleted, using a styled HTML template.

**API and Routing**
* Registered the new `DELETE /me` route in `user.routes.ts` for authenticated users to delete their own account, ensuring it is placed before parameterized routes to avoid conflicts. [[1]](diffhunk://#diff-00b00f82f1a783af27104ffe95a610b2f5c9462e91edafe4d82b9b1686fa484cR8) [[2]](diffhunk://#diff-00b00f82f1a783af27104ffe95a610b2f5c9462e91edafe4d82b9b1686fa484cR20-R22)

**Testing**
* Added comprehensive integration tests for the account deletion handler, covering authentication, input validation, service integration, and error scenarios. Mocked email service to prevent actual emails during testing. [[1]](diffhunk://#diff-0491d4dddc266751ec4eece9d81deabe25b4292d1fb8653924fda8964bf5a8e1L1-R8) [[2]](diffhunk://#diff-0491d4dddc266751ec4eece9d81deabe25b4292d1fb8653924fda8964bf5a8e1R282-R471)

These changes collectively provide a secure, user-friendly, and well-tested mechanism for users to delete their own accounts in compliance with privacy best practices.

-

## 🔍 Evidence/Media (screenshots/videos)

<img width="850" height="595" alt="Screenshot 2026-01-24 at 10 00 58" src="https://github.com/user-attachments/assets/b7ebcc61-8ad6-4378-9dc2-1388b8393bc6" />

-
