### PR TITLE
feat: implement PUT /wallets/:id/primary endpoint to set primary wallet

### DIFF
--- a/backend/src/__tests__/services/wallet.service.test.ts
+++ b/backend/src/__tests__/services/wallet.service.test.ts
@@ -2,7 +2,8 @@ import {
     disconnectWallet,
     getWalletById,
     getWalletsByUserId,
-    deleteWallet
+    deleteWallet,
+    setPrimaryWallet
 } from '@/services/wallet.service';
 import { supabase } from '@/lib/supabase/supabase';
 import { AppError } from '@/utils/AppError';
@@ -275,5 +276,242 @@ describe('WalletService - getWalletById', () => {
 
         const result = await getWalletById(mockWalletId);
         expect(result).toBeNull();
+    });
+});
+
+describe('WalletService - setPrimaryWallet', () => {
+    const mockUserId = '123e4567-e89b-12d3-a456-426614174000';
+    const mockWalletId = '456e7890-e89b-12d3-a456-426614174001';
+    const mockOtherUserId = '789e0123-e89b-12d3-a456-426614174002';
+
+    const mockWallet = {
+        id: mockWalletId,
+        user_id: mockUserId,
+        address: 'GEXTERNALWALLET123456789',
+        type: 'external' as const,
+        provider: 'freighter' as const,
+        is_primary: false,
+        created_at: '2024-01-15T10:00:00Z',
+    };
+
+    const mockUpdatedWallet = {
+        ...mockWallet,
+        is_primary: true,
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('Successful primary wallet update', () => {
+        it('should successfully set a wallet as primary', async () => {
+            // Mock getWalletById
+            mockSupabase.from.mockReturnValueOnce({
+                select: jest.fn().mockReturnValue({
+                    eq: jest.fn().mockReturnValue({
+                        single: jest.fn().mockResolvedValue({
+                            data: mockWallet,
+                            error: null,
+                        }),
+                    }),
+                }),
+            } as any);
+
+            // Mock reset all wallets to is_primary = false
+            mockSupabase.from.mockReturnValueOnce({
+                update: jest.fn().mockReturnValue({
+                    eq: jest.fn().mockResolvedValue({
+                        error: null,
+                    }),
+                }),
+            } as any);
+
+            // Mock set selected wallet to is_primary = true
+            mockSupabase.from.mockReturnValueOnce({
+                update: jest.fn().mockReturnValue({
+                    eq: jest.fn().mockReturnValue({
+                        select: jest.fn().mockReturnValue({
+                            single: jest.fn().mockResolvedValue({
+                                data: mockUpdatedWallet,
+                                error: null,
+                            }),
+                        }),
+                    }),
+                }),
+            } as any);
+
+            const result = await setPrimaryWallet(mockWalletId, mockUserId);
+            
+            expect(result).toEqual(mockUpdatedWallet);
+            expect(result.is_primary).toBe(true);
+        });
+
+        it('should atomically update all user wallets in transaction', async () => {
+            // Mock getWalletById
+            mockSupabase.from.mockReturnValueOnce({
+                select: jest.fn().mockReturnValue({
+                    eq: jest.fn().mockReturnValue({
+                        single: jest.fn().mockResolvedValue({
+                            data: mockWallet,
+                            error: null,
+                        }),
+                    }),
+                }),
+            } as any);
+
+            // Mock reset all wallets
+            const mockResetUpdate = jest.fn().mockReturnValue({
+                eq: jest.fn().mockResolvedValue({
+                    error: null,
+                }),
+            });
+            mockSupabase.from.mockReturnValueOnce({
+                update: mockResetUpdate,
+            } as any);
+
+            // Mock set selected wallet
+            mockSupabase.from.mockReturnValueOnce({
+                update: jest.fn().mockReturnValue({
+                    eq: jest.fn().mockReturnValue({
+                        select: jest.fn().mockReturnValue({
+                            single: jest.fn().mockResolvedValue({
+                                data: mockUpdatedWallet,
+                                error: null,
+                            }),
+                        }),
+                    }),
+                }),
+            } as any);
+
+            await setPrimaryWallet(mockWalletId, mockUserId);
+            
+            // Verify that reset was called with is_primary: false
+            expect(mockResetUpdate).toHaveBeenCalledWith({ is_primary: false });
+        });
+    });
+
+    describe('Wallet not found', () => {
+        it('should throw 404 when wallet does not exist', async () => {
+            mockSupabase.from.mockReturnValueOnce({
+                select: jest.fn().mockReturnValue({
+                    eq: jest.fn().mockReturnValue({
+                        single: jest.fn().mockResolvedValue({
+                            data: null,
+                            error: { code: 'PGRST116', message: 'No rows found' },
+                        }),
+                    }),
+                }),
+            } as any);
+
+            await expect(setPrimaryWallet(mockWalletId, mockUserId)).rejects.toThrow(
+                expect.objectContaining({
+                    message: 'Wallet not found',
+                    statusCode: 404,
+                    code: 'WALLET_NOT_FOUND',
+                })
+            );
+        });
+    });
+
+    describe('Ownership validation', () => {
+        it('should throw 403 when wallet belongs to another user', async () => {
+            const walletBelongingToOtherUser = {
+                ...mockWallet,
+                user_id: mockOtherUserId,
+            };
+
+            mockSupabase.from.mockReturnValueOnce({
+                select: jest.fn().mockReturnValue({
+                    eq: jest.fn().mockReturnValue({
+                        single: jest.fn().mockResolvedValue({
+                            data: walletBelongingToOtherUser,
+                            error: null,
+                        }),
+                    }),
+                }),
+            } as any);
+
+            await expect(setPrimaryWallet(mockWalletId, mockUserId)).rejects.toThrow(
+                expect.objectContaining({
+                    message: 'You do not have permission to modify this wallet',
+                    statusCode: 403,
+                    code: 'FORBIDDEN',
+                })
+            );
+        });
+    });
+
+    describe('Database transaction errors', () => {
+        it('should throw error when resetting primary wallets fails', async () => {
+            // Mock getWalletById
+            mockSupabase.from.mockReturnValueOnce({
+                select: jest.fn().mockReturnValue({
+                    eq: jest.fn().mockReturnValue({
+                        single: jest.fn().mockResolvedValue({
+                            data: mockWallet,
+                            error: null,
+                        }),
+                    }),
+                }),
+            } as any);
+
+            // Mock reset all wallets with error
+            mockSupabase.from.mockReturnValueOnce({
+                update: jest.fn().mockReturnValue({
+                    eq: jest.fn().mockResolvedValue({
+                        error: { message: 'Database connection failed' },
+                    }),
+                }),
+            } as any);
+
+            await expect(setPrimaryWallet(mockWalletId, mockUserId)).rejects.toThrow(
+                expect.objectContaining({
+                    message: expect.stringContaining('Failed to reset primary wallets'),
+                })
+            );
+        });
+
+        it('should throw error when setting primary wallet fails', async () => {
+            // Mock getWalletById
+            mockSupabase.from.mockReturnValueOnce({
+                select: jest.fn().mockReturnValue({
+                    eq: jest.fn().mockReturnValue({
+                        single: jest.fn().mockResolvedValue({
+                            data: mockWallet,
+                            error: null,
+                        }),
+                    }),
+                }),
+            } as any);
+
+            // Mock reset all wallets (success)
+            mockSupabase.from.mockReturnValueOnce({
+                update: jest.fn().mockReturnValue({
+                    eq: jest.fn().mockResolvedValue({
+                        error: null,
+                    }),
+                }),
+            } as any);
+
+            // Mock set selected wallet with error
+            mockSupabase.from.mockReturnValueOnce({
+                update: jest.fn().mockReturnValue({
+                    eq: jest.fn().mockReturnValue({
+                        select: jest.fn().mockReturnValue({
+                            single: jest.fn().mockResolvedValue({
+                                data: null,
+                                error: { message: 'Update failed' },
+                            }),
+                        }),
+                    }),
+                }),
+            } as any);
+
+            await expect(setPrimaryWallet(mockWalletId, mockUserId)).rejects.toThrow(
+                expect.objectContaining({
+                    message: expect.stringContaining('Failed to set primary wallet'),
+                })
+            );
+        });
     });
 });

--- a/backend/src/routes/wallet.routes.ts
+++ b/backend/src/routes/wallet.routes.ts
@@ -4,7 +4,11 @@
  */
 
 import { Router } from "express";
-import { connectExternalWalletHandler, disconnectWallet } from "@/controllers/wallet.controller";
+import { 
+  connectExternalWalletHandler, 
+  disconnectWallet,
+  setPrimaryWallet
+} from "@/controllers/wallet.controller";
 import { verifyToken } from "@/middlewares/auth.middleware";
 
 const router = Router();
@@ -21,6 +25,21 @@ const router = Router();
 router.post("/external", verifyToken, connectExternalWalletHandler);
 
 /**
+ * PUT /api/v1/wallets/:id/primary
+ * Set a wallet as the primary wallet for the authenticated user
+ * - Requires valid JWT authentication
+ * - Validates UUID format for :id parameter
+ * - Uses database transaction for atomicity
+ * - Sets is_primary = false on ALL user's wallets
+ * - Sets is_primary = true on the selected wallet
+ * - Returns 404 if wallet not found
+ * - Returns 403 if wallet belongs to another user
+ * - Returns 400 if invalid UUID format
+ * - Returns 200 with updated wallet data on success
+ */
+router.put("/:id/primary", verifyToken, setPrimaryWallet);
+
+/**
  * DELETE /api/v1/wallets/:id
  * Disconnect (remove) an external wallet from the authenticated user's account
  * - Requires valid JWT authentication
@@ -30,6 +49,6 @@ router.post("/external", verifyToken, connectExternalWalletHandler);
  * - Returns 403 if wallet belongs to another user
  * - Returns 400 if trying to delete invisible wallet or last wallet
  */
-router.delete("/:id", disconnectWallet);
+router.delete("/:id", verifyToken, disconnectWallet);
 
 export default router;


### PR DESCRIPTION


# 📝 Pull Request Title
PUT /wallets/:id/primary - Set Primary Wallet Endpoint
## 🛠️ Issue
938
- Closes #938 

## 📚 Description

-

## ✅ Changes applied

-- Add setPrimaryWallet service method with atomic transaction
- Add controller with JWT auth and UUID validation
- Add PUT /:id/primary route with authentication middleware
- Add comprehensive unit tests for setPrimaryWallet functionality
- Ensure only one primary wallet per user through atomic updates
- Return 200 OK on success, 401/403/404 on errors

## 🔍 Evidence/Media (screenshots/videos)

  
<img width="683" height="646" alt="Screenshot from 2026-01-24 16-06-13" src="https://github.com/user-attachments/assets/d4798b0a-003d-4bf0-9517-af4929f70482" />
<img width="580" height="502" alt="Screenshot from 2026-01-24 15-51-32" src="https://github.com/user-attachments/assets/9fc537eb-9fb0-4eca-a09d-82b3d75ec480" />

