### PR TITLE
feat: implement GET /balances/transactions endpoint with filtering an…

### DIFF
--- a/backend/src/__tests__/services/balance.service.test.ts
+++ b/backend/src/__tests__/services/balance.service.test.ts
@@ -1042,3 +1042,437 @@ describe('BalanceService - debitAvailable', () => {
     });
   });
 });
+
+describe('BalanceService - getTransactionHistory', () => {
+  const mockUserId = '123e4567-e89b-12d3-a456-426614174000';
+
+  const mockTransactions = [
+    {
+      id: 'tx-1',
+      user_id: mockUserId,
+      amount: 100,
+      currency: 'USD',
+      type: 'credit',
+      reference_id: 'ref-1',
+      reference_type: 'topup',
+      balance_before: 0,
+      balance_after: 100,
+      description: 'Top up',
+      created_at: '2024-01-15T10:30:00Z'
+    },
+    {
+      id: 'tx-2',
+      user_id: mockUserId,
+      amount: 50,
+      currency: 'USD',
+      type: 'debit',
+      reference_id: 'ref-2',
+      reference_type: 'withdrawal',
+      balance_before: 100,
+      balance_after: 50,
+      description: 'Withdrawal',
+      created_at: '2024-01-14T09:00:00Z'
+    }
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Success cases', () => {
+    it('should retrieve transaction history with no filters', async () => {
+      const mockQuery = {
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        order: jest.fn().mockReturnThis(),
+        range: jest.fn().mockResolvedValue({
+          data: mockTransactions,
+          error: null,
+          count: 2
+        })
+      };
+
+      (mockSupabase.from as jest.Mock).mockReturnValue(mockQuery);
+
+      const result = await balanceService.getTransactionHistory(mockUserId, {
+        page: 1,
+        limit: 20
+      });
+
+      expect(mockSupabase.from).toHaveBeenCalledWith('balance_transactions');
+      expect(mockQuery.select).toHaveBeenCalledWith('*', { count: 'exact' });
+      expect(mockQuery.eq).toHaveBeenCalledWith('user_id', mockUserId);
+      expect(mockQuery.order).toHaveBeenCalledWith('created_at', { ascending: false });
+      expect(mockQuery.range).toHaveBeenCalledWith(0, 19);
+
+      expect(result).toEqual({
+        transactions: mockTransactions,
+        pagination: {
+          page: 1,
+          limit: 20,
+          total: 2,
+          pages: 1
+        }
+      });
+    });
+
+    it('should filter by currency', async () => {
+      const mockQuery = {
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        order: jest.fn().mockReturnThis(),
+        range: jest.fn().mockResolvedValue({
+          data: [mockTransactions[0]],
+          error: null,
+          count: 1
+        })
+      };
+
+      (mockSupabase.from as jest.Mock).mockReturnValue(mockQuery);
+
+      const result = await balanceService.getTransactionHistory(mockUserId, {
+        currency: 'USD',
+        page: 1,
+        limit: 20
+      });
+
+      expect(mockQuery.eq).toHaveBeenCalledWith('user_id', mockUserId);
+      expect(mockQuery.eq).toHaveBeenCalledWith('currency', 'USD');
+      expect(result.transactions).toHaveLength(1);
+    });
+
+    it('should filter by transaction type', async () => {
+      const mockQuery = {
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        order: jest.fn().mockReturnThis(),
+        range: jest.fn().mockResolvedValue({
+          data: [mockTransactions[0]],
+          error: null,
+          count: 1
+        })
+      };
+
+      (mockSupabase.from as jest.Mock).mockReturnValue(mockQuery);
+
+      const result = await balanceService.getTransactionHistory(mockUserId, {
+        type: 'credit',
+        page: 1,
+        limit: 20
+      });
+
+      expect(mockQuery.eq).toHaveBeenCalledWith('type', 'credit');
+      expect(result.transactions).toHaveLength(1);
+    });
+
+    it('should filter by date range', async () => {
+      const mockQuery = {
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        gte: jest.fn().mockReturnThis(),
+        lt: jest.fn().mockReturnThis(),
+        order: jest.fn().mockReturnThis(),
+        range: jest.fn().mockResolvedValue({
+          data: mockTransactions,
+          error: null,
+          count: 2
+        })
+      };
+
+      (mockSupabase.from as jest.Mock).mockReturnValue(mockQuery);
+
+      const result = await balanceService.getTransactionHistory(mockUserId, {
+        from: '2024-01-01',
+        to: '2024-01-31',
+        page: 1,
+        limit: 20
+      });
+
+      expect(mockQuery.gte).toHaveBeenCalledWith('created_at', '2024-01-01');
+      expect(mockQuery.lt).toHaveBeenCalledWith('created_at', expect.any(String));
+      expect(result.transactions).toHaveLength(2);
+    });
+
+    it('should handle pagination correctly', async () => {
+      const mockQuery = {
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        order: jest.fn().mockReturnThis(),
+        range: jest.fn().mockResolvedValue({
+          data: [mockTransactions[1]],
+          error: null,
+          count: 10
+        })
+      };
+
+      (mockSupabase.from as jest.Mock).mockReturnValue(mockQuery);
+
+      const result = await balanceService.getTransactionHistory(mockUserId, {
+        page: 2,
+        limit: 5
+      });
+
+      expect(mockQuery.range).toHaveBeenCalledWith(5, 9);
+      expect(result.pagination).toEqual({
+        page: 2,
+        limit: 5,
+        total: 10,
+        pages: 2
+      });
+    });
+
+    it('should use default pagination values when not provided', async () => {
+      const mockQuery = {
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        order: jest.fn().mockReturnThis(),
+        range: jest.fn().mockResolvedValue({
+          data: mockTransactions,
+          error: null,
+          count: 2
+        })
+      };
+
+      (mockSupabase.from as jest.Mock).mockReturnValue(mockQuery);
+
+      const result = await balanceService.getTransactionHistory(mockUserId, {});
+
+      expect(mockQuery.range).toHaveBeenCalledWith(0, 19);
+      expect(result.pagination).toEqual({
+        page: 1,
+        limit: 20,
+        total: 2,
+        pages: 1
+      });
+    });
+
+    it('should return empty array when no transactions found', async () => {
+      const mockQuery = {
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        order: jest.fn().mockReturnThis(),
+        range: jest.fn().mockResolvedValue({
+          data: [],
+          error: null,
+          count: 0
+        })
+      };
+
+      (mockSupabase.from as jest.Mock).mockReturnValue(mockQuery);
+
+      const result = await balanceService.getTransactionHistory(mockUserId, {
+        page: 1,
+        limit: 20
+      });
+
+      expect(result.transactions).toEqual([]);
+      expect(result.pagination.total).toBe(0);
+    });
+  });
+
+  describe('Validation errors', () => {
+    it('should throw BadRequestError for invalid user ID', async () => {
+      await expect(
+        balanceService.getTransactionHistory('invalid-uuid', {})
+      ).rejects.toThrow(BadRequestError);
+    });
+
+    it('should throw ValidationError for unsupported currency', async () => {
+      await expect(
+        balanceService.getTransactionHistory(mockUserId, {
+          currency: 'EUR'
+        })
+      ).rejects.toThrow(ValidationError);
+    });
+
+    it('should throw ValidationError for unsupported transaction type', async () => {
+      await expect(
+        balanceService.getTransactionHistory(mockUserId, {
+          type: 'invalid' as any
+        })
+      ).rejects.toThrow(ValidationError);
+    });
+
+    it('should throw ValidationError when from date is after to date', async () => {
+      await expect(
+        balanceService.getTransactionHistory(mockUserId, {
+          from: '2024-01-31',
+          to: '2024-01-01'
+        })
+      ).rejects.toThrow(ValidationError);
+    });
+
+    it('should throw ValidationError for invalid from date', async () => {
+      await expect(
+        balanceService.getTransactionHistory(mockUserId, {
+          from: 'invalid-date'
+        })
+      ).rejects.toThrow(ValidationError);
+    });
+
+    it('should throw ValidationError for invalid to date', async () => {
+      await expect(
+        balanceService.getTransactionHistory(mockUserId, {
+          to: 'invalid-date'
+        })
+      ).rejects.toThrow(ValidationError);
+    });
+
+    it('should throw ValidationError for page less than 1', async () => {
+      await expect(
+        balanceService.getTransactionHistory(mockUserId, {
+          page: 0
+        })
+      ).rejects.toThrow(ValidationError);
+    });
+
+    it('should throw ValidationError for limit less than 1', async () => {
+      await expect(
+        balanceService.getTransactionHistory(mockUserId, {
+          limit: 0
+        })
+      ).rejects.toThrow(ValidationError);
+    });
+
+    it('should throw ValidationError for limit greater than 100', async () => {
+      await expect(
+        balanceService.getTransactionHistory(mockUserId, {
+          limit: 101
+        })
+      ).rejects.toThrow(ValidationError);
+    });
+  });
+
+  describe('Database errors', () => {
+    it('should throw InternalServerError on database error', async () => {
+      const mockQuery = {
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        order: jest.fn().mockReturnThis(),
+        range: jest.fn().mockResolvedValue({
+          data: null,
+          error: { message: 'Database connection failed' },
+          count: null
+        })
+      };
+
+      (mockSupabase.from as jest.Mock).mockReturnValue(mockQuery);
+
+      await expect(
+        balanceService.getTransactionHistory(mockUserId, {
+          page: 1,
+          limit: 20
+        })
+      ).rejects.toThrow(InternalServerError);
+
+      expect(mockLogger.error).toHaveBeenCalled();
+    });
+
+    it('should handle null count gracefully', async () => {
+      const mockQuery = {
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        order: jest.fn().mockReturnThis(),
+        range: jest.fn().mockResolvedValue({
+          data: mockTransactions,
+          error: null,
+          count: null
+        })
+      };
+
+      (mockSupabase.from as jest.Mock).mockReturnValue(mockQuery);
+
+      const result = await balanceService.getTransactionHistory(mockUserId, {
+        page: 1,
+        limit: 20
+      });
+
+      expect(result.pagination.total).toBe(0);
+      expect(result.pagination.pages).toBe(0);
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('should handle all transaction types', async () => {
+      const allTypes = ['credit', 'debit', 'hold', 'release', 'settle_in', 'settle_out'];
+
+      for (const type of allTypes) {
+        const mockQuery = {
+          select: jest.fn().mockReturnThis(),
+          eq: jest.fn().mockReturnThis(),
+          order: jest.fn().mockReturnThis(),
+          range: jest.fn().mockResolvedValue({
+            data: [],
+            error: null,
+            count: 0
+          })
+        };
+
+        (mockSupabase.from as jest.Mock).mockReturnValue(mockQuery);
+
+        await expect(
+          balanceService.getTransactionHistory(mockUserId, {
+            type: type as any
+          })
+        ).resolves.not.toThrow();
+      }
+    });
+
+    it('should handle all supported currencies', async () => {
+      const currencies = ['USD', 'XLM'];
+
+      for (const currency of currencies) {
+        const mockQuery = {
+          select: jest.fn().mockReturnThis(),
+          eq: jest.fn().mockReturnThis(),
+          order: jest.fn().mockReturnThis(),
+          range: jest.fn().mockResolvedValue({
+            data: [],
+            error: null,
+            count: 0
+          })
+        };
+
+        (mockSupabase.from as jest.Mock).mockReturnValue(mockQuery);
+
+        await expect(
+          balanceService.getTransactionHistory(mockUserId, {
+            currency
+          })
+        ).resolves.not.toThrow();
+      }
+    });
+
+    it('should handle combined filters', async () => {
+      const mockQuery = {
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        gte: jest.fn().mockReturnThis(),
+        lt: jest.fn().mockReturnThis(),
+        order: jest.fn().mockReturnThis(),
+        range: jest.fn().mockResolvedValue({
+          data: [],
+          error: null,
+          count: 0
+        })
+      };
+
+      (mockSupabase.from as jest.Mock).mockReturnValue(mockQuery);
+
+      const result = await balanceService.getTransactionHistory(mockUserId, {
+        currency: 'USD',
+        type: 'credit',
+        from: '2024-01-01',
+        to: '2024-01-31',
+        page: 2,
+        limit: 10
+      });
+
+      expect(mockQuery.eq).toHaveBeenCalledWith('currency', 'USD');
+      expect(mockQuery.eq).toHaveBeenCalledWith('type', 'credit');
+      expect(mockQuery.gte).toHaveBeenCalled();
+      expect(mockQuery.lt).toHaveBeenCalled();
+      expect(mockQuery.range).toHaveBeenCalledWith(10, 19);
+    });
+  });
+});

--- a/backend/src/controllers/balance.controller.ts
+++ b/backend/src/controllers/balance.controller.ts
@@ -7,8 +7,9 @@ import { Request, Response, NextFunction } from "express";
 import { AuthenticatedRequest } from "@/types/auth.types";
 import { balanceService } from "@/services/balance.service";
 import { ValidationError, BadRequestError } from "@/utils/AppError";
-import { buildListResponse } from "@/utils/responseBuilder";
-import { SUPPORTED_CURRENCIES } from "@/types/balance.types";
+import { buildListResponse, buildPaginatedResponse } from "@/utils/responseBuilder";
+import { SUPPORTED_CURRENCIES, TRANSACTION_TYPES, TransactionType } from "@/types/balance.types";
+import { validateIntegerRange } from "@/utils/validation";
 
 /**
  * GET /api/v1/balances
@@ -60,6 +61,101 @@ export const getBalances = async (
     return res.status(200).json(
       buildListResponse(balances, "Balances retrieved successfully")
     );
+  } catch (error: any) {
+    next(error);
+  }
+};
+
+/**
+ * GET /api/v1/balances/transactions
+ * Retrieve authenticated user's balance transaction history
+ * 
+ * Query Parameters:
+ * - currency (optional): Filter by currency (USD, XLM)
+ * - type (optional): Filter by transaction type (credit, debit, hold, release, settle_in, settle_out)
+ * - from (optional): Start date filter (YYYY-MM-DD)
+ * - to (optional): End date filter (YYYY-MM-DD)
+ * - page (optional): Page number (default: 1)
+ * - limit (optional): Items per page (default: 20, max: 100)
+ * 
+ * Returns:
+ * - 200 OK: Paginated transaction history
+ * - 400 Bad Request: Invalid parameters
+ * - 401 Unauthorized: Missing or invalid JWT token (handled by middleware)
+ */
+export const getTransactionHistory = async (
+  req: AuthenticatedRequest,
+  res: Response,
+  next: NextFunction
+) => {
+  try {
+    // Guard check: ensure user is authenticated
+    if (!req.user) {
+      throw new BadRequestError("Authentication required");
+    }
+
+    const userId = req.user.id;
+
+    // Extract and parse query parameters
+    const currency = req.query.currency as string | undefined;
+    const type = req.query.type as string | undefined;
+    const from = req.query.from as string | undefined;
+    const to = req.query.to as string | undefined;
+    const page = req.query.page ? parseInt(req.query.page as string, 10) : 1;
+    const limit = req.query.limit ? parseInt(req.query.limit as string, 10) : 20;
+
+    // Validate currency if provided
+    if (currency && !SUPPORTED_CURRENCIES.includes(currency as any)) {
+      throw new ValidationError(
+        `Invalid currency: ${currency}. Supported currencies: ${SUPPORTED_CURRENCIES.join(', ')}`
+      );
+    }
+
+    // Validate transaction type if provided
+    if (type && !TRANSACTION_TYPES.includes(type as TransactionType)) {
+      throw new ValidationError(
+        `Invalid transaction type: ${type}. Supported types: ${TRANSACTION_TYPES.join(', ')}`
+      );
+    }
+
+    // Validate pagination parameters
+    if (!validateIntegerRange(page, 1, 1000)) {
+      throw new ValidationError("Page number must be between 1 and 1000");
+    }
+
+    if (!validateIntegerRange(limit, 1, 100)) {
+      throw new ValidationError("Limit must be between 1 and 100");
+    }
+
+    // Call service
+    const result = await balanceService.getTransactionHistory(userId, {
+      currency,
+      type: type as TransactionType | undefined,
+      from,
+      to,
+      page,
+      limit
+    });
+
+    // Format transactions for response
+    const formattedTransactions = result.transactions.map((tx) => ({
+      id: tx.id,
+      type: tx.type,
+      amount: Number(tx.amount).toFixed(2),
+      currency: tx.currency,
+      reference_type: tx.reference_type,
+      reference_id: tx.reference_id,
+      balance_after: Number(tx.balance_after).toFixed(2),
+      created_at: tx.created_at
+    }));
+
+    return res.status(200).json({
+      success: true,
+      data: {
+        transactions: formattedTransactions,
+        pagination: result.pagination
+      }
+    });
   } catch (error: any) {
     next(error);
   }

--- a/backend/src/routes/balance.routes.ts
+++ b/backend/src/routes/balance.routes.ts
@@ -4,7 +4,7 @@
  */
 
 import { Router } from "express";
-import { getBalances } from "@/controllers/balance.controller";
+import { getBalances, getTransactionHistory } from "@/controllers/balance.controller";
 import { authenticateToken } from "@/middlewares/auth.middleware";
 
 const router = Router();
@@ -24,5 +24,26 @@ const router = Router();
  * - 401 Unauthorized: Missing or invalid JWT token
  */
 router.get("/", authenticateToken(), getBalances);
+
+/**
+ * GET /api/v1/balances/transactions
+ * Retrieve authenticated user's balance transaction history with filtering and pagination
+ * 
+ * Query Parameters:
+ * - currency (optional): Filter by currency (USD, XLM)
+ * - type (optional): Filter by transaction type (credit, debit, hold, release, settle_in, settle_out)
+ * - from (optional): Start date filter (YYYY-MM-DD)
+ * - to (optional): End date filter (YYYY-MM-DD)
+ * - page (optional): Page number (default: 1)
+ * - limit (optional): Items per page (default: 20, max: 100)
+ * 
+ * Authentication: Required (JWT)
+ * 
+ * Returns:
+ * - 200 OK: Paginated transaction history
+ * - 400 Bad Request: Invalid parameters
+ * - 401 Unauthorized: Missing or invalid JWT token
+ */
+router.get("/transactions", authenticateToken(), getTransactionHistory);
 
 export default router;

--- a/backend/src/services/balance.service.ts
+++ b/backend/src/services/balance.service.ts
@@ -16,7 +16,11 @@ import {
   Currency, 
   CreditReference,
   DebitReference,
-  SUPPORTED_CURRENCIES 
+  SUPPORTED_CURRENCIES,
+  TransactionFilters,
+  TransactionHistoryResult,
+  TRANSACTION_TYPES,
+  TransactionType
 } from "../types/balance.types";
 import { logger } from "../utils/logger"; 
 
@@ -361,6 +365,148 @@ export class BalanceService {
         err instanceof BadRequestError || 
         err instanceof InternalServerError ||
         err instanceof InsufficientFundsError
+      ) {
+        throw err;
+      }
+      throw new InternalServerError(`Unexpected error in balance service: ${err.message}`);
+    }
+  }
+
+  /**
+   * Retrieves transaction history for a user with filtering and pagination.
+   * @param userId - The user ID to get transaction history for
+   * @param filters - Filter and pagination options
+   * @returns Transaction history with pagination info
+   */
+  async getTransactionHistory(
+    userId: string,
+    filters: TransactionFilters
+  ): Promise<TransactionHistoryResult> {
+    const correlationId = crypto.randomUUID();
+    
+    try {
+      logger.info(
+        `[BalanceService] Starting getTransactionHistory ${correlationId} - User: ${userId}, Filters: ${JSON.stringify(filters)}`
+      );
+
+      // 1. Validation
+      if (!validateUUID(userId)) {
+        throw new BadRequestError("Invalid user ID format");
+      }
+
+      // Validate currency if provided
+      if (filters.currency && !SUPPORTED_CURRENCIES.includes(filters.currency as Currency)) {
+        throw new ValidationError(`Currency ${filters.currency} is not supported. Supported currencies: ${SUPPORTED_CURRENCIES.join(', ')}`);
+      }
+
+      // Validate transaction type if provided
+      if (filters.type && !TRANSACTION_TYPES.includes(filters.type as TransactionType)) {
+        throw new ValidationError(`Transaction type ${filters.type} is not supported. Supported types: ${TRANSACTION_TYPES.join(', ')}`);
+      }
+
+      // Validate date range
+      if (filters.from && filters.to) {
+        const fromDate = new Date(filters.from);
+        const toDate = new Date(filters.to);
+        
+        if (isNaN(fromDate.getTime())) {
+          throw new ValidationError('Invalid from date format');
+        }
+        
+        if (isNaN(toDate.getTime())) {
+          throw new ValidationError('Invalid to date format');
+        }
+        
+        if (fromDate > toDate) {
+          throw new ValidationError('from date must be before or equal to to date');
+        }
+      } else if (filters.from) {
+        const fromDate = new Date(filters.from);
+        if (isNaN(fromDate.getTime())) {
+          throw new ValidationError('Invalid from date format');
+        }
+      } else if (filters.to) {
+        const toDate = new Date(filters.to);
+        if (isNaN(toDate.getTime())) {
+          throw new ValidationError('Invalid to date format');
+        }
+      }
+
+      // Validate pagination
+      const page = filters.page !== undefined ? filters.page : 1;
+      const limit = filters.limit !== undefined ? filters.limit : 20;
+
+      if (page < 1) {
+        throw new ValidationError('Page must be greater than 0');
+      }
+
+      if (limit < 1 || limit > 100) {
+        throw new ValidationError('Limit must be between 1 and 100');
+      }
+
+      // 2. Build query
+      let query = supabase
+        .from('balance_transactions')
+        .select('*', { count: 'exact' })
+        .eq('user_id', userId);
+
+      // Apply filters
+      if (filters.currency) {
+        query = query.eq('currency', filters.currency);
+      }
+
+      if (filters.type) {
+        query = query.eq('type', filters.type);
+      }
+
+      if (filters.from) {
+        query = query.gte('created_at', filters.from);
+      }
+
+      if (filters.to) {
+        // Add one day to include the entire 'to' date
+        const toDate = new Date(filters.to);
+        toDate.setDate(toDate.getDate() + 1);
+        query = query.lt('created_at', toDate.toISOString());
+      }
+
+      // Apply ordering (newest first)
+      query = query.order('created_at', { ascending: false });
+
+      // Apply pagination
+      const offset = (page - 1) * limit;
+      query = query.range(offset, offset + limit - 1);
+
+      // 3. Execute query
+      const { data, error, count } = await query;
+
+      if (error) {
+        logger.error(`[BalanceService] Database Error ${correlationId}`, error);
+        throw new InternalServerError(`Failed to retrieve transaction history: ${error.message}`);
+      }
+
+      const total = count || 0;
+      const pages = Math.ceil(total / limit);
+
+      logger.info(
+        `[BalanceService] Success ${correlationId} - Found ${data?.length || 0} transactions (Total: ${total})`
+      );
+
+      return {
+        transactions: data || [],
+        pagination: {
+          page,
+          limit,
+          total,
+          pages
+        }
+      };
+
+    } catch (err: any) {
+      if (
+        err instanceof ValidationError || 
+        err instanceof BadRequestError || 
+        err instanceof InternalServerError
       ) {
         throw err;
       }

--- a/backend/src/types/balance.types.ts
+++ b/backend/src/types/balance.types.ts
@@ -39,3 +39,26 @@ export interface BalanceTransaction {
   description?: string;
   created_at: string;
 }
+
+export type TransactionType = 'credit' | 'debit' | 'hold' | 'release' | 'settle_in' | 'settle_out';
+
+export const TRANSACTION_TYPES: TransactionType[] = ['credit', 'debit', 'hold', 'release', 'settle_in', 'settle_out'];
+
+export interface TransactionFilters {
+  currency?: string;
+  type?: TransactionType;
+  from?: string; // ISO date string
+  to?: string; // ISO date string
+  page?: number;
+  limit?: number;
+}
+
+export interface TransactionHistoryResult {
+  transactions: BalanceTransaction[];
+  pagination: {
+    page: number;
+    limit: number;
+    total: number;
+    pages: number;
+  };
+}


### PR DESCRIPTION


# 📝 Pull Request Title
Added GET /balances/transactions - Transaction History Endpoint
## 🛠️ Issue
Closes Issues #956 
- Closes #issue956

## 📚 Description

--- Add getTransactionHistory method to BalanceService with full filtering support

## ✅ Changes applied


- Implement controller handler with parameter validation
- Add route for /balances/transactions endpoint with JWT auth
- Support filters: currency, type, date range (from/to)
- Implement pagination with defaults (page: 1, limit: 20, max: 100)
- Order transactions by created_at DESC (newest first)
- Add comprehensive unit tests with >80% coverage (78 tests passing)
- Validate all query parameters with proper error handling
- Return formatted response with transaction data and pagination info


## 🔍 Evidence/Media (screenshots/videos)
<img width="810" height="550" alt="Screenshot from 2026-01-25 17-35-09" src="https://github.com/user-attachments/assets/3c4f41aa-486f-4381-80fa-ae177bd54092" />

-
