### PR TITLE
Feat: revoke specific session endpoint

### DIFF
--- a/backend/src/routes/auth.routes.ts
+++ b/backend/src/routes/auth.routes.ts
@@ -15,7 +15,7 @@ import {
   registerWithWallet,
   loginWithEmail,
   getSessions,
-  deactivateSession,
+  revokeSession,
   forgotPassword,
   resetPassword,
 } from "@/controllers/auth.controller";
@@ -50,6 +50,8 @@ router.post("/reset-password", authLimiter, resetPassword);
 // User routes
 router.get("/me", authenticateToken(), me);
 router.get("/sessions", authenticateToken(), getSessions);
-router.delete("/sessions/:sessionId", authenticateToken(), deactivateSession);
+
+// Revoke Session Route
+router.delete("/sessions/:id", authenticateToken(), revokeSession);
 
 export default router;


### PR DESCRIPTION
# 📝 Feature: Revoke Specific Session Endpoint

## 🛠️ Issue

- Closes #963

## 📚 Description

Implemented the `DELETE /auth/sessions/:id` endpoint which allows authenticated users to revoke specific active sessions (e.g., logging out a remote device).

This implements `revokeSession` workflow. It shifts from implicit database checks to explicit logic in the application layer to ensure proper security boundaries and meaningful error messages (distinguishing between "Session not found" and "Forbidden").

## ✅ Changes applied

- **Service (`src/services/auth.service.ts`):**
  - added `revokeSession`.
  - Added specific validation to prevent users from revoking their *current* active session (returns 400).
  - Added ownership checks to ensure users can only revoke their own sessions (returns 403).
  - Added existence checks to return 404 if the session ID doesn't exist.
- **Controller (`src/controllers/auth.controller.ts`):**
  - Added UUID format validation for the `:id` parameter to prevent invalid database queries.
  - Linked the controller to the new service logic and standardized the JSON response format.
- **Routes (`src/routes/auth.routes.ts`):**
  - Updated the route definition to standard RESTful syntax: `DELETE /sessions/:id`.
  - Linked the route to the updated `revokeSession` controller.


