### PR TITLE
POST /auth/logout - Logout Current Session Endpoint

### DIFF
--- a/backend/src/__tests__/auth.v1.logout.test.ts
+++ b/backend/src/__tests__/auth.v1.logout.test.ts
@@ -1,0 +1,85 @@
+import request from "supertest";
+import express from "express";
+import cookieParser from "cookie-parser";
+
+jest.mock("@/middlewares/auth.middleware", () => {
+  const { AppError } = require("@/utils/AppError");
+
+  return {
+    authenticateToken: () => (req: any, _res: any, next: any) => {
+      const auth = req.headers.authorization;
+      if (!auth) {
+        return next(new AppError("Authentication required", 401));
+      }
+      req.user = { id: "user-123" };
+      next();
+    },
+  };
+});
+
+jest.mock("@/services/auth.service", () => ({
+  logoutAllUserSessions: jest.fn(),
+  logoutCurrentSession: jest.fn(),
+}));
+
+import authV1Routes from "@/routes/auth.v1.routes";
+import { errorHandlerMiddleware } from "@/middlewares/errorHandler.middleware";
+import * as authService from "@/services/auth.service";
+
+const app = express();
+app.use(cookieParser());
+app.use(express.json());
+app.use("/api/v1/auth", authV1Routes);
+app.use(errorHandlerMiddleware);
+
+describe("POST /api/v1/auth/logout", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns 401 if unauthorized", async () => {
+    const res = await request(app).post("/api/v1/auth/logout").send({});
+
+    expect(res.status).toBe(401);
+  });
+
+  it("revokes the current refresh token and returns 200", async () => {
+    (authService.logoutCurrentSession as jest.Mock).mockResolvedValue(undefined);
+
+    const res = await request(app)
+      .post("/api/v1/auth/logout")
+      .set("Authorization", "Bearer test")
+      .set("Cookie", ["refreshToken=refresh-token-value"])
+      .send({});
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      success: true,
+      message: "Logged out successfully",
+    });
+
+    expect(authService.logoutCurrentSession).toHaveBeenCalledWith(
+      "user-123",
+      expect.objectContaining({
+        refreshToken: "refresh-token-value",
+      }),
+    );
+  });
+
+  it("revokes all sessions when logout_all=true", async () => {
+    (authService.logoutAllUserSessions as jest.Mock).mockResolvedValue(undefined);
+
+    const res = await request(app)
+      .post("/api/v1/auth/logout")
+      .set("Authorization", "Bearer test")
+      .send({ logout_all: true });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      success: true,
+      message: "Logged out successfully",
+    });
+
+    expect(authService.logoutAllUserSessions).toHaveBeenCalledWith("user-123");
+  });
+});

--- a/backend/src/controllers/auth.controller.ts
+++ b/backend/src/controllers/auth.controller.ts
@@ -37,6 +37,33 @@ export async function getNonce(
   }
 }
 
+export async function logoutV1(req: Request, res: Response, next: NextFunction) {
+  try {
+    const logout_all = Boolean(req.body?.logout_all);
+    const userId = req.user.id;
+    const ip = req.ip || req.connection.remoteAddress || "unknown";
+    const userAgent = req.get("User-Agent") || "unknown";
+    const refreshToken = (req as any).cookies?.refreshToken as string | undefined;
+
+    if (logout_all) {
+      await authService.logoutAllUserSessions(userId);
+    } else {
+      await authService.logoutCurrentSession(userId, {
+        refreshToken,
+        ip,
+        userAgent,
+      });
+    }
+
+    res.status(200).json({
+      success: true,
+      message: "Logged out successfully",
+    });
+  } catch (err) {
+    next(err);
+  }
+}
+
 /**
  * Register a new user with email and password
  * Creates a smart wallet (contract account) for the user

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -27,6 +27,7 @@ import cors from "cors";
 import cookieParser from "cookie-parser";
 import userRoutes from "@/routes/user.routes";
 import authRoutes from "@/routes/auth.routes";
+import authV1Routes from "@/routes/auth.v1.routes";
 import oauthRoutes from "@/routes/oauth.routes";
 import escrowInitRoutes from "@/routes/escrow-init.routes";
 import escrowBalanceRoutes from "@/routes/escrow-balance.routes";
@@ -101,6 +102,7 @@ app.get("/", (_req, res) => {
 
 // API Routes
 app.use("/api/auth", authLimiter, authRoutes);
+app.use("/api/v1/auth", authV1Routes);
 app.use("/api/oauth", oauthRoutes);
 app.use("/api/escrows", authenticateToken(), escrowInitRoutes);
 app.use("/api/escrows", authenticateToken(), escrowBalanceRoutes);

--- a/backend/src/routes/auth.v1.routes.ts
+++ b/backend/src/routes/auth.v1.routes.ts
@@ -1,0 +1,9 @@
+import { Router } from "express";
+import { logoutV1 } from "@/controllers/auth.controller";
+import { authenticateToken } from "@/middlewares/auth.middleware";
+
+const router = Router();
+
+router.post("/logout", authenticateToken(), logoutV1);
+
+export default router;


### PR DESCRIPTION
# 📝 Pull Request Title
**POST /auth/logout - Logout Current Session Endpoint #965**

## 🛠️ Issue
- Closes #965

## 📚 Description
- Implemented a new versioned logout endpoint `POST /api/v1/auth/logout` protected by JWT authentication.
- The endpoint revokes the user’s current refresh token (idempotent), and supports `logout_all=true` to revoke all active refresh tokens for the user.
- Added unit tests to validate unauthorized behavior and successful logout flows.

## ✅ Changes applied
- Added `POST /api/v1/auth/logout` route under `/api/v1/auth` with [authenticateToken()](cci:1://file:///c:/Users/RAMPOP/Desktop/offer-hub-monorepo/backend/src/__tests__/wallet.test.ts:10:4-13:5) protection.
- Added [logoutV1](cci:1://file:///c:/Users/RAMPOP/Desktop/offer-hub-monorepo/backend/src/controllers/auth.controller.ts:39:0-64:1) controller to handle `logout_all` and session revocation and return `{ success: true, message: "Logged out successfully" }`.
- Added [logoutAllUserSessions](cci:1://file:///c:/Users/RAMPOP/Desktop/offer-hub-monorepo/backend/src/services/auth.service.ts:854:0-867:1) and [logoutCurrentSession](cci:1://file:///c:/Users/RAMPOP/Desktop/offer-hub-monorepo/backend/src/services/auth.service.ts:869:0-951:1) service functions to revoke refresh tokens (idempotent).
- Added unit tests: [src/__tests__/auth.v1.logout.test.ts](cci:7://file:///c:/Users/RAMPOP/Desktop/offer-hub-monorepo/backend/src/__tests__/auth.v1.logout.test.ts:0:0-0:0) (verifies 401, logout current session, logout all sessions).



## 🔍 Evidence/Media (screenshots/videos)

-
<img width="1191" height="581" alt="hub-test" src="https://github.com/user-attachments/assets/c35ad12f-cc12-4479-8bd6-f43734a5a4b9" />

