### PR TITLE
feat(docs): add client-side Export as PDF action for docs pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "framer-motion": "^12.34.1",
         "fuse.js": "^7.1.0",
         "gray-matter": "^4.0.3",
+        "html2pdf.js": "^0.14.0",
         "lucide-react": "^0.574.0",
         "next": "^15.1.0",
         "next-mdx-remote": "^6.0.0",
@@ -60,6 +61,15 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1188,6 +1198,19 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/react": {
       "version": "19.2.13",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.13.tgz",
@@ -1206,6 +1229,13 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -2116,6 +2146,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.19",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
@@ -2284,6 +2323,26 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/ccount": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
@@ -2449,6 +2508,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/core-js": {
+      "version": "3.48.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.48.0.tgz",
+      "integrity": "sha512-zpEHTy1fjTMZCKLHUZoVeylt9XrzaIN2rbPXEt0k+q7JE5CkCZdo6bNq55bn24a69CH7ErAVLKijxJja4fw+UQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2462,6 +2533,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/cssesc": {
@@ -2671,6 +2751,15 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
+      "integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dunder-proto": {
@@ -3532,6 +3621,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-png": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
+      "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pako": "^2.0.3",
+        "iobuffer": "^5.3.2",
+        "pako": "^2.1.0"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -3540,6 +3640,12 @@
       "dependencies": {
         "reusify": "^1.0.4"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -4057,6 +4163,30 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/html2pdf.js": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/html2pdf.js/-/html2pdf.js-0.14.0.tgz",
+      "integrity": "sha512-yvNJgE/8yru2UeGflkPdjW8YEY+nDH5X7/2WG4uiuSCwYiCp8PZ8EKNiTAa6HxJ1NjC51fZSIEq6xld5CADKBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "dompurify": "^3.3.1",
+        "html2canvas": "^1.0.0",
+        "jspdf": "^4.0.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -4114,6 +4244,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/iobuffer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
+      "license": "MIT"
     },
     "node_modules/is-alphabetical": {
       "version": "2.0.1",
@@ -4682,6 +4818,23 @@
       },
       "bin": {
         "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/jspdf": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.0.tgz",
+      "integrity": "sha512-hR/hnRevAXXlrjeqU5oahOE+Ln9ORJUB5brLHHqH67A+RBQZuFr5GkbI9XQI8OUFSEezKegsi45QRpc4bGj75Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "fast-png": "^6.2.0",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.11",
+        "core-js": "^3.6.0",
+        "dompurify": "^3.3.1",
+        "html2canvas": "^1.0.0-rc.5"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -6049,6 +6202,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -6112,6 +6271,13 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "license": "MIT"
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -6377,6 +6543,16 @@
       ],
       "license": "MIT"
     },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "node_modules/react": {
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
@@ -6516,6 +6692,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
@@ -6647,6 +6830,16 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
       }
     },
     "node_modules/run-parallel": {
@@ -6993,6 +7186,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
@@ -7254,6 +7457,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "3.4.19",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
@@ -7317,6 +7530,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/thenify": {
@@ -7782,6 +8004,15 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
+      }
     },
     "node_modules/vfile": {
       "version": "6.0.3",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "framer-motion": "^12.34.1",
     "fuse.js": "^7.1.0",
     "gray-matter": "^4.0.3",
+    "html2pdf.js": "^0.14.0",
     "lucide-react": "^0.574.0",
     "next": "^15.1.0",
     "next-mdx-remote": "^6.0.0",

--- a/src/app/docs/[...slug]/page.tsx
+++ b/src/app/docs/[...slug]/page.tsx
@@ -4,6 +4,7 @@ import { MDXRemote } from "next-mdx-remote/rsc";
 import { getAllDocSlugs, getDocBySlug, extractHeadings } from "@/lib/mdx";
 import { MDX_COMPONENTS } from "@/components/docs/mdx-components";
 import { TableOfContents } from "@/components/docs/TableOfContents";
+import { DocPageActions } from "@/components/docs/DocPageActions";
 
 interface PageProps {
   params: Promise<{ slug: string[] }>;
@@ -39,18 +40,30 @@ export default async function DocPage({ params }: PageProps) {
       <article className="flex-1 min-w-0">
         {/* Page header */}
         <div className="mb-8 pb-6 border-b" style={{ borderColor: "#d1d5db" }}>
-          <h1 className="text-3xl font-bold mb-2" style={{ color: "#19213D" }}>
-            {doc.frontmatter.title}
-          </h1>
-          {doc.frontmatter.description && (
-            <p className="text-base leading-relaxed" style={{ color: "#6D758F" }}>
-              {doc.frontmatter.description}
-            </p>
-          )}
+          <div className="flex flex-col lg:flex-row lg:items-end lg:justify-between gap-4">
+            <div>
+              <h1 className="text-3xl font-bold mb-2" style={{ color: "#19213D" }}>
+                {doc.frontmatter.title}
+              </h1>
+              {doc.frontmatter.description && (
+                <p className="text-base leading-relaxed" style={{ color: "#6D758F" }}>
+                  {doc.frontmatter.description}
+                </p>
+              )}
+            </div>
+
+            <DocPageActions
+              slug={doc.slug}
+              title={doc.frontmatter.title}
+              description={doc.frontmatter.description}
+              markdownContent={doc.content}
+              frontmatter={doc.frontmatter}
+            />
+          </div>
         </div>
 
         {/* MDX content */}
-        <div className="max-w-none">
+        <div className="max-w-none" id="doc-page-export-content">
           <MDXRemote source={doc.content} components={MDX_COMPONENTS} />
         </div>
       </article>

--- a/src/components/docs/DocPageActions.tsx
+++ b/src/components/docs/DocPageActions.tsx
@@ -1,0 +1,248 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Download, FileCode2, FileJson, FileText, Github } from "lucide-react";
+
+import type { DocFrontmatter } from "@/lib/mdx";
+
+interface DocPageActionsProps {
+  slug: string;
+  title: string;
+  description?: string;
+  markdownContent: string;
+  frontmatter: DocFrontmatter;
+}
+
+const DOCS_REPO_BASE = "https://github.com/OFFER-HUB/offer-hub-monorepo/blob/main/content/docs";
+
+function dateStamp() {
+  return new Date().toISOString().split("T")[0];
+}
+
+function downloadBlob(filename: string, content: string, mimeType: string) {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+}
+
+export function DocPageActions({ slug, title, description, markdownContent, frontmatter }: DocPageActionsProps) {
+  const [isExportingPdf, setIsExportingPdf] = useState(false);
+
+  const markdownFileName = useMemo(() => `${slug.replace(/\//g, "-")}-${dateStamp()}.md`, [slug]);
+  const jsonFileName = useMemo(() => `${slug.replace(/\//g, "-")}-${dateStamp()}.json`, [slug]);
+  const pdfFileName = useMemo(() => `${slug.replace(/\//g, "-")}-${dateStamp()}.pdf`, [slug]);
+
+  function handleExportMarkdown() {
+    downloadBlob(markdownFileName, markdownContent, "text/markdown;charset=utf-8");
+  }
+
+  function handleExportJson() {
+    const payload = {
+      slug,
+      title,
+      description,
+      frontmatter,
+      content: markdownContent,
+      exportedAt: new Date().toISOString(),
+    };
+
+    downloadBlob(jsonFileName, JSON.stringify(payload, null, 2), "application/json;charset=utf-8");
+  }
+
+  async function handleExportPdf() {
+    setIsExportingPdf(true);
+
+    try {
+      const html2pdfModule = await import("html2pdf.js");
+      const html2pdf = html2pdfModule.default;
+      const source = document.getElementById("doc-page-export-content");
+
+      if (!source) {
+        throw new Error("Could not find docs content container.");
+      }
+
+      const exportContainer = document.createElement("section");
+      exportContainer.setAttribute("data-doc-pdf-root", "true");
+      exportContainer.style.position = "fixed";
+      exportContainer.style.left = "-100000px";
+      exportContainer.style.top = "0";
+      exportContainer.style.width = "850px";
+      exportContainer.style.background = "#ffffff";
+      exportContainer.style.padding = "28px 34px";
+      exportContainer.style.fontFamily = "Inter, Roboto, Arial, sans-serif";
+      exportContainer.style.color = "#6D758F";
+
+      const logo = `${window.location.origin}/OFFER-HUB-logo.png`;
+      const printableDate = new Date().toLocaleDateString("en-CA", {
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+      });
+
+      exportContainer.innerHTML = `
+        <header style="display:flex;align-items:center;justify-content:space-between;gap:20px;padding-bottom:18px;border-bottom:1px solid #e5e7eb;margin-bottom:18px;">
+          <div style="display:flex;align-items:center;gap:10px;">
+            <img src="${logo}" alt="OFFER-HUB" style="height:36px;width:auto;object-fit:contain;" />
+          </div>
+          <div style="text-align:right;">
+            <div style="font-size:12px;letter-spacing:0.08em;color:#149A9B;font-weight:700;text-transform:uppercase;">Documentation Export</div>
+            <div style="font-size:12px;color:#6D758F;">${printableDate}</div>
+          </div>
+        </header>
+        <h1 style="font-size:30px;line-height:1.2;margin:0 0 8px;color:#19213D;">${title}</h1>
+        ${description ? `<p style="font-size:14px;line-height:1.6;margin:0 0 18px;color:#6D758F;">${description}</p>` : ""}
+      `;
+
+      const clonedContent = source.cloneNode(true) as HTMLElement;
+
+      // Remove action buttons and any controls from PDF output.
+      clonedContent.querySelectorAll("[data-pdf-exclude='true']").forEach((node) => node.remove());
+      clonedContent.querySelectorAll("button").forEach((node) => node.remove());
+
+      const style = document.createElement("style");
+      style.textContent = `
+        [data-doc-pdf-root] * {
+          box-sizing: border-box;
+        }
+        [data-doc-pdf-root] h2,
+        [data-doc-pdf-root] h3,
+        [data-doc-pdf-root] h4 {
+          color: #19213D !important;
+          break-after: avoid-page;
+        }
+        [data-doc-pdf-root] p,
+        [data-doc-pdf-root] li,
+        [data-doc-pdf-root] td,
+        [data-doc-pdf-root] th {
+          color: #6D758F !important;
+          line-height: 1.65;
+          font-size: 13px;
+        }
+        [data-doc-pdf-root] a {
+          color: #149A9B !important;
+          text-decoration: underline;
+        }
+        [data-doc-pdf-root] pre {
+          background: #0f172a !important;
+          color: #e2e8f0 !important;
+          border-radius: 10px;
+          padding: 14px;
+          overflow: hidden;
+          white-space: pre-wrap;
+          word-break: break-word;
+          box-shadow: none !important;
+        }
+        [data-doc-pdf-root] pre code,
+        [data-doc-pdf-root] code {
+          font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace !important;
+        }
+        [data-doc-pdf-root] table {
+          width: 100%;
+          border-collapse: collapse;
+          margin: 16px 0;
+          font-size: 12px;
+        }
+        [data-doc-pdf-root] table th,
+        [data-doc-pdf-root] table td {
+          border: 1px solid #d1d5db;
+          padding: 8px;
+          text-align: left;
+        }
+        [data-doc-pdf-root] table th {
+          background: #eef2ff;
+          color: #19213D !important;
+          font-weight: 700;
+        }
+        [data-doc-pdf-root] blockquote {
+          border-left: 4px solid #149A9B;
+          background: rgba(20, 154, 155, 0.07);
+          border-radius: 8px;
+          padding: 8px 12px;
+          margin: 12px 0;
+        }
+      `;
+
+      exportContainer.appendChild(style);
+      exportContainer.appendChild(clonedContent);
+      document.body.appendChild(exportContainer);
+
+      await html2pdf()
+        .set({
+          margin: [10, 10, 10, 10],
+          filename: pdfFileName,
+          image: { type: "jpeg", quality: 0.98 },
+          html2canvas: {
+            scale: 2,
+            useCORS: true,
+            backgroundColor: "#ffffff",
+          },
+          jsPDF: {
+            unit: "mm",
+            format: "a4",
+            orientation: "portrait",
+          },
+          pagebreak: { mode: ["css", "legacy"] },
+        })
+        .from(exportContainer)
+        .save();
+
+      exportContainer.remove();
+    } catch (error) {
+      console.error("PDF export failed", error);
+    } finally {
+      setIsExportingPdf(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-2" data-pdf-exclude="true">
+      <button
+        type="button"
+        onClick={handleExportMarkdown}
+        className="inline-flex items-center gap-1.5 px-3 py-2 rounded-xl text-sm font-medium border transition-colors"
+        style={{ borderColor: "#d1d5db", color: "#19213D", background: "#ffffff" }}
+      >
+        <FileCode2 size={15} />
+        Export Markdown
+      </button>
+
+      <button
+        type="button"
+        onClick={handleExportJson}
+        className="inline-flex items-center gap-1.5 px-3 py-2 rounded-xl text-sm font-medium border transition-colors"
+        style={{ borderColor: "#d1d5db", color: "#19213D", background: "#ffffff" }}
+      >
+        <FileJson size={15} />
+        Export JSON
+      </button>
+
+      <button
+        type="button"
+        onClick={handleExportPdf}
+        disabled={isExportingPdf}
+        className="inline-flex items-center gap-1.5 px-3 py-2 rounded-xl text-sm font-medium border transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+        style={{ borderColor: "#149A9B", color: "#149A9B", background: "#ffffff" }}
+      >
+        {isExportingPdf ? <Download size={15} /> : <FileText size={15} />}
+        {isExportingPdf ? "Generating PDF..." : "Export as PDF"}
+      </button>
+
+      <a
+        href={`${DOCS_REPO_BASE}/${slug}.mdx`}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-flex items-center gap-1.5 px-3 py-2 rounded-xl text-sm font-medium border transition-colors"
+        style={{ borderColor: "#d1d5db", color: "#19213D", background: "#ffffff" }}
+      >
+        <Github size={15} />
+        Edit on GitHub
+      </a>
+    </div>
+  );
+}

--- a/src/types/html2pdf.d.ts
+++ b/src/types/html2pdf.d.ts
@@ -1,0 +1,23 @@
+declare module "html2pdf.js" {
+  interface Html2PdfOptions {
+    margin?: number | number[];
+    filename?: string;
+    image?: {
+      type?: "jpeg" | "png" | "webp";
+      quality?: number;
+    };
+    html2canvas?: Record<string, unknown>;
+    jsPDF?: Record<string, unknown>;
+    pagebreak?: {
+      mode?: Array<"css" | "legacy" | "avoid-all">;
+    };
+  }
+
+  interface Html2PdfInstance {
+    set: (options: Html2PdfOptions) => Html2PdfInstance;
+    from: (source: HTMLElement | string) => Html2PdfInstance;
+    save: () => Promise<void>;
+  }
+
+  export default function html2pdf(): Html2PdfInstance;
+}


### PR DESCRIPTION
 # Title
<img width="833" height="380" alt="Screenshot from 2026-02-21 01-28-26" src="https://github.com/user-attachments/assets/cfe7dfcb-c693-4c10-9d40-56dc00132d14" />

 ## Summary

This PR adds a new **Export as PDF** action to docs detail pages and places it alongside the existing docs actions in the page header:

- Export Markdown
- Export JSON
- Export as PDF (new)
- Edit on GitHub

PDF export is generated fully client-side using `html2pdf.js` (no external services).

## What was implemented

### 1) New docs action bar component
- Added `src/components/docs/DocPageActions.tsx`
- Includes header actions:
  - Export Markdown (`.md`)
  - Export JSON (`.json`)
  - Export as PDF (`.pdf`, with `lucide-react` `FileText` icon)
  - Edit on GitHub link to the current `.mdx` source

### 2) PDF export generation (client-side)
- Library: `html2pdf.js` (lazy-loaded via dynamic import)
- Source: clones the rendered docs content container
- Adds branded PDF header:
  - OFFER-HUB logo (`/public/OFFER-HUB-logo.png`)
  - Page title
  - Export date
- Output filename format:
  - `<slug>-YYYY-MM-DD.pdf`
  - Example: `getting-started-2026-02-21.pdf`

### 3) PDF styling for docs content
Applied export-only styles to ensure clean rendering of:
- Headings/body text using docs palette:
  - headings `#19213D`
  - body `#6D758F`
  - accents `#149A9B`
- Code blocks:
  - dark background `#0f172a`
  - monospace font stack
- Tables:
  - full-width, bordered, readable header styling
- Callouts/blockquote blocks:
  - accent border + subtle background

### 4) Docs page integration
- Updated `src/app/docs/[...slug]/page.tsx`
- Injected `<DocPageActions />` into the docs header area
- Added `id="doc-page-export-content"` wrapper for export targeting

### 5) Dependency + typing updates
- Added dependency:
  - `html2pdf.js` in `package.json`
- Added local type declaration:
  - `src/types/html2pdf.d.ts`

---

## Acceptance Criteria Mapping

- [x] Button with PDF icon (`lucide-react` `FileText`) in docs page header
- [x] PDF renders full page content (headings, text, code blocks, callouts, tables)
- [x] Code blocks styled in PDF (monospace + dark background)
- [x] PDF generated client-side using `html2pdf.js`
- [x] Filename uses page slug + date (`<slug>-YYYY-MM-DD.pdf`)
- [x] No external services required
- [x] Placed alongside Export Markdown, Export JSON, and Edit on GitHub

---

## Files Changed

- `package.json`
- `package-lock.json`
- `src/app/docs/[...slug]/page.tsx`
- `src/components/docs/DocPageActions.tsx` (new)
- `src/types/html2pdf.d.ts` (new)

## Validation

- TypeScript compile check passed:
  - `npx tsc --noEmit` ✅

## Notes

- `html2pdf.js` is lazy-loaded on click to reduce initial page bundle impact.
- Export logic removes interactive controls from the PDF clone before rendering.
- 
Closes #1048
