### PR TITLE
feat(docs): build responsive docs layout shell

### DIFF
--- a/src/app/docs/[...slug]/page.tsx
+++ b/src/app/docs/[...slug]/page.tsx
@@ -1,9 +1,8 @@
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 import { MDXRemote } from "next-mdx-remote/rsc";
-import { getAllDocSlugs, getDocBySlug, extractHeadings } from "@/lib/mdx";
+import { getAllDocSlugs, getDocBySlug } from "@/lib/mdx";
 import { MDX_COMPONENTS } from "@/components/docs/mdx-components";
-import { TableOfContents } from "@/components/docs/TableOfContents";
 import { DocPageActions } from "@/components/docs/DocPageActions";
 
 interface PageProps {
@@ -32,50 +31,36 @@ export default async function DocPage({ params }: PageProps) {
 
   if (!doc) notFound();
 
-  const headings = extractHeadings(doc.content);
-
   return (
-    <div className="flex gap-10">
-      {/* ── Article ── */}
-      <article className="flex-1 min-w-0">
-        {/* Page header */}
-        <div className="mb-8 pb-6 border-b" style={{ borderColor: "#d1d5db" }}>
-          <div className="flex flex-col lg:flex-row lg:items-end lg:justify-between gap-4">
-            <div>
-              <h1 className="text-3xl font-bold mb-2" style={{ color: "#19213D" }}>
-                {doc.frontmatter.title}
-              </h1>
-              {doc.frontmatter.description && (
-                <p className="text-base leading-relaxed" style={{ color: "#6D758F" }}>
-                  {doc.frontmatter.description}
-                </p>
-              )}
-            </div>
-
-            <DocPageActions
-              slug={doc.slug}
-              title={doc.frontmatter.title}
-              description={doc.frontmatter.description}
-              markdownContent={doc.content}
-              frontmatter={doc.frontmatter}
-            />
+    <article className="min-w-0">
+      {/* Page header */}
+      <div className="mb-8 pb-6 border-b" style={{ borderColor: "#d1d5db" }}>
+        <div className="flex flex-col lg:flex-row lg:items-end lg:justify-between gap-4">
+          <div>
+            <h1 className="text-3xl font-bold mb-2" style={{ color: "#19213D" }}>
+              {doc.frontmatter.title}
+            </h1>
+            {doc.frontmatter.description && (
+              <p className="text-base leading-relaxed" style={{ color: "#6D758F" }}>
+                {doc.frontmatter.description}
+              </p>
+            )}
           </div>
-        </div>
 
-        {/* MDX content */}
-        <div className="max-w-none" id="doc-page-export-content">
-          <MDXRemote source={doc.content} components={MDX_COMPONENTS} />
+          <DocPageActions
+            slug={doc.slug}
+            title={doc.frontmatter.title}
+            description={doc.frontmatter.description}
+            markdownContent={doc.content}
+            frontmatter={doc.frontmatter}
+          />
         </div>
-      </article>
+      </div>
 
-      {/* ── Table of Contents ── */}
-      {headings.length > 0 && (
-        <aside className="hidden xl:block w-52 flex-shrink-0">
-          <div className="sticky top-24">
-            <TableOfContents headings={headings} />
-          </div>
-        </aside>
-      )}
-    </div>
+      {/* MDX content */}
+      <div className="max-w-none" id="doc-page-export-content">
+        <MDXRemote source={doc.content} components={MDX_COMPONENTS} />
+      </div>
+    </article>
   );
 }

--- a/src/app/docs/layout.tsx
+++ b/src/app/docs/layout.tsx
@@ -1,38 +1,8 @@
 import { getSidebarNav } from "@/lib/mdx";
-import { DocsSidebar } from "@/components/docs/DocsSidebar";
+import { DocsLayoutShell } from "@/components/docs/DocsLayoutShell";
 
 export default function DocsLayout({ children }: { children: React.ReactNode }) {
   const nav = getSidebarNav();
 
-  return (
-    <div className="min-h-screen" style={{ background: "#F1F3F7" }}>
-      {/* Top padding for fixed navbar */}
-      <div className="pt-16">
-        <div className="max-w-7xl mx-auto px-4 lg:px-8">
-          <div className="flex gap-8 min-h-[calc(100vh-4rem)]">
-
-            {/* ── Sidebar ── */}
-            <aside
-              className="hidden lg:block w-64 flex-shrink-0 py-10"
-            >
-              <div className="sticky top-24">
-                <div
-                  className="rounded-2xl shadow-raised p-5"
-                  style={{ background: "#F1F3F7" }}
-                >
-                  <DocsSidebar nav={nav} />
-                </div>
-              </div>
-            </aside>
-
-            {/* ── Main content ── */}
-            <main className="flex-1 min-w-0 py-10">
-              {children}
-            </main>
-
-          </div>
-        </div>
-      </div>
-    </div>
-  );
+  return <DocsLayoutShell nav={nav}>{children}</DocsLayoutShell>;
 }

--- a/src/components/docs/DocsLayoutShell.tsx
+++ b/src/components/docs/DocsLayoutShell.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { Menu, X, ChevronRight } from "lucide-react";
+
+import type { Heading, SidebarSection } from "@/lib/mdx";
+import { DocsSidebar } from "@/components/docs/DocsSidebar";
+import { TableOfContents } from "@/components/docs/TableOfContents";
+
+interface DocsLayoutShellProps {
+  nav: SidebarSection[];
+  children: React.ReactNode;
+}
+
+function formatSegment(segment: string) {
+  return decodeURIComponent(segment)
+    .replace(/-/g, " ")
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function collectHeadingsFromPage(): Heading[] {
+  const root = document.getElementById("doc-page-export-content");
+  if (!root) return [];
+
+  const nodes = Array.from(root.querySelectorAll("h2[id], h3[id]"));
+  return nodes.map((node) => {
+    const level = node.tagName.toLowerCase() === "h2" ? 2 : 3;
+    return {
+      level,
+      id: node.id,
+      text: node.textContent?.trim() || "",
+    } as Heading;
+  });
+}
+
+export function DocsLayoutShell({ nav, children }: DocsLayoutShellProps) {
+  const pathname = usePathname();
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  const [headings, setHeadings] = useState<Heading[]>([]);
+
+  const pathSegments = useMemo(() => {
+    const [, docs, ...rest] = pathname.split("/");
+    if (docs !== "docs") return [];
+    return rest.filter(Boolean);
+  }, [pathname]);
+
+  useEffect(() => {
+    setIsDrawerOpen(false);
+  }, [pathname]);
+
+  useEffect(() => {
+    const timeoutId = window.setTimeout(() => {
+      setHeadings(collectHeadingsFromPage());
+    }, 50);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [pathname, children]);
+
+  return (
+    <div className="min-h-screen" style={{ background: "#F1F3F7" }}>
+      <div className="pt-16">
+        <div className="max-w-[1440px] mx-auto px-4 lg:px-8 py-6">
+          <div className="mb-4 flex items-center gap-3">
+            <button
+              type="button"
+              onClick={() => setIsDrawerOpen(true)}
+              className="lg:hidden inline-flex items-center justify-center h-10 w-10 rounded-xl border"
+              style={{ borderColor: "#e5e7eb", background: "#ffffff", color: "#19213D" }}
+              aria-label="Open docs navigation"
+            >
+              <Menu size={18} />
+            </button>
+
+            <nav aria-label="Breadcrumb" className="flex flex-wrap items-center gap-1 text-sm">
+              <Link href="/docs" style={{ color: "#6D758F" }} className="hover:underline">
+                Docs
+              </Link>
+              {pathSegments.map((segment, index) => {
+                const href = `/docs/${pathSegments.slice(0, index + 1).join("/")}`;
+                const isLast = index === pathSegments.length - 1;
+                return (
+                  <span key={`${segment}-${index}`} className="inline-flex items-center gap-1">
+                    <ChevronRight size={14} style={{ color: "#6D758F" }} />
+                    {isLast ? (
+                      <span style={{ color: "#149A9B" }} className="font-medium">
+                        {formatSegment(segment)}
+                      </span>
+                    ) : (
+                      <Link href={href} style={{ color: "#6D758F" }} className="hover:underline">
+                        {formatSegment(segment)}
+                      </Link>
+                    )}
+                  </span>
+                );
+              })}
+            </nav>
+          </div>
+
+          <div className="grid grid-cols-1 lg:grid-cols-[16rem_minmax(0,1fr)] xl:grid-cols-[16rem_minmax(0,1fr)_14rem] gap-6 min-h-[calc(100vh-8rem)]">
+            <aside className="hidden lg:block w-64 flex-shrink-0">
+              <div
+                className="sticky top-24 rounded-2xl p-5 border-r"
+                style={{ background: "#F1F3F7", borderColor: "#e5e7eb" }}
+              >
+                <DocsSidebar nav={nav} />
+              </div>
+            </aside>
+
+            <main className="min-w-0">
+              <div
+                className="rounded-2xl border px-4 sm:px-6 md:px-8 py-8 md:py-10"
+                style={{ background: "#ffffff", borderColor: "#e5e7eb" }}
+              >
+                <div className="max-w-3xl">{children}</div>
+
+                {headings.length > 0 && (
+                  <div
+                    className="xl:hidden mt-10 pt-6 border-t"
+                    style={{ borderColor: "#e5e7eb" }}
+                  >
+                    <TableOfContents headings={headings} />
+                  </div>
+                )}
+              </div>
+            </main>
+
+            <aside className="hidden xl:block w-56 flex-shrink-0">
+              {headings.length > 0 && (
+                <div className="sticky top-24">
+                  <TableOfContents headings={headings} />
+                </div>
+              )}
+            </aside>
+          </div>
+        </div>
+      </div>
+
+      {isDrawerOpen && (
+        <div className="fixed inset-0 z-50 lg:hidden">
+          <button
+            type="button"
+            className="absolute inset-0 bg-black/30"
+            aria-label="Close docs navigation overlay"
+            onClick={() => setIsDrawerOpen(false)}
+          />
+          <aside
+            className="relative h-full w-72 max-w-[85vw] p-4 border-r shadow-raised"
+            style={{ background: "#F1F3F7", borderColor: "#e5e7eb" }}
+          >
+            <div className="mb-3 flex items-center justify-between">
+              <p className="text-sm font-semibold" style={{ color: "#19213D" }}>
+                Documentation
+              </p>
+              <button
+                type="button"
+                onClick={() => setIsDrawerOpen(false)}
+                className="inline-flex items-center justify-center h-9 w-9 rounded-lg border"
+                style={{ borderColor: "#e5e7eb", color: "#19213D", background: "#ffffff" }}
+                aria-label="Close docs navigation"
+              >
+                <X size={16} />
+              </button>
+            </div>
+            <div className="h-[calc(100%-3rem)] overflow-y-auto pr-1">
+              <DocsSidebar nav={nav} />
+            </div>
+          </aside>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
<img width="1726" height="946" alt="Screenshot from 2026-02-21 01-58-16" src="https://github.com/user-attachments/assets/753b2f98-7b1b-44a2-81c3-879b1c170078" />
<img width="665" height="715" alt="Screenshot from 2026-02-21 01-57-36" src="https://github.com/user-attachments/assets/dcb63670-88a6-40a8-918e-53449eb315f5" />
<img width="665" height="715" alt="Screenshot from 2026-02-21 01-57-31" src="https://github.com/user-attachments/assets/c7ac222c-541c-4bdf-8e01-d9b9f9b7926d" />

This PR implements the main documentation shell for all `/docs/**` routes with a responsive three-column layout:

- Left: sticky docs sidebar navigation
- Center: main content area
- Right: sticky Table of Contents (TOC)

It also adds a mobile sidebar drawer and breadcrumb navigation for route context.

## What was changed

### 1) New docs layout shell component
- Added `src/components/docs/DocsLayoutShell.tsx`
- Responsibilities:
  - Render responsive docs shell for all docs pages
  - Handle mobile sidebar drawer open/close
  - Render breadcrumb path from current route
  - Render right TOC on desktop
  - Move TOC below content on tablet/smaller screens
  - Keep sidebar and TOC sticky on scroll

### 2) Refactor `/docs` layout to use shell
- Updated `src/app/docs/layout.tsx`
- Replaced inline layout structure with:
  - `<DocsLayoutShell nav={nav}>{children}</DocsLayoutShell>`

### 3) Move TOC ownership from page to layout
- Updated `src/app/docs/[...slug]/page.tsx`
- Removed page-level TOC column and heading extraction
- Kept page focused on:
  - document header
  - export actions
  - MDX content rendering

## UI/Design details implemented

- Sidebar:
  - width `w-64`
  - background `#F1F3F7`
  - border-right `#e5e7eb`
  - sticky behavior (`top-24`)

- Content area:
  - white background
  - generous padding (`px-8 py-10` on md+)
  - readability max width `max-w-3xl`

- TOC:
  - desktop width `w-56`
  - sticky on desktop
  - moves below content on smaller breakpoints
  - keeps existing active/inactive color behavior
    - active `#149A9B`
    - inactive `#6D758F`

- Mobile:
  - hamburger button in docs header area
  - slide-in sidebar drawer with overlay + close button

- Breadcrumb:
  - rendered at top of docs shell
  - shows current docs path segments

---

## Acceptance Criteria Mapping

- [x] Layout created at `src/app/docs/layout.tsx`
- [x] Three-column layout: sidebar + content + right TOC
- [x] Tablet behavior: TOC collapses/moves below content
- [x] Mobile behavior: sidebar becomes slide-in drawer via hamburger
- [x] Sidebar and TOC sticky on scroll
- [x] Content area has readable max width (`max-w-3xl`)
- [x] Top breadcrumb navigation for current docs path
- [x] Fully responsive layout

---

## Files Changed

- `src/app/docs/layout.tsx`
- `src/components/docs/DocsLayoutShell.tsx` (new)
- `src/app/docs/[...slug]/page.tsx`

## Validation

- TypeScript compile passes:
  - `npx tsc --noEmit`
  
  Closes #1030