### PR TITLE
Added badge component

### DIFF
--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { cn } from '@/lib/cn';
+
+type BadgeVariant = 'easy' | 'medium' | 'hard' | 'feature' | 'fix' | 'breaking' | 'new';
+
+interface BadgeProps {
+  variant: BadgeVariant;
+  label?: string;
+  className?: string;
+}
+
+const variantStyles: Record<BadgeVariant, string> = {
+  easy: 'bg-[rgba(22,163,74,0.12)] text-[#16a34a]',
+  medium: 'bg-[rgba(217,119,6,0.12)] text-[#d97706]',
+  hard: 'bg-[rgba(220,38,38,0.12)] text-[#dc2626]',
+  feature: 'bg-[rgba(20,154,155,0.12)] text-[#149A9B]',
+  new: 'bg-[rgba(20,154,155,0.12)] text-[#149A9B]',
+  fix: 'bg-[rgba(109,117,143,0.12)] text-[#6D758F]',
+  breaking: 'bg-[rgba(220,38,38,0.15)] text-[#dc2626] border border-[#dc2626]',
+};
+
+const defaultLabels: Record<BadgeVariant, string> = {
+  easy: 'Easy',
+  medium: 'Medium',
+  hard: 'Hard',
+  feature: 'Feature',
+  new: 'New',
+  fix: 'Fix',
+  breaking: 'Breaking',
+};
+
+export const Badge: React.FC<BadgeProps> = ({ variant, label, className }) => {
+  const displayLabel = label ?? defaultLabels[variant];
+
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium',
+        variantStyles[variant],
+        className
+      )}
+    >
+      {displayLabel}
+    </span>
+  );
+};


### PR DESCRIPTION
# feat(ui): create Badge component for labels and tags

## Summary
This PR implements a reusable `<Badge>` component for displaying difficulty levels, categories, and status tags across the site (especially for Community and Use Cases pages). The component follows the brand guidelines and supports 7 variants with distinct styling.

## Changes
- Created `src/components/ui/Badge.tsx` with TypeScript support
- Implemented 7 variants: `easy`, `medium`, `hard`, `feature`, `fix`, `breaking`, `new`
- Each variant has brand-compliant background colors and text colors
- Pill-shaped design with `rounded-full`, `text-xs`, `px-2.5 py-0.5`
- Accepts optional `label` prop to override default labels
- Uses `cn` utility for className merging

## Checklist
- [x] Component created at `src/components/ui/Badge.tsx`
- [x] Accepts `variant` prop with all 7 types
- [x] Accepts optional `label` override prop
- [x] Each variant has distinct background and text colors per spec
- [x] Small, pill-shaped design (rounded-full, text-xs, px-2.5 py-0.5)
- [x] Follows brand color guidelines
- [x] TypeScript typed for type safety
- [x] No diagnostics/errors

## Variant Colors
- **easy:** `rgba(22,163,74,0.12)` bg, `#16a34a` text
- **medium:** `rgba(217,119,6,0.12)` bg, `#d97706` text
- **hard:** `rgba(220,38,38,0.12)` bg, `#dc2626` text
- **feature/new:** `rgba(20,154,155,0.12)` bg, `#149A9B` text
- **fix:** `rgba(109,117,143,0.12)` bg, `#6D758F` text
- **breaking:** `rgba(220,38,38,0.15)` bg, `#dc2626` text + border

## Usage Example
```tsx
import { Badge } from '@/components/ui/Badge';

<Badge variant="easy" />
<Badge variant="feature" label="New Feature" />
<Badge variant="breaking" />
```

## Notes for reviewer
Standalone component with no dependencies on other issues. Ready to be used across Community and Use Cases pages.

---

## For GitHub PR

**Title:**
```
feat(ui): create Badge component for labels and tags
```

**Description:**

Closes #1014

Creates reusable Badge component for difficulty levels, categories, and status tags. Supports 7 variants (easy, medium, hard, feature, fix, breaking, new) with brand-compliant colors. Pill-shaped design ready for Community and Use Cases pages.
