### PR TITLE
feat(community): add ContributorGrid component with mock data

### DIFF
--- a/src/components/community/ContributorGrid.tsx
+++ b/src/components/community/ContributorGrid.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { motion } from "framer-motion";
+import SectionHeading from "@/components/community/SectionHeading";
+
+interface Contributor {
+  name: string;
+  username: string;
+  area: string;
+  commits: number;
+}
+
+interface ContributorGridProps {
+  contributors?: Contributor[];
+}
+
+const mockContributors: Contributor[] = [
+  { name: "Ada M.", username: "ada-m", area: "Core Protocol", commits: 248 },
+  { name: "Dami O.", username: "dami-o", area: "Frontend", commits: 133 },
+  { name: "Hassan K.", username: "hassan-k", area: "DevRel", commits: 92 },
+  { name: "Lina S.", username: "lina-s", area: "Tooling", commits: 87 },
+  { name: "Marta P.", username: "marta-p", area: "QA", commits: 76 },
+  { name: "Tomi A.", username: "tomi-a", area: "Docs", commits: 70 },
+  { name: "Carlos R.", username: "carlos-r", area: "Backend", commits: 64 },
+  { name: "Femi B.", username: "femi-b", area: "Smart Contracts", commits: 58 },
+];
+
+function getInitials(name: string) {
+  return name
+    .split(" ")
+    .map((w) => w[0])
+    .join("")
+    .toUpperCase()
+    .slice(0, 2);
+}
+
+export default function ContributorGrid({ contributors }: ContributorGridProps) {
+  const data = contributors ?? mockContributors;
+
+  return (
+    <section id="contributor-grid" className="py-24">
+      <div className="max-w-7xl mx-auto px-6 lg:px-8">
+        <SectionHeading
+          eyebrow="Community"
+          title="Our Contributors"
+          subtitle="The people building and shipping OFFER-HUB every day."
+        />
+
+        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+          {data.map((contributor, i) => (
+            <motion.article
+              key={contributor.username}
+              className="rounded-2xl p-6 shadow-raised flex flex-col items-center text-center"
+              style={{ background: "#F1F3F7" }}
+              initial={{ opacity: 0, y: 36 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              transition={{ delay: i * 0.06, duration: 0.5, ease: "easeOut" }}
+              viewport={{ once: true, margin: "-60px" }}
+            >
+              <div
+                className="w-16 h-16 rounded-full shadow-raised-sm flex items-center justify-center text-lg font-bold text-white"
+                style={{ background: "#149A9B" }}
+              >
+                {getInitials(contributor.name)}
+              </div>
+              <h3
+                className="mt-4 text-base font-bold"
+                style={{ color: "#19213D" }}
+              >
+                {contributor.name}
+              </h3>
+              <p
+                className="mt-1 text-xs font-light"
+                style={{ color: "#6D758F" }}
+              >
+                {contributor.area}
+              </p>
+              <p
+                className="mt-3 text-sm font-medium"
+                style={{ color: "#149A9B" }}
+              >
+                {contributor.commits} commits
+              </p>
+            </motion.article>
+          ))}
+        </div>
+
+        <motion.div
+          className="mt-12 text-center"
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.5, ease: "easeOut" }}
+          viewport={{ once: true }}
+        >
+          <a
+            href="https://github.com/OFFER-HUB/offer-hub-monorepo/graphs/contributors"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-block px-6 py-3 rounded-xl text-sm font-semibold transition-all duration-[400ms] ease-out border hover:shadow-raised-hover"
+            style={{ color: "#149A9B", borderColor: "#149A9B" }}
+          >
+            View all on GitHub
+          </a>
+        </motion.div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

Implements the `ContributorGrid` section component for the `/community` page (closes #1026).

## Changes

- **Added** `src/components/community/ContributorGrid.tsx`
  - Responsive grid: 2 columns on mobile, 3 on tablet, 4 on desktop
  - 8 mock contributor cards with initials avatar, area, and commit count
  - Framer Motion staggered entrance animation on cards
  - Section includes: eyebrow label, "Our Contributors" heading, grid, and "View all on GitHub" CTA button
  - Accepts optional `contributors` prop array so it's ready to receive real data later

## Checklist

- [x] Component created at `src/components/community/ContributorGrid.tsx`
- [x] Renders a grid of 8 mock contributor cards
- [x] Responsive: 2 columns on mobile, 3 on tablet, 4 on desktop
- [x] Section includes: eyebrow label, heading, grid, and CTA button
- [x] Accepts optional `contributors` prop for future API integration
- [x] Framer Motion stagger animation on cards
- [x] Follows design system (shadow-raised, #F1F3F7 bg, teal accents)
- [x] Build passes with no errors

## Design

- Grid gap: `gap-6`
- Section container: `py-24`, `max-w-7xl mx-auto px-6 lg:px-8`
- CTA button: outlined teal, `border border-[#149A9B] text-[#149A9B]`, `rounded-xl`
- Cards: neumorphic `shadow-raised`, `rounded-2xl`, centered layout
- Animation: staggered fade-up (`delay: i * 0.06`)

## Notes

- ContributorCard component (#1015) is not yet merged, so cards are implemented inline
- Uses `SectionHeading` component for consistent section header styling
- Mock data uses initials-based avatars (no external image dependencies)
- Component is independent and can be imported into #1025 (community layout)

## Screenshots 

<img width="1710" height="984" alt="Screenshot 2026-02-22 at 7 02 41 PM" src="https://github.com/user-attachments/assets/a83a2aef-15fe-4717-ac73-50403b01c12a" />
