### PR TITLE
feat: add pricing page with tiers for open source, self-hosted, and e…

### DIFF
--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -1,0 +1,161 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowUpRight, Building2, Cloud, Code2 } from "lucide-react";
+import type { ComponentType } from "react";
+
+import { Footer } from "@/components/layout/Footer";
+import { Navbar } from "@/components/layout/Navbar";
+
+export const metadata: Metadata = {
+  title: "Pricing | OFFER-HUB",
+  description:
+    "OFFER-HUB pricing: open source core for free, free self-hosting, and enterprise support available on request.",
+};
+
+type PricingTier = {
+  name: string;
+  priceLabel: string;
+  description: string;
+  features: string[];
+  ctaLabel: string;
+  ctaHref: string;
+  ctaStyle: "primary" | "secondary";
+  external?: boolean;
+  icon: ComponentType<{ className?: string }>;
+};
+
+const tiers: PricingTier[] = [
+  {
+    name: "Open Source",
+    priceLabel: "Free forever",
+    description:
+      "Build with the full OFFER-HUB core codebase under an open-source model designed for developer trust and transparency.",
+    features: [
+      "Core platform access at no cost",
+      "Community-driven development and feedback",
+      "Public issue tracking and roadmap visibility",
+      "Ideal for prototypes, pilots, and technical evaluation",
+    ],
+    ctaLabel: "View on GitHub",
+    ctaHref: "https://github.com/OFFER-HUB/offer-hub-monorepo",
+    ctaStyle: "secondary",
+    external: true,
+    icon: Code2,
+  },
+  {
+    name: "Self-Hosted",
+    priceLabel: "Free",
+    description:
+      "Deploy OFFER-HUB on your own infrastructure and keep full control of runtime, data boundaries, and security operations.",
+    features: [
+      "No platform licensing cost",
+      "Run in your cloud or on-prem environment",
+      "Own your deployment architecture and update cadence",
+      "Best for teams with DevOps and compliance requirements",
+    ],
+    ctaLabel: "Start Self-Hosting",
+    ctaHref: "/docs/getting-started",
+    ctaStyle: "primary",
+    icon: Cloud,
+  },
+  {
+    name: "Enterprise",
+    priceLabel: "Contact us",
+    description:
+      "For businesses that need prioritized guidance, strategic architecture support, and coordinated rollout assistance.",
+    features: [
+      "Implementation advisory and onboarding support",
+      "Architecture and integration consultations",
+      "Priority troubleshooting and escalation channel",
+      "Custom support scope based on your business needs",
+    ],
+    ctaLabel: "Talk to Sales",
+    ctaHref: "/contact",
+    ctaStyle: "secondary",
+    icon: Building2,
+  },
+];
+
+export default function PricingPage() {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Navbar />
+
+      <main className="flex-grow pt-28 pb-20">
+        <section className="max-w-5xl mx-auto px-6 lg:px-8">
+          <div className="text-center max-w-3xl mx-auto">
+            <p className="text-xs font-medium uppercase tracking-[0.36em] text-[#149A9B]">
+              Pricing
+            </p>
+            <h1 className="mt-4 text-4xl md:text-5xl font-black tracking-tight text-[#19213D]">
+              Open by default. Scalable by design.
+            </h1>
+            <p className="mt-5 text-base md:text-lg leading-relaxed text-[#6D758F]">
+              OFFER-HUB keeps core access free for builders and lets teams self-host without
+              licensing fees. If you need enterprise-level support, our team can tailor a
+              support model around your rollout.
+            </p>
+          </div>
+
+          <div className="mt-14 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {tiers.map((tier) => {
+              const Icon = tier.icon;
+              const ctaClassName =
+                tier.ctaStyle === "primary"
+                  ? "bg-[#149A9B] text-white border border-[#149A9B] hover:bg-[#0d7377]"
+                  : "bg-[#F1F3F7] text-[#149A9B] border border-[#149A9B] hover:bg-[#e7edf4]";
+
+              return (
+                <article
+                  key={tier.name}
+                  className="rounded-2xl p-7 bg-[#F1F3F7] shadow-raised hover:shadow-raised-hover transition-all duration-[400ms] ease-out flex flex-col"
+                >
+                  <div className="w-11 h-11 rounded-xl shadow-raised-sm bg-[#F1F3F7] flex items-center justify-center">
+                    <Icon className="w-5 h-5 text-[#149A9B]" />
+                  </div>
+
+                  <h2 className="mt-5 text-2xl font-bold text-[#19213D]">{tier.name}</h2>
+                  <p className="mt-2 text-sm font-semibold uppercase tracking-[0.22em] text-[#149A9B]">
+                    {tier.priceLabel}
+                  </p>
+                  <p className="mt-4 text-sm leading-relaxed text-[#6D758F]">{tier.description}</p>
+
+                  <ul className="mt-6 space-y-3 flex-grow">
+                    {tier.features.map((feature) => (
+                      <li key={feature} className="flex items-start gap-2 text-sm text-[#19213D]">
+                        <span className="mt-1 h-1.5 w-1.5 rounded-full bg-[#149A9B] shrink-0" />
+                        <span>{feature}</span>
+                      </li>
+                    ))}
+                  </ul>
+
+                  <Link
+                    href={tier.ctaHref}
+                    target={tier.external ? "_blank" : undefined}
+                    rel={tier.external ? "noopener noreferrer" : undefined}
+                    className={`mt-8 w-full inline-flex items-center justify-center gap-2 px-5 py-3 rounded-xl text-sm font-semibold shadow-raised hover:shadow-raised-hover active:shadow-sunken-subtle transition-all duration-[400ms] ease-out ${ctaClassName}`}
+                  >
+                    <span>{tier.ctaLabel}</span>
+                    <ArrowUpRight className="w-4 h-4" />
+                  </Link>
+                </article>
+              );
+            })}
+          </div>
+
+          <p className="mt-10 text-center text-sm text-[#6D758F]">
+            Need help choosing the right setup? Reach us through our
+            {" "}
+            <Link href="/contact" className="text-[#149A9B] font-semibold hover:underline">
+              contact channel
+            </Link>
+            {" "}
+            and we can recommend a path based on your business stage.
+          </p>
+        </section>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}


### PR DESCRIPTION
# Title

Create `/pricing` page explaining open source / self-host / enterprise model
<img width="1909" height="1020" alt="Screenshot from 2026-02-23 04-34-29" src="https://github.com/user-attachments/assets/d9ff08ba-e316-40f2-bad1-e466fa29e099" />

## Summary

This PR implements a new pricing page at `/pricing` that clearly communicates OFFER-HUB's pricing philosophy: the core platform is free and open source, self-hosting is free, and enterprise support is available on request. The page follows the existing visual language with neumorphic cards, brand-aligned colors, and responsive layout behavior for mobile, tablet, and desktop.

## Changes

- Added new route page: `src/app/pricing/page.tsx`
- Implemented three pricing tiers:
- `Open Source` (`Free forever`)
- `Self-Hosted` (`Free`)
- `Enterprise` (`Contact us`)
- Added tier structure for each card:
- Name
- Price/label
- Description
- Feature/inclusions list
- CTA button
- Wired CTA links:
- Open Source CTA -> `https://github.com/OFFER-HUB/offer-hub-monorepo`
- Enterprise CTA -> `/contact`
- Self-Hosted CTA -> `/docs/getting-started`
- Applied neumorphic card style with existing utility shadows:
- `shadow-raised`
- `shadow-raised-hover`
- `shadow-sunken-subtle` (active state)
- Matched required design constraints:
- Colors: `#149A9B`, `#F1F3F7`, `#19213D`, `#6D758F`
- Layout container: `max-w-5xl mx-auto px-6 lg:px-8`
- Responsive grid: `grid-cols-1 md:grid-cols-2 lg:grid-cols-3`

## Checklist

- [x] Page created at `src/app/pricing/page.tsx`
- [x] Three clearly defined tiers: Open Source (free), Self-Hosted (free), Enterprise (contact us)
- [x] Each tier includes name, price/label, description, features/inclusions, and CTA button
- [x] Enterprise CTA links to `/contact`
- [x] Open Source CTA links to GitHub repository
- [x] Fully responsive for mobile, tablet, and desktop
- [x] Uses neumorphic card style consistent with the rest of the site


Closes #1007 

 ## How to test locally

 ```bash
 # from repository root
 cd "./backend"
 npm test src/__tests__/controllers/wallet.controller.test.ts --runInBand
 ```

 ## Notes for reviewer

 - I ran the controller unit tests; they pass locally. Full test suite shows unrelated integration test failures in other modules (task/escrow) due to test env secrets; those are unchanged by this PR.

 ## Suggested PR title

 feat(wallets): add GET /wallets endpoint (list user wallets)

 ## Suggested PR description (short)

 Implements GET /api/v1/wallets for authenticated users to list their connected wallets (both system-invisible and external). Adds controller, route and unit tests. Response excludes private keys and orders primary wallets first.
