### PR TITLE
Add "Edit this page on GitHub" link to documentation pages

### DIFF
--- a/src/app/docs/[...slug]/page.tsx
+++ b/src/app/docs/[...slug]/page.tsx
@@ -4,6 +4,7 @@ import { MDXRemote } from "next-mdx-remote/rsc";
 import { getAllDocSlugs, getDocBySlug } from "@/lib/mdx";
 import { MDX_COMPONENTS } from "@/components/docs/mdx-components";
 import { DocPageActions } from "@/components/docs/DocPageActions";
+import { EditOnGitHub } from "@/components/docs/EditOnGitHub";
 
 interface PageProps {
   params: Promise<{ slug: string[] }>;
@@ -60,6 +61,11 @@ export default async function DocPage({ params }: PageProps) {
       {/* MDX content */}
       <div className="max-w-none" id="doc-page-export-content">
         <MDXRemote source={doc.content} components={MDX_COMPONENTS} />
+      </div>
+
+      {/* Edit on GitHub link */}
+      <div className="mt-8 pt-6 border-t" style={{ borderColor: "#d1d5db" }}>
+        <EditOnGitHub filePath={`content/docs/${doc.slug}.mdx`} />
       </div>
     </article>
   );

--- a/src/components/docs/EditOnGitHub.tsx
+++ b/src/components/docs/EditOnGitHub.tsx
@@ -1,0 +1,21 @@
+import { Pencil } from 'lucide-react';
+
+interface EditOnGitHubProps {
+  filePath: string;
+}
+
+export function EditOnGitHub({ filePath }: EditOnGitHubProps) {
+  const githubEditUrl = `https://github.com/OFFER-HUB/offer-hub-monorepo/edit/main/${filePath}`;
+
+  return (
+    <a
+      href={githubEditUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="inline-flex items-center gap-1.5 text-sm text-[#6D758F] hover:text-[#149A9B] transition-colors"
+    >
+      <Pencil size={14} />
+      <span>Edit this page on GitHub</span>
+    </a>
+  );
+}


### PR DESCRIPTION
## Summary
This PR implements the "Edit this page on GitHub" link at the bottom of every documentation page. This is a standard open source pattern that invites contributors to improve the documentation directly from the browser.

## Changes
- Created `EditOnGitHub` component at `src/components/docs/EditOnGitHub.tsx`
- Integrated component into `src/app/docs/[...slug]/page.tsx` below MDX content
- Component accepts `filePath` prop and generates GitHub edit URL
- Styled with text-sm, color #6D758F, hover #149A9B per design specs
- Uses Pencil icon from lucide-react (size 14)

## Checklist
- [x] Component created at `src/components/docs/EditOnGitHub.tsx`
- [x] Accepts `filePath` prop (relative path to MDX file)
- [x] Renders link to `https://github.com/OFFER-HUB/offer-hub-monorepo/edit/main/{filePath}`
- [x] Opens in new tab with proper security attributes
- [x] Shows Pencil icon from lucide-react
- [x] Placed above Previous/Next navigation (bottom of page)
- [x] Styled per design: text-sm, #6D758F, hover #149A9B
- [x] No background, no border — subtle text link

## How to test locally
```bash
# Start the dev server
npm run dev

# Navigate to any documentation page, e.g.:
# http://localhost:3000/docs/getting-started
# http://localhost:3000/docs/api-reference/overview

# Verify:
# 1. "Edit this page on GitHub" link appears at bottom
# 2. Link opens correct GitHub edit page in new tab
# 3. Hover effect changes color to #149A9B
# 4. Pencil icon displays inline with text
```

## Notes for reviewer
- Component is standalone with no dependencies on other issues
- File path is constructed from doc slug: `content/docs/${doc.slug}.mdx`
- Link positioned with top border separator for visual clarity
- Uses existing color palette from tailwind.config.ts

## Suggested PR title
feat(docs): add "Edit this page on GitHub" link to documentation pages

## Suggested PR description (short)
Adds "Edit this page on GitHub" link to all documentation pages, enabling contributors to easily suggest improvements. Includes Pencil icon and follows design system styling (#6D758F with #149A9B hover).

Closes #1034

