### PR TITLE
feat: Create <Callout> component with Note, Warning, Tip, and Danger …

### DIFF
--- a/content/docs/api-reference/overview.mdx
+++ b/content/docs/api-reference/overview.mdx
@@ -73,7 +73,7 @@ Errors also use the same envelope format:
 | `422` | Validation Error |
 | `500` | Internal Server Error |
 
-<Callout variant="note">
+<Callout type="note">
   All error messages are safe to display to end users. Internal details are logged server-side only.
 </Callout>
 
@@ -81,7 +81,7 @@ Errors also use the same envelope format:
 
 The API enforces rate limits per IP address. Exceeding the limit returns `429 Too Many Requests`.
 
-<Callout variant="warning">
+<Callout type="warning">
   Default limits: **100 requests / 15 minutes** for public endpoints, **300 / 15 min** for authenticated endpoints.
 </Callout>
 

--- a/content/docs/api-reference/webhooks.mdx
+++ b/content/docs/api-reference/webhooks.mdx
@@ -87,7 +87,7 @@ function verifyWebhook(payload: string, signature: string, secret: string): bool
 }
 ```
 
-<Callout variant="danger">
+<Callout type="danger">
   Always verify the signature before processing a webhook payload. Skipping this step exposes your application to spoofed events.
 </Callout>
 
@@ -105,7 +105,7 @@ OFFER-HUB retries failed webhook deliveries with exponential back-off:
 
 After 5 failed attempts the webhook is disabled. Re-enable it from your dashboard.
 
-<Callout variant="note">
+<Callout type="note">
   Your endpoint must respond with a `2xx` status code within **10 seconds**. Long-running processing should be handled asynchronously.
 </Callout>
 

--- a/content/docs/configuration.mdx
+++ b/content/docs/configuration.mdx
@@ -34,7 +34,7 @@ STELLAR_RPC_URL=https://soroban-testnet.stellar.org
 STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
 ```
 
-<Callout variant="note">
+<Callout type="note">
   Use `mainnet` for production. The Soroban RPC endpoint changes between networks.
 </Callout>
 
@@ -89,6 +89,6 @@ NEXT_PUBLIC_STELLAR_NETWORK=testnet
 | `NODE_ENV` | No | `development` | Runtime environment |
 | `STELLAR_NETWORK` | No | `testnet` | `testnet` or `mainnet` |
 
-<Callout variant="danger">
+<Callout type="danger">
   Never commit your `.env` file to version control. It is already listed in `.gitignore`.
 </Callout>

--- a/content/docs/getting-started.mdx
+++ b/content/docs/getting-started.mdx
@@ -7,7 +7,7 @@ section: Getting Started
 
 OFFER-HUB is a non-custodial escrow payment layer for modern marketplaces. It enables secure, trustless transactions between buyers and sellers without requiring you to build complex payment infrastructure.
 
-<Callout variant="tip">
+<Callout type="tip">
   If you just want to run the project locally, jump straight to the [Installation](/docs/installation) guide.
 </Callout>
 

--- a/content/docs/installation.mdx
+++ b/content/docs/installation.mdx
@@ -49,7 +49,7 @@ Apply the Supabase migrations to create the required tables and RPC functions:
 
 <CommandLine>cd backend && npx supabase db push</CommandLine>
 
-<Callout variant="warning">
+<Callout type="warning">
   Make sure you have the Supabase CLI installed and are logged in before running migrations.
 </Callout>
 
@@ -78,6 +78,6 @@ You should see:
 }
 ```
 
-<Callout variant="tip">
+<Callout type="tip">
   Continue to [Configuration](/docs/configuration) to learn about all available environment variables and Supabase setup.
 </Callout>

--- a/src/components/docs/Callout.tsx
+++ b/src/components/docs/Callout.tsx
@@ -1,52 +1,53 @@
 import { Info, AlertTriangle, Lightbulb, AlertOctagon } from "lucide-react";
 import { cn } from "@/lib/cn";
 
-type CalloutVariant = "note" | "warning" | "tip" | "danger";
+type CalloutType = "note" | "warning" | "tip" | "danger";
 
 interface CalloutProps {
-  variant?: CalloutVariant;
+  type?: CalloutType;
   children: React.ReactNode;
 }
 
 const VARIANTS: Record<
-  CalloutVariant,
+  CalloutType,
   { icon: React.ReactNode; borderColor: string; bgColor: string; iconColor: string; label: string }
 > = {
   note: {
     icon: <Info size={16} />,
     borderColor: "#149A9B",
-    bgColor: "rgba(20,154,155,0.07)",
+    bgColor: "rgba(20,154,155,0.08)",
     iconColor: "#149A9B",
     label: "Note",
   },
   tip: {
     icon: <Lightbulb size={16} />,
     borderColor: "#16a34a",
-    bgColor: "rgba(22,163,74,0.07)",
+    bgColor: "rgba(22,163,74,0.08)",
     iconColor: "#16a34a",
     label: "Tip",
   },
   warning: {
     icon: <AlertTriangle size={16} />,
     borderColor: "#d97706",
-    bgColor: "rgba(217,119,6,0.07)",
+    bgColor: "rgba(217,119,6,0.08)",
     iconColor: "#d97706",
     label: "Warning",
   },
   danger: {
     icon: <AlertOctagon size={16} />,
-    borderColor: "#dc2626",
-    bgColor: "rgba(220,38,38,0.07)",
-    iconColor: "#dc2626",
+    borderColor: "#FF0000",
+    bgColor: "rgba(255,0,0,0.08)",
+    iconColor: "#FF0000",
     label: "Danger",
   },
 };
 
-export function Callout({ variant = "note", children }: CalloutProps) {
-  const config = VARIANTS[variant];
+export function Callout({ type = "note", children }: CalloutProps) {
+  const config = VARIANTS[type];
 
   return (
     <div
+      role="note"
       className={cn("rounded-xl px-4 py-3 my-5 border-l-4")}
       style={{
         borderLeftColor: config.borderColor,

--- a/src/components/docs/mdx-components.tsx
+++ b/src/components/docs/mdx-components.tsx
@@ -79,7 +79,7 @@ export const MDX_COMPONENTS: MDXComponents = {
   },
 
   // Blockquote → Callout note
-  blockquote: ({ children }) => <Callout variant="note">{children}</Callout>,
+  blockquote: ({ children }) => <Callout type="note">{children}</Callout>,
 
   // Unordered list
   ul: ({ children }) => (


### PR DESCRIPTION
Title: feat: Create <Callout> component with Note, Warning, Tip, and Danger variants                                         
  
  Summary

  This PR implements the reusable <Callout> component for use in documentation pages. It highlights important
  information with visual distinction based on severity or type, following the existing docs component pattern.

  Changes

  - Implemented <Callout> at src/components/docs/Callout.tsx with note, tip, warning, and danger variants
  - Updated src/components/docs/mdx-components.tsx to use the new type= prop (blockquote fallback)
  - Updated all existing MDX docs files to use type= instead of the old variant= prop:
    - content/docs/getting-started.mdx
    - content/docs/installation.mdx
    - content/docs/configuration.mdx
    - content/docs/api-reference/overview.mdx
    - content/docs/api-reference/webhooks.mdx

  Checklist

  - Component created at src/components/docs/Callout.tsx
  - Accepts type prop: 'note' | 'warning' | 'tip' | 'danger'
  - Accepts children for the callout body content
  - Each variant has a distinct icon (lucide-react), border color, and background tint
  - Fully accessible (role="note" on the wrapper div)
  - Responsive and works inside a prose/markdown layout
  - Variant colors match design spec exactly (border, bg, icon)
  - danger uses #FF0000 / rgba(255,0,0,0.08) as specified
  - All bg opacities set to 0.08 as specified
  - rounded-xl + border-l-4 applied

  How to test locally

  # Generate the docs search index first (gitignored, required for build)
  npm run docs:index

  # Start the dev server
  npm run dev

  Then visit any of these pages to see all four variants in action:
  - http://localhost:3000/docs/getting-started — tip
  - http://localhost:3000/docs/installation — warning, tip
  - http://localhost:3000/docs/configuration — note, danger
  - http://localhost:3000/docs/api-reference/overview — note, warning
  - http://localhost:3000/docs/api-reference/webhooks — danger, note
  
<img width="1366" height="548" alt="Screenshot (1610)" src="https://github.com/user-attachments/assets/44641d65-ea12-461c-ab38-e689d04fcb8e" />

<img width="1366" height="437" alt="Screenshot (1611)" src="https://github.com/user-attachments/assets/a3064fa9-87e0-427c-9a06-2edeff4e9f2a" />

  Notes for reviewer

  - The pre-existing component used a variant= prop and slightly off colors (#dc2626 for danger, bg opacity 0.07). This
  PR corrects both to match the design spec.
  - All existing MDX files that referenced <Callout variant="..."> have been updated to <Callout type="..."> to stay
  consistent with the new prop name.
  - src/data/docs-index.json is gitignored (generated); run npm run docs:index to regenerate it locally
  
  
  
  closes #1012