### PR TITLE
feat(components): create RepoStats component with mock data (#1018)

### DIFF
--- a/src/components/community/RepoStats.tsx
+++ b/src/components/community/RepoStats.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { motion, type Variants } from "framer-motion";
+import { Star, GitFork, Eye, AlertCircle } from "lucide-react";
+
+interface RepoStatsProps {
+     stars?: number;
+     forks?: number;
+     watchers?: number;
+     openIssues?: number;
+}
+
+const fadeUp: Variants = {
+     hidden: { opacity: 0, y: 28 },
+     visible: (i: number) => ({
+          opacity: 1,
+          y: 0,
+          transition: { delay: i * 0.1, duration: 0.55, ease: "easeOut" as const },
+     }),
+};
+
+const mockStats = {
+     stars: 2547,
+     forks: 380,
+     watchers: 145,
+     openIssues: 23,
+};
+
+export default function RepoStats({
+     stars = mockStats.stars,
+     forks = mockStats.forks,
+     watchers = mockStats.watchers,
+     openIssues = mockStats.openIssues,
+}: RepoStatsProps) {
+     const stats = [
+          {
+               icon: Star,
+               value: stars,
+               label: "Stars",
+          },
+          {
+               icon: GitFork,
+               value: forks,
+               label: "Forks",
+          },
+          {
+               icon: Eye,
+               value: watchers,
+               label: "Watchers",
+          },
+          {
+               icon: AlertCircle,
+               value: openIssues,
+               label: "Open Issues",
+          },
+     ];
+
+     return (
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-6">
+               {stats.map((stat, i) => {
+                    const Icon = stat.icon;
+                    return (
+                         <motion.div
+                              key={stat.label}
+                              custom={i}
+                              variants={fadeUp}
+                              initial="hidden"
+                              whileInView="visible"
+                              viewport={{ once: true, margin: "-80px" }}
+                              className="flex flex-col items-center text-center p-6 rounded-2xl shadow-raised"
+                              style={{ background: "#F1F3F7" }}
+                         >
+                              <Icon size={20} style={{ color: "#149A9B" }} />
+                              <span
+                                   className="text-3xl font-black tracking-tight mt-3"
+                                   style={{ color: "#149A9B" }}
+                              >
+                                   {stat.value.toLocaleString()}
+                              </span>
+                              <span
+                                   className="text-sm uppercase tracking-widest mt-2"
+                                   style={{ color: "#6D758F" }}
+                              >
+                                   {stat.label}
+                              </span>
+                         </motion.div>
+                    );
+               })}
+          </div>
+     );
+}


### PR DESCRIPTION
# Title

feat(community): add RepoStats component with mock data (#1018)

## Summary

This PR implements the `<RepoStats>` component for displaying high-level GitHub repository statistics on the `/community` page hero section. The component accepts props for stars, forks, watchers, and open issues counts, displays them in a responsive grid with neumorphic card design, and includes sensible mock data defaults. The component follows the existing design system guidelines and uses framer-motion for smooth entrance animations.

## Changes

- Added `RepoStats` component in `src/components/community/RepoStats.tsx`
- Displays 4 repository statistics (stars, forks, watchers, open issues) with lucide-react icons
- Implements responsive layout: 2x2 grid on mobile (grid-cols-2), 4-column layout on desktop (md:grid-cols-4)
- Includes mock data with sensible defaults (2,547 stars, 380 forks, 145 watchers, 23 open issues)
- Supports customizable props while maintaining standalone mock data functionality
- Styled according to design system: primary color #149A9B, secondary text #6D758F, neumorphic shadow-raised cards
- Added framer-motion animations for staggered fade-up effect matching existing components

## Checklist

- [x] Component created at `src/components/community/RepoStats.tsx`
- [x] Accepts props: `stars` (number), `forks` (number), `watchers` (number), `openIssues` (number)
- [x] Each stat displays icon (lucide-react), numeric value, and label
- [x] Responsive layout: 2x2 grid on mobile, 4 columns on desktop
- [x] Stat value styling: `text-3xl font-black`, color `#149A9B`
- [x] Label styling: `text-sm uppercase tracking-widest`, color `#6D758F`
- [x] Icon: size 20, color `#149A9B`
- [x] Neumorphic card design: `shadow-raised`, `rounded-2xl`, `p-6`, background `#F1F3F7`
- [x] Hardcoded mock data renders correctly
- [x] Follows design reference from `src/components/StatsSection.tsx`
- [x] Client component with framer-motion animations

## Close #1018 


https://github.com/user-attachments/assets/16496c7e-bf3e-4a08-82f2-3ce859aa1e85

