### PR TITLE
feat: build Table of Contents component with scroll-aware active heading (#1032)

### DIFF
--- a/src/components/docs/TableOfContents.tsx
+++ b/src/components/docs/TableOfContents.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { cn } from "@/lib/cn";
 import type { Heading } from "@/lib/mdx";
 
 interface TableOfContentsProps {
@@ -12,17 +11,30 @@ export function TableOfContents({ headings }: TableOfContentsProps) {
   const [activeId, setActiveId] = useState<string>("");
 
   useEffect(() => {
-    if (headings.length === 0) return;
-
     const observer = new IntersectionObserver(
       (entries) => {
-        for (const entry of entries) {
-          if (entry.isIntersecting) {
-            setActiveId(entry.target.id);
+        // Collect all intersecting entries
+        const visibleEntries = entries
+          .filter((entry) => entry.isIntersecting)
+          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
+
+        if (visibleEntries.length > 0) {
+          // If we are at the bottom of the page, the last visible entry should be active
+          const isAtBottom =
+            window.innerHeight + window.scrollY >= document.documentElement.scrollHeight - 50;
+
+          if (isAtBottom) {
+            setActiveId(visibleEntries[visibleEntries.length - 1].target.id);
+          } else {
+            // Otherwise, pick the one closest to our top margin (100px)
+            setActiveId(visibleEntries[0].target.id);
           }
         }
       },
-      { rootMargin: "0px 0px -60% 0px", threshold: 0.1 }
+      {
+        rootMargin: "-100px 0px -40% 0px",
+        threshold: [0, 1],
+      }
     );
 
     headings.forEach(({ id }) => {
@@ -30,37 +42,63 @@ export function TableOfContents({ headings }: TableOfContentsProps) {
       if (el) observer.observe(el);
     });
 
-    return () => observer.disconnect();
+    // Handle scroll to bottom explicitly to catch the last items
+    const handleScroll = () => {
+      const isAtBottom =
+        window.innerHeight + window.scrollY >= document.documentElement.scrollHeight - 50;
+      if (isAtBottom && headings.length > 0) {
+        setActiveId(headings[headings.length - 1].id);
+      }
+    };
+
+    window.addEventListener("scroll", handleScroll);
+    return () => {
+      observer.disconnect();
+      window.removeEventListener("scroll", handleScroll);
+    };
   }, [headings]);
+
+  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>, id: string) => {
+    e.preventDefault();
+    const element = document.getElementById(id);
+    if (element) {
+      const top = element.getBoundingClientRect().top + window.scrollY - 100;
+      window.scrollTo({
+        top,
+        behavior: "smooth",
+      });
+      window.history.pushState(null, "", `#${id}`);
+    }
+  };
 
   if (headings.length === 0) return null;
 
   return (
-    <nav className="flex flex-col gap-1">
-      <p
-        className="text-xs font-semibold uppercase tracking-widest mb-2"
-        style={{ color: "#6D758F" }}
-      >
-        On this page
-      </p>
-      {headings.map((heading) => (
-        <a
-          key={heading.id}
-          href={`#${heading.id}`}
-          className={cn(
-            "text-sm transition-all duration-150 leading-snug py-0.5",
-            heading.level === 3 && "pl-3",
-            activeId === heading.id
-              ? "font-medium"
-              : "hover:opacity-80"
-          )}
-          style={{
-            color: activeId === heading.id ? "#149A9B" : "#6D758F",
-          }}
-        >
-          {heading.text}
-        </a>
-      ))}
+    <nav className="hidden md:block w-full max-w-[240px]">
+      <div className="flex flex-col">
+        <p className="text-xs font-semibold uppercase tracking-widest text-text-primary mb-4">
+          On this page
+        </p>
+        <ul className="flex flex-col gap-3">
+          {headings.map((heading) => (
+            <li
+              key={heading.id}
+              className={heading.level === 3 ? "pl-3" : ""}
+            >
+              <a
+                href={`#${heading.id}`}
+                onClick={(e) => handleClick(e, heading.id)}
+                className={`text-sm transition-colors duration-200 block leading-tight ${activeId === heading.id
+                  ? "text-primary font-semibold"
+                  : "text-text-secondary hover:text-text-primary"
+                  }`}
+              >
+                {heading.text}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </div>
     </nav>
   );
 }


### PR DESCRIPTION

# Title

Build Table of Contents component with scroll-aware active heading

## Summary

This PR implements the [TableOfContents](cci:1://file:///c:/Trabajos%20Progra/DRIPS-WAVE/offer-hub/src/components/docs/TableOfContents.tsx:9:0-103:1) component for documentation pages. It automatically highlights the currently visible heading as the user scrolls using `IntersectionObserver`, renders h2 and h3 headings as anchor links with smooth scroll, and is hidden on mobile devices.

## Changes

- Updated [src/components/docs/TableOfContents.tsx](cci:7://file:///c:/Trabajos%20Progra/DRIPS-WAVE/offer-hub/src/components/docs/TableOfContents.tsx:0:0-0:0) with full scroll-aware logic
- Uses `IntersectionObserver` to detect the active heading in viewport
- Active heading highlighted with `#149A9B` (teal)
- h3 items indented with `pl-3` relative to h2 items
- Smooth scroll on click with offset to avoid content being hidden under navbar
- Handles bottom-of-page edge case: last headings correctly highlighted when scrolled to bottom
- Hidden on mobile/small screens (`hidden md:block`)

## Checklist

- [x] Component located at [src/components/docs/TableOfContents.tsx](cci:7://file:///c:/Trabajos%20Progra/DRIPS-WAVE/offer-hub/src/components/docs/TableOfContents.tsx:0:0-0:0)
- [x] Accepts `headings` prop: array of `{ id, text, level }` objects
- [x] Renders h2 and h3 headings as anchor links
- [x] h3 items are indented relative to h2 (`pl-3`)
- [x] Uses `IntersectionObserver` to detect the currently visible heading
- [x] Active heading highlighted in `#149A9B`
- [x] Smooth scroll to heading on click
- [x] Hidden on mobile (TOC is only for desktop/tablet)
- [x] "On this page" label uses `text-xs font-semibold uppercase tracking-widest`, color `#19213D`
- [x] Item colors: default `#6D758F`, active `#149A9B`, hover `#19213D`

## How to test locally

```bash
# from repository root
npm run dev
# Navigate to any docs page, e.g.:
# http://localhost:3000/docs/getting-started
```

## Notes for reviewer
The component integrates directly into the existing 
DocsLayoutShell
 which already imports and renders it on the right sidebar for xl screens and inline for md screens.
Bottom-of-page edge case is handled via a scroll event listener that forces the last heading active when the user reaches the end of the page.

## Closes
Closes #1032

