### PR TITLE
Created the contributor card component

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -24,6 +24,15 @@ const nextConfig: NextConfig = {
       },
     ];
   },
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "avatars.githubusercontent.com",
+        pathname: "/**",
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/src/components/community/ContributorCard.tsx
+++ b/src/components/community/ContributorCard.tsx
@@ -8,49 +8,6 @@ export interface ContributorCardProps {
   profileUrl: string;
 }
 
-// paste this 👇 section in any component to test, note this can also be mapped over.
-{
-  /* <section className="py-16">
-<div className="max-w-7xl mx-auto px-6 lg:px-8">
-  <div className="mb-8 text-center">
-    <p className="text-xs font-medium uppercase tracking-[0.36em] text-primary">
-      Community preview
-    </p>
-    <h2 className="mt-3 text-2xl md:text-3xl font-black tracking-tight text-text-primary">
-      Example contributors
-    </h2>
-  </div>
-
-  <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-5">
-    <ContributorCard
-      avatar="https://avatars.githubusercontent.com/u/583231?v=4"
-      username="octocat"
-      contributions={42}
-      profileUrl="https://github.com/octocat"
-    />
-    <ContributorCard
-      avatar="https://avatars.githubusercontent.com/u/1?v=4"
-      username="early-bird"
-      contributions={7}
-      profileUrl="https://github.com/early-bird"
-    />
-    <ContributorCard
-      avatar="https://avatars.githubusercontent.com/u/2?v=4"
-      username="very-long-username-that-wraps-nicely"
-      contributions={120}
-      profileUrl="https://github.com/very-long-username-that-wraps-nicely"
-    />
-    <ContributorCard
-      avatar="https://avatars.githubusercontent.com/u/3?v=4"
-      username="design-systems"
-      contributions={5}
-      profileUrl="https://github.com/design-systems"
-    />
-  </div>
-</div>
-</section> */
-}
-
 export default function ContributorCard({
   avatar,
   username,
@@ -58,7 +15,7 @@ export default function ContributorCard({
   profileUrl,
 }: ContributorCardProps) {
   return (
-    <article className="w-full max-w-xs mx-auto rounded-2xl p-5 shadow-raised bg-background transition-shadow duration-[400ms] ease-out hover:shadow-raised-hover">
+    <article className="w-full max-w-xs mx-auto rounded-2xl p-5 shadow-raised bg-background transition-shadow duration-[400ms] ease-out">
       <Link
         href={profileUrl}
         target="_blank"


### PR DESCRIPTION
Implemented the `ContributorCard` component with mock data .

## Summary

This PR adds a reusable `ContributorCard` component for the community area and wires it up with mock data so we can validate the layout, behavior, and styling before integrating it into the `/community` page.   closes #1015 

## Changes

- `src/components/community/ContributorCard.tsx`
  - Created `ContributorCard` component with props: `avatar`, `username`, `contributions`, `profileUrl`
  - Implemented neumorphic card styling: `shadow-raised`, `bg-background`, `rounded-2xl`, `p-5`, responsive width (`w-full max-w-xs`)
  - Used `next/image` for avatars
- `next.config.ts`
  - Added `images.remotePatterns` entry for `https://avatars.githubusercontent.com/**` so GitHub avatars load via `next/image`
- `src/app/page.tsx`
 
## Checklist 

- [x] Component created at `src/components/community/ContributorCard.tsx`
- [x] Accepts props: `avatar` (URL), `username` (string), `contributions` (number), `profileUrl` (string)
- [x] Displays avatar image, GitHub username, number of contributions, and link to GitHub profile
- [x] Avatar uses Next.js `Image` component
- [x] GitHub profile link opens in a new tab
- [x] Card layout is fully responsive and works inside a grid
- [x] Follows design: neumorphic card (`shadow-raised`, `bg-background`), `rounded-2xl`, `p-5`, avatar `w-14 h-14 rounded-full`, username `font-semibold` with `#19213D`, contributions `text-sm` with `#6D758F`

- How to test locally
 - from repo root
npm install
npm run dev
