### PR TITLE
feat: create CodeBlock component with syntax highlighting and copy bu…

### DIFF
--- a/src/components/docs/CodeBlock.tsx
+++ b/src/components/docs/CodeBlock.tsx
@@ -30,7 +30,7 @@ export function CodeBlock({
       try {
         const html = await codeToHtml(rawCode, {
           lang: language,
-          theme: "one-dark-pro", // Tema con mejor contraste y colores más vibrantes
+          theme: "one-dark-pro",
         });
         if (isMounted) {
           setHighlightedCode(html);
@@ -61,23 +61,20 @@ export function CodeBlock({
   return (
     <div
       className={cn(
-        "relative rounded-xl overflow-hidden my-6 border border-white/10 group shadow-2xl",
+        "relative rounded-xl overflow-hidden my-6 border border-white/10 group shadow-2xl bg-[#0f172a]",
         className
       )}
-      style={{ background: "#0f172a" }}
     >
       {/* Header bar */}
       <div className="flex items-center justify-between px-4 py-2 bg-white/5 border-b border-white/10">
-        <span
-          className="text-xs font-semibold uppercase tracking-wider font-mono"
-          style={{ color: "#6D758F" }}
-        >
+        <span className="text-xs font-semibold uppercase tracking-wider font-mono text-text-secondary">
           {language}
         </span>
         <button
+          type="button"
           onClick={handleCopy}
           aria-label={copied ? "Copied" : "Copy code"}
-          className="relative flex items-center justify-center p-1.5 rounded-lg transition-all duration-200 hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-[#149A9B]/50"
+          className="relative flex items-center justify-center p-1.5 rounded-lg transition-all duration-200 hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-primary/50"
         >
           <AnimatePresence mode="wait" initial={false}>
             {copied ? (
@@ -100,8 +97,7 @@ export function CodeBlock({
               >
                 <Copy
                   size={14}
-                  className="transition-colors duration-200"
-                  style={{ color: "#149A9B" }}
+                  className="text-primary transition-colors duration-200"
                 />
               </motion.div>
             )}
@@ -114,7 +110,7 @@ export function CodeBlock({
         {highlightedCode ? (
           <div
             dangerouslySetInnerHTML={{ __html: highlightedCode }}
-            className="shiki-container [&>pre]:!bg-transparent [&>pre]:!p-0 [&>pre]:!m-0 [&>pre]:!outline-none [&_span]:!text-[inherit] shiki-vibrant"
+            className="shiki-container [&>pre]:!bg-transparent [&>pre]:!p-0 [&>pre]:!m-0 [&>pre]:!outline-none shiki-vibrant"
           />
         ) : (
           <pre className="text-slate-400 animate-pulse">
@@ -125,10 +121,10 @@ export function CodeBlock({
 
       <style jsx global>{`
         .shiki-container pre {
-          color: #e2e8f0; /* Color base claro por si el tema falla */
+          color: #e2e8f0;
         }
         .shiki-vibrant span {
-          filter: brightness(1.2); /* Aumenta ligeramente el brillo de los tokens */
+          filter: brightness(1.2);
         }
       `}</style>
     </div>


### PR DESCRIPTION
## Tittle 
feat(docs): create <CodeBlock> component with syntax highlighting and copy button
## Summary

Implements the reusable `<CodeBlock>` component for all documentation pages. Supports syntax highlighting for multiple languages and includes a one-click copy-to-clipboard button with animated confirmation.

Closes #1011

## Changes

- Created [src/components/docs/CodeBlock.tsx](cci:7://file:///c:/Trabajos%20Progra/DRIPS-WAVE/offer-hub/src/components/docs/CodeBlock.tsx:0:0-0:0)
- Accepts [code](cci:1://file:///c:/Trabajos%20Progra/DRIPS-WAVE/offer-hub/src/components/docs/mdx-components.tsx:61:2-69:3) (string) and `language` (string) props, with `language` defaulting to `typescript`
- Syntax highlighting via **Shiki** (`one-dark-pro` theme) — chosen over `prism-react-renderer` because Shiki was already installed in the project and provides superior, accurate highlighting
- Copy-to-clipboard button in the top-right corner using `navigator.clipboard.writeText`
- Copy button shows a `✓` (Check) icon for **2 seconds** after clicking, animated via `framer-motion` `AnimatePresence`
- Language label displayed in the top-left in muted color (`text-text-secondary` / `#6D758F`)
- Dark background (`bg-[#0f172a]`), `rounded-xl` border, consistent with design system
- Fixed: removed `[&_span]:!text-[inherit]` Tailwind class that was overriding Shiki's token colors
- Fully accessible: `type="button"`, dynamic `aria-label` ("Copy code" / "Copied"), keyboard-navigable with focus ring using `focus:ring-primary/50`

## Checklist

- [x] Component created at [src/components/docs/CodeBlock.tsx](cci:7://file:///c:/Trabajos%20Progra/DRIPS-WAVE/offer-hub/src/components/docs/CodeBlock.tsx:0:0-0:0)
- [x] Accepts [code](cci:1://file:///c:/Trabajos%20Progra/DRIPS-WAVE/offer-hub/src/components/docs/mdx-components.tsx:61:2-69:3) (string) and `language` (string) props
- [x] Syntax highlighting using **Shiki** (documented choice)
- [x] Copy to clipboard button in the top-right corner
- [x] Copy button shows ✓ confirmation for 2 seconds after clicking
- [x] Displays language label in the top-left (e.g. `typescript`, `bash`)
- [x] Fully accessible (keyboard navigable, `aria-label`)
- [x] Styled consistently with the design system (`#0f172a`, `#149A9B`, `#6D758F`, `rounded-xl`)

## How to test locally

```bash
npm run docs:index   # generate search index (required if not present)
npm run dev
```
Then navigate to http://localhost:3000/docs and open any documentation page with a code block.


https://github.com/user-attachments/assets/fdc4cdc6-bcf8-477a-b14d-9552e6970040

