### PR TITLE
feat: Create /community 'Join us' section with Discord, Telegram, X, …

### DIFF
--- a/src/components/community/CommunityChannelsSection.tsx
+++ b/src/components/community/CommunityChannelsSection.tsx
@@ -1,10 +1,7 @@
-import {
-  ArrowUpRight,
-  Disc3,
-  Github,
-  Send,
-  Twitter,
-} from "lucide-react";
+"use client";
+
+import { ArrowUpRight, Disc3, Github, Send, Twitter } from "lucide-react";
+import { motion } from "framer-motion";
 import SectionHeading from "@/components/community/SectionHeading";
 
 const channels = [
@@ -44,7 +41,13 @@ const CommunityChannelsSection = () => {
           subtitle="Find us where the conversation is happening."
         />
 
-        <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4">
+        <motion.div
+          initial={{ opacity: 0, y: 32 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true, margin: "-60px" }}
+          transition={{ duration: 0.5, ease: [0.22, 1, 0.36, 1] }}
+          className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4"
+        >
           {channels.map((channel) => {
             const Icon = channel.icon;
             return (
@@ -68,7 +71,7 @@ const CommunityChannelsSection = () => {
               </a>
             );
           })}
-        </div>
+        </motion.div>
       </div>
     </section>
   );


### PR DESCRIPTION
---

## Description

The `CommunityChannelsSection` component was already fully implemented with all 4 channel cards, responsive grid, neumorphic styles, and correct routing in `page.tsx`. This PR completes the final acceptance criterion by adding a `framer-motion` scroll-triggered animation to the cards grid.

## Changes

**`src/components/community/CommunityChannelsSection.tsx`**
- Added `"use client"` directive (required for framer-motion)
- Imported `motion` from `framer-motion`
- Replaced the plain `<div>` grid wrapper with `<motion.div>` with `whileInView`, `initial`, `viewport`, and `transition` props

## What was already in place
- 4 channel cards: Discord, Telegram, X, GitHub
- Platform icon, name, description, and CTA per card
- Links opening in new tab with `rel="noopener noreferrer"`
- Responsive grid: 1 col → 2 col → 4 col
- Neumorphic `shadow-raised`, `rounded-2xl`, `hover:-translate-y-1`
- `SectionHeading` integration
- Default export matching the import in `page.tsx`

## Testing
- [ ] Section renders at the bottom of `/community`
- [ ] Cards animate in on scroll
- [ ] Animation triggers once (`once: true`)
- [ ] All 4 links open correct URLs in a new tab
- [ ] Responsive grid works on mobile, tablet, desktop