### PR TITLE
feat: implement export to markdown button for docs #1043

### DIFF
--- a/src/components/docs/DocsLayoutShell.tsx
+++ b/src/components/docs/DocsLayoutShell.tsx
@@ -12,6 +12,8 @@ import type { Heading, SidebarSection } from "@/lib/mdx";
 import { DocsSidebar } from "@/components/docs/DocsSidebar";
 import { TableOfContents } from "@/components/docs/TableOfContents";
 import { Navbar } from "@/components/layout/Navbar";
+import { EditOnGitHub } from "@/components/docs/EditOnGitHub";
+import { ExportMarkdown } from "@/components/docs/ExportMarkdown";
 
 // Use production URL for AI assistant links
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://offer-hub.tech";
@@ -120,7 +122,11 @@ export function DocsLayoutShell({ nav, children }: DocsLayoutShellProps) {
             </nav>
 
             {/* "Copy" Component - Compact, Neumorphic, Aligned */}
-            <div className="flex items-center justify-start md:justify-end">
+            <div className="flex items-center justify-start md:justify-end gap-x-6">
+              <div className="hidden sm:flex items-center gap-x-6 mr-2">
+                <EditOnGitHub filePath={`content/docs/${pathname.replace("/docs/", "")}.mdx`} />
+                <ExportMarkdown slug={pathname.replace("/docs/", "")} />
+              </div>
               <DocActionsMenu slug={pathname.replace("/docs/", "")} />
             </div>
           </div>

--- a/src/components/docs/ExportMarkdown.tsx
+++ b/src/components/docs/ExportMarkdown.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { Download } from 'lucide-react';
+
+interface ExportMarkdownProps {
+    slug: string;
+}
+
+export function ExportMarkdown({ slug }: ExportMarkdownProps) {
+    function handleExport() {
+        const el = document.getElementById("doc-metadata-for-actions");
+        if (!el) {
+            console.error("Documentation metadata not found");
+            return;
+        }
+
+        const markdown = el.getAttribute("data-markdown");
+        if (!markdown) {
+            console.error("Documentation content not found");
+            return;
+        }
+
+        const blob = new Blob([markdown], { type: "text/markdown;charset=utf-8" });
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement("a");
+        link.href = url;
+        link.download = `${slug.replace(/\//g, "-")}.md`;
+        document.body.appendChild(link);
+        link.click();
+        link.remove();
+        URL.revokeObjectURL(url);
+    }
+
+    return (
+        <button
+            onClick={handleExport}
+            className="inline-flex items-center gap-1.5 text-sm text-[#6D758F] hover:text-[#149A9B] transition-colors"
+        >
+            <Download size={14} />
+            <span>Export Markdown</span>
+        </button>
+    );
+}


### PR DESCRIPTION
# Tittle: implement export to markdown button for docs #1043
Closes #1043 
## Summary

This PR implements a client-side "Export Markdown" button on all documentation pages. When clicked, it downloads the current page's content as a `.md` file using the browser's Blob API — no external services or APIs involved.

## Changes

- Added [src/components/docs/ExportMarkdown.tsx](cci:7://file:///c:/Trabajos%20Progra/DRIPS-WAVE/offer-hub/src/components/docs/ExportMarkdown.tsx:0:0-0:0) — new reusable client component with a `Download` icon (lucide-react) that triggers a `.md` file download named after the page slug
- Modified [src/components/docs/DocsLayoutShell.tsx](cci:7://file:///c:/Trabajos%20Progra/DRIPS-WAVE/offer-hub/src/components/docs/DocsLayoutShell.tsx:0:0-0:0) — integrated [ExportMarkdown](cci:1://file:///c:/Trabajos%20Progra/DRIPS-WAVE/offer-hub/src/components/docs/ExportMarkdown.tsx:8:0-42:1) and [EditOnGitHub](cci:1://file:///c:/Trabajos%20Progra/DRIPS-WAVE/offer-hub/src/components/docs/EditOnGitHub.tsx:6:0-20:1) buttons into the docs header, placed alongside the existing "Copy" menu

## Checklist

- [x] New [ExportMarkdown](cci:1://file:///c:/Trabajos%20Progra/DRIPS-WAVE/offer-hub/src/components/docs/ExportMarkdown.tsx:8:0-42:1) component created at [src/components/docs/ExportMarkdown.tsx](cci:7://file:///c:/Trabajos%20Progra/DRIPS-WAVE/offer-hub/src/components/docs/ExportMarkdown.tsx:0:0-0:0)
- [x] Uses `Download` icon from `lucide-react`
- [x] Styled consistently with the existing [EditOnGitHub](cci:1://file:///c:/Trabajos%20Progra/DRIPS-WAVE/offer-hub/src/components/docs/EditOnGitHub.tsx:6:0-20:1) button
- [x] Button placed in the docs page header, next to "Edit on GitHub"
- [x] Download triggered via Blob API (fully client-side, no external APIs)
- [x] Downloaded file named using the page slug (e.g. `getting-started.md`)
- [x] Content sourced from the hidden `doc-metadata-for-actions` element

## How to test locally

 from repository root
```bash
cd offer-hub
npm install
npm run dev
```
## Navigate to http://localhost:3000/docs/getting-started
Click "Export Markdown" in the header — a .md file should download automatically

## Notes for reviewer

- The component reads content from the existing hidden `<div id="doc-metadata-for-actions" data-markdown="...">` element already present in the docs page template — no changes to the data layer were needed.
- On small screens (< sm), the buttons are hidden to preserve layout; the "Copy" dropdown menu still provides markdown export functionality on mobile.

## Screenshots/evidence 
<img width="1842" height="986" alt="image" src="https://github.com/user-attachments/assets/59477eea-470a-4387-bfb4-26610af884d6" />
<img width="1184" height="667" alt="image" src="https://github.com/user-attachments/assets/154a6684-04b6-441c-a5cc-f01112283fbf" />
