### PR TITLE
fix(waitlist): use separate fields for purpose and referral

### DIFF
--- a/src/components/community/RegistrationForm.tsx
+++ b/src/components/community/RegistrationForm.tsx
@@ -40,7 +40,8 @@ export default function RegistrationForm() {
                     {
                         email: formData.email,
                         name: formData.name,
-                        company: `${formData.purpose} | Source: ${formData.referral}`
+                        purpose: formData.purpose,
+                        referral: formData.referral
                     }
                 ]);
 


### PR DESCRIPTION
## Summary

This PR fixes the waitlist registration form to store `purpose` and `referral` as separate database columns instead of concatenating them into a single `company` field. This aligns with the updated waitlist table schema in Supabase.

## Changes

- Updated `RegistrationForm.tsx` to insert `purpose` and `referral` as individual fields
- Removed the concatenation logic that combined both fields into `company`

## Checklist

- [x] Form fields map correctly to database columns
- [x] No breaking changes to the registration flow

## How to test locally

1. Navigate to the community page with the waitlist form
2. Fill out and submit the form
3. Verify in Supabase that `purpose` and `referral` are stored as separate columns

## Notes for reviewer

The Supabase table was recreated with the correct schema (`purpose` and `referral` columns instead of `company`). This code change makes the frontend match that schema.