### PR TITLE
feat(dark-mode): add dark mode infrastructure and configuration

### DIFF
--- a/content/docs/guide/style-guide.mdx
+++ b/content/docs/guide/style-guide.mdx
@@ -1,0 +1,266 @@
+---
+title: Style Guide
+description: Design system colors, typography, and component styling for OFFER-HUB.
+order: 11
+section: Guide
+---
+
+This guide documents the OFFER-HUB design system, including colors, typography, and component styling for both light and dark modes.
+
+## Color System
+
+OFFER-HUB uses CSS variables for theme-aware colors. All colors automatically adapt when switching between light and dark modes.
+
+### Background Colors
+
+| Token | Light Mode | Dark Mode | Usage |
+|-------|------------|-----------|-------|
+| `--color-bg-base` | `#F1F3F7` | `#1a1a2e` | Page background |
+| `--color-bg-elevated` | `#ffffff` | `#25253d` | Cards, modals, elevated surfaces |
+| `--color-bg-sunken` | `#e8eaef` | `#12121f` | Inset areas, input backgrounds |
+
+### Text Colors
+
+| Token | Light Mode | Dark Mode | Usage |
+|-------|------------|-----------|-------|
+| `--color-text-primary` | `#19213D` | `#f1f3f7` | Headings, primary text |
+| `--color-text-secondary` | `#6D758F` | `#a0a6b8` | Body text, descriptions |
+| `--color-text-muted` | `#9ca3af` | `#6D758F` | Placeholder text, hints |
+
+### Brand Colors
+
+| Token | Light Mode | Dark Mode | Usage |
+|-------|------------|-----------|-------|
+| `--color-primary` | `#149A9B` | `#1fb8b9` | Primary buttons, links, accents |
+| `--color-primary-hover` | `#0d7377` | `#25d4d5` | Primary hover states |
+| `--color-secondary` | `#002333` | `#002333` | Secondary elements |
+| `--color-accent` | `#15949C` | `#15949C` | Accent highlights |
+
+### Semantic Colors
+
+| Token | Light Mode | Dark Mode | Usage |
+|-------|------------|-----------|-------|
+| `--color-success` | `#16a34a` | `#16a34a` | Success states |
+| `--color-warning` | `#d97706` | `#d97706` | Warning states |
+| `--color-error` | `#FF0000` | `#FF0000` | Error states |
+
+### Shadow Colors (Neumorphic)
+
+| Token | Light Mode | Dark Mode | Usage |
+|-------|------------|-----------|-------|
+| `--shadow-dark` | `#d1d5db` | `#0f0f1a` | Dark shadow in neumorphic effects |
+| `--shadow-light` | `#ffffff` | `#252540` | Light shadow in neumorphic effects |
+
+### Border Colors
+
+| Token | Light Mode | Dark Mode | Usage |
+|-------|------------|-----------|-------|
+| `--color-border` | `#d1d5db` | `#3d3d5c` | Borders, dividers |
+
+---
+
+## Tailwind Utility Classes
+
+Use these Tailwind classes for theme-aware styling:
+
+### Backgrounds
+
+```jsx
+// Page background
+<div className="bg-bg-base" />
+
+// Card/elevated surface
+<div className="bg-bg-elevated" />
+
+// Sunken/inset area
+<div className="bg-bg-sunken" />
+```
+
+### Text
+
+```jsx
+// Primary text (headings)
+<h1 className="text-content-primary" />
+
+// Secondary text (body)
+<p className="text-content-secondary" />
+
+// Muted text (hints)
+<span className="text-content-muted" />
+```
+
+### Brand Colors
+
+```jsx
+// Primary color
+<button className="bg-theme-primary hover:bg-theme-primary-hover" />
+
+// Accent color
+<span className="text-theme-accent" />
+```
+
+### Neumorphic Shadows
+
+```jsx
+// Raised surface
+<div className="shadow-neu-raised" />
+
+// Small raised surface
+<div className="shadow-neu-raised-sm" />
+
+// Sunken/pressed surface
+<div className="shadow-neu-sunken" />
+
+// Subtle sunken
+<div className="shadow-neu-sunken-subtle" />
+```
+
+### Borders
+
+```jsx
+<div className="border border-theme-border" />
+```
+
+---
+
+## Typography
+
+### Font Family
+
+OFFER-HUB uses **Inter** as the primary font:
+
+```css
+font-family: var(--font-inter), Roboto, Outfit, sans-serif;
+```
+
+### Font Weights
+
+| Weight | Class | Usage |
+|--------|-------|-------|
+| 400 | `font-normal` | Body text |
+| 500 | `font-medium` | Emphasis, labels |
+| 700 | `font-bold` | Headings, buttons |
+| 900 | `font-black` | Hero titles |
+
+### Text Sizes
+
+| Size | Class | Usage |
+|------|-------|-------|
+| 12px | `text-xs` | Small labels |
+| 13px | `text-[13px]` | Nav links |
+| 14px | `text-sm` | Body text, buttons |
+| 16px | `text-base` | Default body |
+| 18-24px | `text-lg` to `text-2xl` | Subheadings |
+| 32-48px | `text-3xl` to `text-5xl` | Section titles |
+| 56-72px | `text-6xl` to `text-7xl` | Hero titles |
+
+---
+
+## Component Styling
+
+### Buttons
+
+#### Primary Button (Neumorphic)
+
+```jsx
+<button className="btn-neumorphic-primary px-6 py-2 rounded-full text-sm font-semibold">
+  Button Text
+</button>
+```
+
+#### Secondary Button (Neumorphic)
+
+```jsx
+<button className="btn-neumorphic-secondary px-6 py-2 rounded-full text-sm font-semibold">
+  Button Text
+</button>
+```
+
+### Cards
+
+```jsx
+<div className="bg-bg-elevated shadow-neu-raised rounded-2xl p-6">
+  <h3 className="text-content-primary font-bold">Card Title</h3>
+  <p className="text-content-secondary">Card description</p>
+</div>
+```
+
+### Inputs
+
+```jsx
+<input
+  type="text"
+  className="bg-bg-sunken shadow-neu-sunken-subtle rounded-xl px-4 py-3 text-content-primary placeholder:text-content-muted border-none outline-none"
+  placeholder="Enter text..."
+/>
+```
+
+---
+
+## Z-Index Scale
+
+| Value | Usage |
+|-------|-------|
+| `-1` | Background effects (dot grid) |
+| `0` | Default content |
+| `10` | Elevated cards |
+| `50` | Sticky elements |
+| `100` | Dropdowns |
+| `499` | Mobile menu backdrop |
+| `500` | Navbar |
+| `501` | Mobile menu panel |
+
+<Callout type="warning">
+  Ensure content cards have a higher z-index than background effects (like the dot grid) to prevent visual overlap.
+</Callout>
+
+---
+
+## Dark Mode Implementation
+
+### Using the Theme Toggle
+
+The theme can be toggled using the `useTheme` hook:
+
+```tsx
+import { useTheme } from '@/components/providers/ThemeProvider';
+
+function MyComponent() {
+  const { resolvedTheme, toggleTheme } = useTheme();
+
+  return (
+    <button onClick={toggleTheme}>
+      Current theme: {resolvedTheme}
+    </button>
+  );
+}
+```
+
+### Theme Persistence
+
+Theme preference is automatically saved to `localStorage` under the key `offer-hub-theme` and persists across sessions.
+
+### System Preference
+
+When set to "system", the theme automatically follows the user's OS preference and updates in real-time if changed.
+
+---
+
+## Migration Guide
+
+When migrating components to support dark mode, replace hardcoded colors with theme-aware alternatives:
+
+| Before (Hardcoded) | After (Theme-aware) |
+|--------------------|---------------------|
+| `bg-[#F1F3F7]` | `bg-bg-base` |
+| `bg-white` | `bg-bg-elevated` |
+| `text-[#19213D]` | `text-content-primary` |
+| `text-[#6D758F]` | `text-content-secondary` |
+| `text-[#149A9B]` | `text-theme-primary` |
+| `border-[#d1d5db]` | `border-theme-border` |
+| `style={{ background: "#F1F3F7" }}` | `className="bg-bg-base"` |
+| `style={{ color: "#19213D" }}` | `className="text-content-primary"` |
+
+<Callout type="note">
+  Always test components in both light and dark modes after migration to ensure proper contrast and visibility.
+</Callout>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,9 +2,68 @@
 @tailwind components;
 @tailwind utilities;
 
+/* ══════════════════════════════════════════════════════════════════════════════
+   THEME VARIABLES - Dark Mode Support
+   ══════════════════════════════════════════════════════════════════════════════ */
+
+:root {
+  /* Backgrounds */
+  --color-bg-base: #F1F3F7;
+  --color-bg-elevated: #ffffff;
+  --color-bg-sunken: #e8eaef;
+
+  /* Text */
+  --color-text-primary: #19213D;
+  --color-text-secondary: #6D758F;
+  --color-text-muted: #9ca3af;
+
+  /* Brand */
+  --color-primary: #149A9B;
+  --color-primary-hover: #0d7377;
+  --color-secondary: #002333;
+  --color-accent: #15949C;
+
+  /* Neumorphic shadows */
+  --shadow-dark: #d1d5db;
+  --shadow-light: #ffffff;
+
+  /* Semantic */
+  --color-success: #16a34a;
+  --color-warning: #d97706;
+  --color-error: #FF0000;
+
+  /* Borders */
+  --color-border: #d1d5db;
+}
+
+.dark {
+  /* Backgrounds */
+  --color-bg-base: #1a1a2e;
+  --color-bg-elevated: #25253d;
+  --color-bg-sunken: #12121f;
+
+  /* Text */
+  --color-text-primary: #f1f3f7;
+  --color-text-secondary: #a0a6b8;
+  --color-text-muted: #6D758F;
+
+  /* Brand */
+  --color-primary: #1fb8b9;
+  --color-primary-hover: #25d4d5;
+
+  /* Neumorphic shadows for dark */
+  --shadow-dark: #0f0f1a;
+  --shadow-light: #252540;
+
+  /* Borders */
+  --color-border: #3d3d5c;
+}
+
 /* Subtle page background — faint teal corner glows only (Dot grid handled by React) */
 body {
-  background-color: #F1F3F7;
+  background-color: var(--color-bg-base);
+  color: var(--color-text-primary);
+  transition: background-color 0.3s ease, color 0.3s ease;
 }
 
 body::before {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import Analytics from "@/components/Analytics";
 import { ClientBackground } from "@/components/layout/ClientBackground";
 import { NavigationProgress } from "@/components/ui/NavigationProgress";
 import { FloatingCTA } from "@/components/ui/FloatingCTA";
+import { ThemeProvider } from "@/components/providers/ThemeProvider";
 
 const inter = Inter({
   subsets: ["latin"],
@@ -26,15 +27,17 @@ export default function RootLayout({
   children,
 }: Readonly<{ children: React.ReactNode }>) {
   return (
-    <html lang="en" className={inter.variable}>
+    <html lang="en" className={inter.variable} suppressHydrationWarning>
       <body className={`${inter.className} antialiased relative min-h-screen`}>
-        <Suspense fallback={null}>
-          <NavigationProgress />
-        </Suspense>
-        <Analytics />
-        <ClientBackground />
-        {children}
-        <FloatingCTA />
+        <ThemeProvider>
+          <Suspense fallback={null}>
+            <NavigationProgress />
+          </Suspense>
+          <Analytics />
+          <ClientBackground />
+          {children}
+          <FloatingCTA />
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { Menu, X, Send } from "lucide-react";
 import { cn } from "@/lib/cn";
+import { ThemeToggle } from "@/components/ui/ThemeToggle";
 
 const navLinks = [
   { href: "/#features", label: "Features" },
@@ -120,6 +121,7 @@ export function Navbar() {
 
             {/* ── Desktop CTAs ── */}
             <div className="hidden lg:flex items-center gap-3">
+              <ThemeToggle />
               <a
                 href="#waitlist-form"
                 className="px-6 py-2 rounded-full text-sm font-semibold btn-neumorphic-primary flex items-center gap-2 group"
@@ -193,7 +195,11 @@ export function Navbar() {
               })}
             </div>
 
-            <div className="mt-6 pt-6 border-t border-[#d1d5db]/50">
+            <div className="mt-6 pt-6 border-t border-[#d1d5db]/50 flex flex-col gap-4">
+              <div className="flex items-center justify-between">
+                <span className="text-sm text-[#6D758F]">Theme</span>
+                <ThemeToggle />
+              </div>
               <a
                 href="#waitlist-form"
                 onClick={() => setIsMenuOpen(false)}

--- a/src/components/providers/ThemeProvider.tsx
+++ b/src/components/providers/ThemeProvider.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { createContext, useContext, useEffect, useState, useCallback } from "react";
+
+type Theme = "light" | "dark" | "system";
+type ResolvedTheme = "light" | "dark";
+
+interface ThemeContextType {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+  resolvedTheme: ResolvedTheme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+const STORAGE_KEY = "offer-hub-theme";
+
+function getSystemTheme(): ResolvedTheme {
+  if (typeof window === "undefined") return "light";
+  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>("system");
+  const [resolvedTheme, setResolvedTheme] = useState<ResolvedTheme>("light");
+  const [mounted, setMounted] = useState(false);
+
+  // Initialize theme from localStorage
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY) as Theme | null;
+    if (stored && ["light", "dark", "system"].includes(stored)) {
+      setThemeState(stored);
+    }
+    setMounted(true);
+  }, []);
+
+  // Apply theme to document and update resolved theme
+  useEffect(() => {
+    if (!mounted) return;
+
+    const root = document.documentElement;
+    const resolved: ResolvedTheme = theme === "system" ? getSystemTheme() : theme;
+
+    setResolvedTheme(resolved);
+    root.classList.remove("light", "dark");
+    root.classList.add(resolved);
+  }, [theme, mounted]);
+
+  // Listen for system theme changes
+  useEffect(() => {
+    if (!mounted || theme !== "system") return;
+
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+    const handleChange = () => {
+      const resolved = getSystemTheme();
+      setResolvedTheme(resolved);
+      document.documentElement.classList.remove("light", "dark");
+      document.documentElement.classList.add(resolved);
+    };
+
+    mediaQuery.addEventListener("change", handleChange);
+    return () => mediaQuery.removeEventListener("change", handleChange);
+  }, [theme, mounted]);
+
+  const setTheme = useCallback((newTheme: Theme) => {
+    setThemeState(newTheme);
+    localStorage.setItem(STORAGE_KEY, newTheme);
+  }, []);
+
+  const toggleTheme = useCallback(() => {
+    setTheme(resolvedTheme === "dark" ? "light" : "dark");
+  }, [resolvedTheme, setTheme]);
+
+  // Prevent hydration mismatch by not rendering children until mounted
+  // But still render children to avoid layout shift - just don't apply theme class
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme, resolvedTheme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (context === undefined) {
+    throw new Error("useTheme must be used within a ThemeProvider");
+  }
+  return context;
+}

--- a/src/components/ui/ThemeToggle.tsx
+++ b/src/components/ui/ThemeToggle.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { Sun, Moon } from "lucide-react";
+import { useTheme } from "@/components/providers/ThemeProvider";
+import { cn } from "@/lib/cn";
+
+interface ThemeToggleProps {
+  className?: string;
+  size?: number;
+}
+
+export function ThemeToggle({ className, size = 18 }: ThemeToggleProps) {
+  const { resolvedTheme, toggleTheme } = useTheme();
+
+  return (
+    <button
+      onClick={toggleTheme}
+      className={cn(
+        "p-2 rounded-full transition-all duration-300 ease-out",
+        "bg-bg-base shadow-neu-raised-sm hover:shadow-neu-sunken-subtle",
+        "text-content-secondary hover:text-content-primary",
+        className
+      )}
+      aria-label={`Switch to ${resolvedTheme === "dark" ? "light" : "dark"} mode`}
+      title={`Switch to ${resolvedTheme === "dark" ? "light" : "dark"} mode`}
+    >
+      {resolvedTheme === "dark" ? (
+        <Sun size={size} className="transition-transform duration-300" />
+      ) : (
+        <Moon size={size} className="transition-transform duration-300" />
+      )}
+    </button>
+  );
+}

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,4 +1,4 @@
-import { supabase } from './supabase';
+import { supabase, isSupabaseConfigured } from './supabase';
 
 // Generate a unique visitor ID (fingerprint)
 export function generateVisitorId(): string {
@@ -133,8 +133,8 @@ export async function getGeolocation() {
 
 // Track page view
 export async function trackPageView(pagePath: string, pageTitle?: string) {
-  // Skip tracking if Supabase is not configured (e.g., during build)
-  if (!process.env.NEXT_PUBLIC_SUPABASE_URL || !process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY) {
+  // Skip tracking if Supabase is not properly configured
+  if (!isSupabaseConfigured) {
     return;
   }
 

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -3,6 +3,14 @@ import { createClient } from '@supabase/supabase-js';
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || '';
 const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '';
 
+// Check if Supabase is properly configured (not using placeholders)
+export const isSupabaseConfigured = Boolean(
+  supabaseUrl &&
+  supabaseAnonKey &&
+  !supabaseUrl.includes('placeholder') &&
+  supabaseUrl.includes('supabase')
+);
+
 // During build time, we don't need actual Supabase credentials
 // The client will only be used at runtime in the browser
 export const supabase = createClient(

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,6 +1,7 @@
 import type { Config } from "tailwindcss";
 
 const config: Config = {
+  darkMode: "class",
   content: [
     "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
@@ -13,18 +14,35 @@ const config: Config = {
         sans: ["var(--font-inter)", "Roboto", "Outfit", "sans-serif"],
       },
       colors: {
+        // Legacy colors (kept for backwards compatibility during migration)
         primary: {
           DEFAULT: "#149A9B",
           hover: "#0d7377",
         },
         secondary: "#002333",
-        "accent": "#15949C",
+        accent: "#15949C",
         background: "#F1F3F7",
         "text-primary": "#19213D",
         "text-secondary": "#6D758F",
         success: "#16a34a",
         warning: "#d97706",
         error: "#FF0000",
+
+        // Theme-aware colors (use these for dark mode support)
+        "theme-primary": "var(--color-primary)",
+        "theme-primary-hover": "var(--color-primary-hover)",
+        "theme-secondary": "var(--color-secondary)",
+        "theme-accent": "var(--color-accent)",
+        "bg-base": "var(--color-bg-base)",
+        "bg-elevated": "var(--color-bg-elevated)",
+        "bg-sunken": "var(--color-bg-sunken)",
+        "content-primary": "var(--color-text-primary)",
+        "content-secondary": "var(--color-text-secondary)",
+        "content-muted": "var(--color-text-muted)",
+        "theme-success": "var(--color-success)",
+        "theme-warning": "var(--color-warning)",
+        "theme-error": "var(--color-error)",
+        "theme-border": "var(--color-border)",
       },
       keyframes: {
         fadeInUp: {
@@ -41,12 +59,20 @@ const config: Config = {
         fadeIn: "fadeIn 300ms ease-out both",
       },
       boxShadow: {
+        // Legacy shadows (kept for backwards compatibility)
         raised: "0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04)",
         "raised-sm": "3px 3px 6px #d1d5db, -3px -3px 6px #ffffff",
         sunken: "inset 4px 4px 8px #d1d5db, inset -4px -4px 8px #ffffff",
         "sunken-subtle": "inset 2px 2px 4px #d1d5db, inset -2px -2px 4px #ffffff",
         neu: "4px 4px 8px #d1d5db, -4px -4px 8px #ffffff",
         "neu-inset": "inset 4px 4px 8px #d1d5db, inset -4px -4px 8px #ffffff",
+
+        // Theme-aware neumorphic shadows (use these for dark mode support)
+        "neu-raised": "6px 6px 12px var(--shadow-dark), -6px -6px 12px var(--shadow-light)",
+        "neu-raised-sm": "3px 3px 6px var(--shadow-dark), -3px -3px 6px var(--shadow-light)",
+        "neu-raised-hover": "2px 2px 4px var(--shadow-dark), -2px -2px 4px var(--shadow-light)",
+        "neu-sunken": "inset 4px 4px 8px var(--shadow-dark), inset -4px -4px 8px var(--shadow-light)",
+        "neu-sunken-subtle": "inset 2px 2px 4px var(--shadow-dark), inset -2px -2px 4px var(--shadow-light)",
       },
     },
   },


### PR DESCRIPTION
# Title

feat(dark-mode): add dark mode infrastructure and configuration

## Summary

This PR implements the complete dark mode infrastructure for OFFER-HUB. It sets up CSS variables, Tailwind configuration, ThemeProvider context, and the ThemeToggle component. This enables contributors to easily implement dark mode in individual components/sections using the theme-aware utility classes.

## Changes

- Added CSS variables for light/dark themes in `src/app/globals.css`
- Configured Tailwind with `darkMode: "class"` and theme-aware colors/shadows in `tailwind.config.ts`
- Created `ThemeProvider` with localStorage persistence and system preference detection
- Created `ThemeToggle` component with sun/moon icons
- Integrated `ThemeProvider` in root layout
- Added `ThemeToggle` to Navbar (desktop and mobile)
- Added `style-guide.mdx` documentation with color palette and usage examples
- Fixed analytics errors when Supabase is not configured

## Checklist

- [x] CSS variables defined for light (`:root`) and dark (`.dark`) modes
- [x] Tailwind configured with `darkMode: "class"`
- [x] Theme-aware color utilities: `bg-bg-base`, `text-content-primary`, etc.
- [x] Theme-aware shadow utilities: `shadow-neu-raised`, `shadow-neu-sunken`, etc.
- [x] ThemeProvider persists preference to localStorage
- [x] ThemeProvider respects system preference when set to "system"
- [x] ThemeToggle visible in Navbar (desktop and mobile)
- [x] Documentation added at `/docs/guide/style-guide`
- [x] Build passes successfully
- [x] Lint passes (only pre-existing warnings)

## How to test locally

```bash
# Start dev server
npm run dev

# Visit http://localhost:3000
# Click the moon/sun icon in the navbar to toggle theme
# Verify theme persists on page refresh
# Verify body background changes between #F1F3F7 (light) and #1a1a2e (dark)
```

## Theme-aware Classes Reference

| Type | Classes |
|------|---------|
| Backgrounds | `bg-bg-base`, `bg-bg-elevated`, `bg-bg-sunken` |
| Text | `text-content-primary`, `text-content-secondary`, `text-content-muted` |
| Brand | `text-theme-primary`, `bg-theme-primary` |
| Shadows | `shadow-neu-raised`, `shadow-neu-raised-sm`, `shadow-neu-sunken` |
| Borders | `border-theme-border` |

## Related Issues

This PR enables the following dark mode issues:
- #1107 - #1127 (21 issues for component migration)

## Notes for reviewer

- This PR only sets up the infrastructure; individual components still use hardcoded colors
- Contributors can now migrate components using the new theme-aware classes
- See the style guide at `/docs/guide/style-guide` for implementation details