### PR TITLE
fix: :lipstick: made dark mode text adjustment

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -44,7 +44,7 @@
 
   /* Text */
   --color-text-primary: #f1f3f7;
-  --color-text-secondary: #a0a6b8;
+  --color-text-secondary: #b8bfd0;
   --color-text-muted: #6D758F;
 
   /* Brand */
@@ -87,6 +87,7 @@ body::before {
 }
 
 @layer utilities {
+
   /* Custom scrollbar utilities */
   .scrollbar-thin {
     scrollbar-width: thin;
@@ -279,18 +280,37 @@ body::before {
 
 /* CSS-only fade-in-up animation (replaces framer-motion whileInView) */
 @keyframes fadeInUp {
-  from { opacity: 0; transform: translateY(24px); }
-  to   { opacity: 1; transform: translateY(0); }
+  from {
+    opacity: 0;
+    transform: translateY(24px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 @keyframes fadeIn {
-  from { opacity: 0; }
-  to   { opacity: 1; }
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
 }
 
 @keyframes fadeInScale {
-  from { opacity: 0; transform: scale(0.96); }
-  to   { opacity: 1; transform: scale(1); }
+  from {
+    opacity: 0;
+    transform: scale(0.96);
+  }
+
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
 }
 
 .animate-fadeIn {


### PR DESCRIPTION
 # Dark Mode Global Text Adjustment


 ## Summary

This PR improves text readability in dark mode by adjusting the secondary text color to a lighter shade. The change enhances contrast and visibility for better user experience. Additionally, keyframe animations are reformatted for improved code readability and consistency.

Closes #1126 

 ## Changes

- Updated `--color-text-secondary` from `#a0a6b8` to `#b8bfd0` in dark mode in globals.css
- Reformatted CSS keyframe animations (`fadeInUp`, `fadeIn`, `fadeInScale`) with expanded multi-line formatting for consistency and maintainability
- Added blank line in utilities layer for better code organization

 ## Checklist

 - [x] Dark mode secondary text color updated to lighter shade (`#b8bfd0`)
- [x] New color provides improved contrast and readability
- [x] Keyframe animations reformatted for consistency
- [x] Changes isolated to global styles only
- [x] No impact on component functionality
- [x] Tested in dark mode theme

## How to test locally

```bash
# Toggle to dark mode in your browser dev tools or system preferences
# Verify that secondary text (subtle text throughout the app) 
# appears with improved contrast and readability
```

## Notes for reviewer

- The color change is a brightness adjustment only; no structural changes to the styling system
- Keyframe animation refactoring is a purely cosmetic code improvement with no functional impact
- Test in dark mode to confirm improved text visibility

