### PR TITLE
feat: Dark mode MermaidDiagram

### DIFF
--- a/src/components/docs/MermaidDiagram.tsx
+++ b/src/components/docs/MermaidDiagram.tsx
@@ -101,6 +101,13 @@ export function MermaidDiagram({
               compositeTitleBackground: "#3d3d5c",
               compositeBackground: "#1a1a2e",
               compositeBorder: "#3d3d5c",
+              // Sequence diagram specific
+              noteBkgColor: "#25253d",
+              noteTextColor: "#f1f3f7",
+              noteBorderColor: "#3d3d5c",
+              actorBkg: "#25253d",
+              actorTextColor: "#f1f3f7",
+              actorBorder: "#3d3d5c",
             }
           : {
               // Primary colors - light teal background with dark text


### PR DESCRIPTION
## Dark Mode Support for MermaidDiagram Component

Closes #1125 

## Problem
The `MermaidDiagram` component had `mermaid.initialize()` called once at the module level with hardcoded light theme variables. This meant diagrams never responded to theme changes — dark mode users saw light-themed diagrams with poor contrast and readability.

## Solution
Moved `mermaid.initialize()` inside the `useEffect` hook and wired it up to the current theme using `useTheme`, so diagrams re-render with the correct theme variables whenever the user switches between light and dark mode.

## Changes Made
- **Removed** static `mermaid.initialize()` call at module level
- **Added** `useTheme` hook to detect `resolvedTheme` inside the component
- **Moved** `mermaid.initialize()` into `useEffect` with conditional dark/light theme variable sets
- **Added** `resolvedTheme` to the `useEffect` dependency array to trigger re-render on theme switch

## Acceptance Criteria
- [x] Mermaid diagrams detect current theme
- [x] Node text is readable in dark mode
- [x] Edge/arrow colors are visible in dark mode
- [x] Node backgrounds adapt to dark mode
- [x] Labels and annotations are readable
- [x] Diagram container background matches theme
- [x] Works with flowcharts, sequence diagrams, and other diagram types

## Testing
- Switch between light and dark mode and verify diagrams re-render correctly
- Test with flowchart and sequence diagram types
- Verify text, nodes, edges, and labels are all readable in both modes