### PR TITLE
fix: use CSS variables for hero section text colors in dark mode

### DIFF
--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -122,10 +122,10 @@ export default function HeroSection() {
         {/* Tagline — product-accurate description */}
         <p
           className="animate-fadeInUp mt-10 text-lg md:text-xl font-light max-w-xl leading-relaxed"
-          style={{ color: "#6D758F", animationDelay: "300ms" }}
+          style={{ color: "var(--color-text-secondary)", animationDelay: "300ms" }}
         >
           A payments orchestrator for modern marketplaces.{" "}
-          <span className="font-semibold" style={{ color: "#19213D" }}>
+          <span className="font-semibold" style={{ color: "var(--color-text-primary)" }}>
             Zero custodial risk. Complete developer control.
           </span>
         </p>


### PR DESCRIPTION
## 🔧 Fix: Dark Mode Text Colors in Hero Section

Closes #1109

## 📘 Description
Replaced hardcoded color values in `HeroSection.tsx` with CSS theme 
variables so the tagline text adapts correctly in dark mode alongside 
the CTA buttons.

## 🛠 Changes Made
- `style={{ color: "#6D758F" }}` → `style={{ color: "var(--color-text-secondary)" }}`
- `style={{ color: "#19213D" }}` → `style={{ color: "var(--color-text-primary)" }}`

**File modified:** `src/components/HeroSection.tsx`

## ✅ Acceptance Criteria Checklist
- [x] Primary CTA button adapts to dark mode
- [x] Secondary button uses theme-aware shadows
- [x] Button text remains readable in both modes
- [x] Hover and active states work in dark mode
- [x] Tested in both light and dark themes

## 📸 Screenshots

### Before

<img width="1913" height="1035" alt="Screenshot From 2026-03-08 10-55-46" src="https://github.com/user-attachments/assets/88d82a16-b31a-4c93-969b-b4c8b3c6575c" />


### After


<img width="1915" height="1023" alt="Screenshot From 2026-03-08 10-58-51" src="https://github.com/user-attachments/assets/d1e3a93c-6d24-45f7-b4fb-cb8c6beeb1f7" />


<img width="1915" height="1023" alt="Screenshot From 2026-03-08 11-03-20" src="https://github.com/user-attachments/assets/39f119ef-bd4e-4e93-90c7-327332ee68e7" />
