### PR TITLE
fix: Dark mode: Footer #1114

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -64,19 +64,10 @@ export function Footer() {
   }, []);
 
   return (
-    <footer
-      className="bg-transparent pt-4 pb-0 relative"
-    >
+    <footer className="bg-transparent pt-4 pb-0 relative">
       <div className="max-w-6xl mx-auto px-6 lg:px-8">
-        {/* ── White card ── */}
-        <div
-          className="rounded-3xl px-10 py-10"
-          style={{
-            background: "#ffffff",
-            boxShadow:
-              "0 4px 32px rgba(0,0,0,0.07), 0 1px 4px rgba(0,0,0,0.04)",
-          }}
-        >
+        {/* ── Card ── */}
+        <div className="rounded-3xl px-10 py-10 bg-bg-elevated shadow-neu-raised">
           <div className="flex flex-col md:flex-row gap-10 md:gap-16">
             {/* Left — logo + desc + socials */}
             <div className="flex flex-col gap-5 md:w-64 flex-shrink-0">
@@ -89,10 +80,7 @@ export function Footer() {
                   className="h-7 w-auto object-contain"
                 />
               </Link>
-              <p
-                className="text-sm leading-relaxed"
-                style={{ color: "#6D758F" }}
-              >
+              <p className="text-sm leading-relaxed text-content-secondary">
                 Empowering freelancers and businesses with secure,
                 blockchain-powered solutions — making work easier to find,
                 manage, and pay.
@@ -105,16 +93,7 @@ export function Footer() {
                     aria-label={s.label}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="transition-colors duration-200"
-                    style={{ color: "#6D758F" }}
-                    onMouseEnter={(e) =>
-                    ((e.currentTarget as HTMLAnchorElement).style.color =
-                      "#19213D")
-                    }
-                    onMouseLeave={(e) =>
-                    ((e.currentTarget as HTMLAnchorElement).style.color =
-                      "#6D758F")
-                    }
+                    className="text-content-secondary hover:text-content-primary transition-colors duration-200"
                   >
                     <s.icon size={18} />
                   </a>
@@ -125,14 +104,8 @@ export function Footer() {
             {/* Right — nav columns */}
             <div className="flex flex-1 gap-8 md:gap-12 flex-wrap">
               {navColumns.map((col) => (
-                <div
-                  key={col.heading}
-                  className="flex flex-col gap-4 min-w-[100px]"
-                >
-                  <h4
-                    className="text-sm font-semibold"
-                    style={{ color: "#19213D" }}
-                  >
+                <div key={col.heading} className="flex flex-col gap-4 min-w-[100px]">
+                  <h4 className="text-sm font-semibold text-content-primary">
                     {col.heading}
                   </h4>
                   <ul className="flex flex-col gap-3">
@@ -140,18 +113,7 @@ export function Footer() {
                       <li key={link.label}>
                         <a
                           href={link.href}
-                          className="text-sm transition-colors duration-200"
-                          style={{ color: "#6D758F" }}
-                          onMouseEnter={(e) =>
-                          ((
-                            e.currentTarget as HTMLAnchorElement
-                          ).style.color = "#19213D")
-                          }
-                          onMouseLeave={(e) =>
-                          ((
-                            e.currentTarget as HTMLAnchorElement
-                          ).style.color = "#6D758F")
-                          }
+                          className="text-sm text-content-secondary hover:text-content-primary transition-colors duration-200"
                         >
                           {link.label}
                         </a>
@@ -164,14 +126,11 @@ export function Footer() {
           </div>
 
           {/* Divider + bottom bar */}
-          <div
-            className="mt-10 pt-6 flex flex-col sm:flex-row items-center justify-between gap-2 border-t"
-            style={{ borderColor: "#e5e7eb" }}
-          >
-            <p className="text-xs" style={{ color: "#9ca3af" }}>
+          <div className="mt-10 pt-6 flex flex-col sm:flex-row items-center justify-between gap-2 border-t border-theme-border">
+            <p className="text-xs text-content-muted">
               © {new Date().getFullYear()} OFFER-HUB. All rights reserved.
             </p>
-            <p className="text-xs" style={{ color: "#9ca3af" }}>
+            <p className="text-xs text-content-muted">
               Powered by Stellar Blockchain
             </p>
           </div>
@@ -185,11 +144,11 @@ export function Footer() {
       >
         <div
           ref={textRef}
-          className="select-none pointer-events-none leading-none mt-2 whitespace-nowrap mx-auto"
+          className="select-none pointer-events-none leading-none mt-2 whitespace-nowrap mx-auto text-theme-primary"
           style={{
             fontWeight: 900,
             letterSpacing: "-0.03em",
-            color: "rgba(25,33,61,0.12)",
+            opacity: 0.3,
             WebkitMaskImage:
               "linear-gradient(to bottom, black 0%, black 30%, transparent 75%)",
             maskImage:


### PR DESCRIPTION
Summary                                                                                                               
  This PR implements dark mode support for the Footer component, replacing all hardcoded color values with theme-aware
  CSS variable tokens. It also fixes a bug where the large decorative "_OFFER-HUB" watermark text disappeared in dark
  mode due to its color blending into the dark background.

  Changes

  - Updated card background from hardcoded #ffffff to bg-bg-elevated shadow-neu-raised in
  src/components/layout/Footer.tsx
  - Replaced all hardcoded text colors with theme tokens: text-content-secondary, text-content-primary,
  text-content-muted
  - Replaced JS-based onMouseEnter/onMouseLeave hover handlers on social icons and nav links with Tailwind hover:
  classes
  - Fixed divider color from hardcoded #e5e7eb to border-theme-border
  - Fixed decorative "_OFFER-HUB" watermark: changed from rgba(25,33,61,0.12) (invisible in dark) to text-theme-primary
  (teal, visible in both modes)

  Checklist

  - Footer background uses bg-bg-elevated
  - Navigation links use theme-aware text colors
  - Social icons are visible in dark mode
  - Fix: Large "_OFFER-HUB" decorative text uses text-theme-primary (teal)
  - Copyright text uses text-content-muted
  - Dividers use border-theme-border
  - Tested in both light and dark modes

  How to test locally

  # from repository root
  npm run dev

  Toggle dark mode and visit any page with the footer. Verify all text, links, icons, and the watermark remain visible
  and correctly colored in both modes.

  Notes for reviewer

  - All color changes use existing CSS variable tokens from src/app/globals.css — no new tokens were introduced.
  - JS hover handlers were removed in favor of Tailwind hover: utility classes, which behave correctly across both
  themes.

  Suggested PR title

  fix(footer): add dark mode support and fix watermark visibility

<img width="1366" height="669" alt="Screenshot (1658)" src="https://github.com/user-attachments/assets/7993f442-dd1e-4f83-b194-5c39b95bb842" />

closes #1114 
