### PR TITLE
fix: Dark mode - Community Hero + Stats

### DIFF
--- a/src/components/community/HeroRepoStatsSection.tsx
+++ b/src/components/community/HeroRepoStatsSection.tsx
@@ -27,10 +27,10 @@ const HeroRepoStatsSection = ({ stats }: HeroRepoStatsSectionProps) => {
             <p className="mb-6 text-[11px] font-black uppercase tracking-[0.4em] text-[#149A9B]">
               Community Network
             </p>
-            <h1 className="text-5xl font-black tracking-tighter text-[#19213D] md:text-7xl leading-[1.05]">
-              Building the Future <br />of <span className="text-[#149A9B]">Payments</span>
+            <h1 className="text-5xl font-black tracking-tighter text-content-primary md:text-7xl leading-[1.05]">
+              Building the Future <br />of <span className="text-theme-primary">Payments</span>
             </h1>
-            <p className="mt-8 max-w-xl text-lg font-medium leading-relaxed text-[#6D758F]">
+            <p className="mt-8 max-w-xl text-lg font-medium leading-relaxed text-content-secondary">
               A global decentralized community of {stats.contributors} contributors
               shipping modular infrastructure every day.
             </p>
@@ -52,18 +52,18 @@ const HeroRepoStatsSection = ({ stats }: HeroRepoStatsSectionProps) => {
               {repoStats.map((stat) => (
                 <div
                   key={stat.label}
-                  className="group rounded-3xl bg-[#F1F3F7] p-6 shadow-raised transition-all duration-500 hover:scale-[1.02]"
+                  className="group rounded-3xl bg-bg-elevated shadow-neu-raised p-6 transition-all duration-500 hover:scale-[1.02]"
                 >
                   <div className="flex items-center justify-between mb-4">
-                    <div className="p-2.5 rounded-xl bg-[#F1F3F7] shadow-sunken-subtle">
+                    <div className="p-2.5 rounded-xl bg-bg-sunken shadow-neu-sunken-subtle">
                       <stat.icon size={18} className={`${stat.color} transition-transform group-hover:scale-110`} />
                     </div>
-                    <div className="h-1 w-4 rounded-full bg-black/5" />
+                    <div className="h-1 w-4 rounded-full bg-theme-primary/20" />
                   </div>
-                  <p className="text-[10px] font-bold uppercase tracking-widest text-[#6D758F]/60">
+                  <p className="text-[10px] font-bold uppercase tracking-widest text-content-secondary">
                     {stat.label}
                   </p>
-                  <p className="mt-1 text-3xl font-black text-[#19213D] tracking-tight">
+                  <p className="mt-1 text-3xl font-black text-content-primary tracking-tight">
                     {stats[stat.label.toLowerCase().replace(" ", "") as keyof typeof stats] || stat.value}
                   </p>
                 </div>

--- a/src/components/community/RepoLinksSection.tsx
+++ b/src/components/community/RepoLinksSection.tsx
@@ -23,7 +23,7 @@ export default function RepoLinksSection() {
         <section id="repo-links" className="py-12 bg-transparent">
             <div className="mx-auto max-w-7xl px-6 lg:px-8">
                 <div className="flex flex-col items-center">
-                    <div className="w-12 h-1 rounded-full bg-[#149A9B]/20 mb-12" />
+                    <div className="w-12 h-1 rounded-full bg-theme-primary/20 mb-12" />
 
                     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8 w-full">
                         {repos.map((repo) => (
@@ -32,23 +32,23 @@ export default function RepoLinksSection() {
                                 href={repo.url}
                                 target="_blank"
                                 rel="noopener noreferrer"
-                                className="group relative flex items-center gap-5 p-6 rounded-3xl bg-[#F1F3F7] shadow-raised transition-all duration-300 active:shadow-sunken hover:scale-[1.02]"
+                                className="group relative flex items-center gap-5 p-6 rounded-3xl bg-bg-elevated shadow-neu-raised transition-all duration-300 active:shadow-neu-sunken hover:scale-[1.02]"
                             >
-                                <div className="w-14 h-14 rounded-2xl bg-[#F1F3F7] shadow-raised-sm flex items-center justify-center flex-shrink-0 group-hover:shadow-sunken transition-all duration-500">
-                                    <Github size={24} className="text-[#149A9B]" />
+                                <div className="w-14 h-14 rounded-2xl bg-bg-sunken shadow-neu-sunken flex items-center justify-center flex-shrink-0 group-hover:shadow-neu-sunken-subtle transition-all duration-500">
+                                    <Github size={24} className="text-theme-primary" />
                                 </div>
 
                                 <div className="min-w-0">
-                                    <h3 className="text-sm font-black uppercase tracking-widest text-[#19213D] flex items-center gap-2">
+                                    <h3 className="text-sm font-black uppercase tracking-widest text-content-primary flex items-center gap-2">
                                         {repo.name}
-                                        <FolderGit2 size={12} className="text-[#6D758F]/40" />
+                                        <FolderGit2 size={12} className="text-content-secondary/40" />
                                     </h3>
-                                    <p className="text-[11px] font-medium text-[#6D758F] mt-1 truncate">
+                                    <p className="text-[11px] font-medium text-content-secondary mt-1 truncate">
                                         {repo.description}
                                     </p>
                                 </div>
 
-                                <div className="absolute top-4 right-4 w-1.5 h-1.5 rounded-full bg-[#149A9B] opacity-0 group-hover:opacity-100 transition-opacity" />
+                                <div className="absolute top-4 right-4 w-1.5 h-1.5 rounded-full bg-theme-primary opacity-0 group-hover:opacity-100 transition-opacity" />
                             </a>
                         ))}
                     </div>


### PR DESCRIPTION
## Summary

Implements dark mode support for the Community page hero section and repository stats as per the issue requirements.

## Changes

### HeroRepoStatsSection.tsx
- Hero title:  (adapts to dark mode)
- Hero accent:  (adapts to dark mode)
- Hero description:  (adapts to dark mode)
- Stats cards:  (neumorphic styling)
- Stat labels: 
- Stat numbers: 

### RepoLinksSection.tsx
- Repo cards:  (neumorphic styling)
- GitHub icons:  (visible in dark mode)
- Repo names/descriptions: /

## Acceptance Criteria
- [x] Hero title uses text-content-primary
- [x] Hero description uses text-content-secondary
- [x] Stats cards have neumorphic styling
- [x] Stat numbers are clearly visible
- [x] Repository link cards adapt to dark mode
- [x] GitHub icons are visible in dark mode

closes #1117