### PR TITLE
fix(docs): add dark mode support for docs layout (#1121)

### DIFF
--- a/src/components/docs/DocsLayoutShell.tsx
+++ b/src/components/docs/DocsLayoutShell.tsx
@@ -88,7 +88,7 @@ export function DocsLayoutShell({ nav, children }: DocsLayoutShellProps) {
   }
 
   return (
-    <div className="min-h-screen bg-transparent">
+    <div className="min-h-screen bg-bg-base">
       <Navbar />
 
       <div className="pt-40 pb-10">
@@ -188,17 +188,17 @@ export function DocsLayoutShell({ nav, children }: DocsLayoutShellProps) {
             onClick={() => setIsDrawerOpen(false)}
           />
           <aside
-            className="relative h-full w-80 max-w-[85vw] p-8 bg-[#F1F3F7]"
+            className="relative h-full w-80 max-w-[85vw] p-8 bg-bg-base shadow-neu-raised"
             style={{ borderTopRightRadius: "30px", borderBottomRightRadius: "30px" }}
           >
-            <div className="mb-8 flex items-center justify-between pb-4 border-b border-[#D1D5DB]/30">
+            <div className="mb-8 flex items-center justify-between pb-4 border-b border-theme-border/40">
               <p className="text-sm font-bold uppercase tracking-widest text-[#149A9B]">
                 Navigation
               </p>
               <button
                 type="button"
                 onClick={() => setIsDrawerOpen(false)}
-                className="inline-flex items-center justify-center p-2 rounded-lg text-[#6D758F] hover:bg-[#149A9B]/5 hover:text-[#19213D] transition-all"
+                className="inline-flex items-center justify-center p-2 rounded-lg text-content-secondary hover:bg-bg-elevated hover:text-content-primary transition-all"
                 aria-label="Close docs navigation"
               >
                 <X size={20} />

--- a/src/components/docs/DocsPagination.tsx
+++ b/src/components/docs/DocsPagination.tsx
@@ -14,31 +14,23 @@ interface DocsPaginationProps {
 export function DocsPagination({ prev, next }: DocsPaginationProps) {
   return (
     <nav
-      className="border-t mt-12 pt-6 flex justify-between"
-      style={{ borderColor: "#e5e7eb" }}
+      className="border-t border-theme-border/50 mt-12 pt-6 flex justify-between gap-4"
       aria-label="Documentation pagination"
     >
       {prev ? (
         <Link
           href={prev.href}
-          className="flex items-start gap-3 group max-w-[45%]"
+          className="flex items-start gap-3 group max-w-[45%] rounded-2xl bg-bg-base shadow-neu-raised px-4 py-3 transition-all duration-200 hover:shadow-neu-raised-hover active:shadow-neu-sunken-subtle"
         >
           <ArrowLeft
             size={20}
-            className="mt-0.5 flex-shrink-0 transition-transform group-hover:-translate-x-1"
-            style={{ color: "#149A9B" }}
+            className="mt-0.5 flex-shrink-0 transition-transform group-hover:-translate-x-1 text-theme-primary"
           />
           <div className="flex flex-col gap-1">
-            <span
-              className="text-xs uppercase tracking-widest"
-              style={{ color: "#6D758F" }}
-            >
+            <span className="text-xs uppercase tracking-widest text-content-secondary">
               Previous
             </span>
-            <span
-              className="text-sm font-semibold transition-colors"
-              style={{ color: "#19213D" }}
-            >
+            <span className="text-sm font-semibold transition-colors text-content-primary group-hover:text-theme-primary">
               {prev.title}
             </span>
           </div>
@@ -50,26 +42,19 @@ export function DocsPagination({ prev, next }: DocsPaginationProps) {
       {next ? (
         <Link
           href={next.href}
-          className="flex items-start gap-3 group max-w-[45%] ml-auto text-right"
+          className="flex items-start gap-3 group max-w-[45%] ml-auto text-right rounded-2xl bg-bg-base shadow-neu-raised px-4 py-3 transition-all duration-200 hover:shadow-neu-raised-hover active:shadow-neu-sunken-subtle"
         >
           <div className="flex flex-col gap-1">
-            <span
-              className="text-xs uppercase tracking-widest"
-              style={{ color: "#6D758F" }}
-            >
+            <span className="text-xs uppercase tracking-widest text-content-secondary">
               Next
             </span>
-            <span
-              className="text-sm font-semibold transition-colors group-hover:text-[#149A9B]"
-              style={{ color: "#19213D" }}
-            >
+            <span className="text-sm font-semibold transition-colors text-content-primary group-hover:text-theme-primary">
               {next.title}
             </span>
           </div>
           <ArrowRight
             size={20}
-            className="mt-0.5 flex-shrink-0 transition-transform group-hover:translate-x-1"
-            style={{ color: "#149A9B" }}
+            className="mt-0.5 flex-shrink-0 transition-transform group-hover:translate-x-1 text-theme-primary"
           />
         </Link>
       ) : (

--- a/src/components/docs/DocsSearchBar.tsx
+++ b/src/components/docs/DocsSearchBar.tsx
@@ -91,7 +91,7 @@ export default function DocsSearchBar() {
         indices.forEach(([start, end]: [number, number], idx: number) => {
             parts.push(text.slice(lastIndex, start));
             parts.push(
-                <span key={idx} className="bg-[rgba(20,154,155,0.15)] text-[#149A9B] rounded px-0.5">
+                <span key={idx} className="bg-theme-primary/15 text-theme-primary rounded px-0.5">
                     {text.slice(start, end + 1)}
                 </span>
             );
@@ -113,20 +113,21 @@ export default function DocsSearchBar() {
                     onKeyDown={handleKeyDown}
                     icon={<Search size={20} />}
                     iconPosition="left"
+                    className="!bg-bg-sunken !shadow-neu-sunken-subtle !text-content-primary !placeholder:text-content-secondary focus:!ring-theme-primary"
                     rightElement={
                         query ? (
                             <button
                                 onClick={() => { setQuery(""); setResults([]); setIsOpen(false); }}
-                                className="text-[#6D758F] hover:text-[#19213D] transition-colors flex items-center justify-center h-full px-2"
+                                className="text-content-secondary hover:text-content-primary transition-colors flex items-center justify-center h-full px-2"
                             >
                                 <X size={18} />
                             </button>
                         ) : (
-                            <div className="flex items-center gap-1.5 pr-2 pointer-events-none text-[#6D758F]">
-                                <kbd className="flex items-center justify-center min-w-[24px] h-[24px] text-[11px] font-sans font-medium rounded-md shadow-[2px_2px_4px_#d1d5db,-2px_-2px_4px_#ffffff] bg-[#F1F3F7]">
+                            <div className="flex items-center gap-1.5 pr-2 pointer-events-none text-content-secondary">
+                                <kbd className="flex items-center justify-center min-w-[24px] h-[24px] text-[11px] font-sans font-medium rounded-md shadow-neu-raised-sm bg-bg-base text-content-primary">
                                     ⌘
                                 </kbd>
-                                <kbd className="flex items-center justify-center min-w-[24px] h-[24px] text-[11px] font-sans font-medium rounded-md shadow-[2px_2px_4px_#d1d5db,-2px_-2px_4px_#ffffff] bg-[#F1F3F7]">
+                                <kbd className="flex items-center justify-center min-w-[24px] h-[24px] text-[11px] font-sans font-medium rounded-md shadow-neu-raised-sm bg-bg-base text-content-primary">
                                     K
                                 </kbd>
                             </div>
@@ -136,7 +137,7 @@ export default function DocsSearchBar() {
             </div>
 
             {isOpen && results.length > 0 && (
-                <div className="absolute top-full mt-3 w-full rounded-2xl overflow-hidden z-[100] shadow-[0_20px_50px_rgba(0,0,0,0.15),0_0_0_1px_rgba(0,0,0,0.05)] animate-in fade-in slide-in-from-top-2 duration-200" style={{ background: "rgba(255, 255, 255, 0.98)", backdropFilter: "blur(16px)" }}>
+                <div className="absolute top-full mt-3 w-full rounded-2xl overflow-hidden z-[100] animate-in fade-in slide-in-from-top-2 duration-200 bg-bg-elevated/95 border border-theme-border/40 shadow-neu-raised backdrop-blur-xl">
                     <div className="max-h-[450px] overflow-y-auto">
                         {results.map((result, idx) => (
                             <div
@@ -150,37 +151,36 @@ export default function DocsSearchBar() {
                                 className="p-4 flex items-start gap-4 cursor-pointer transition-colors"
                                 style={{
                                     backgroundColor: activeIndex === idx ? "rgba(20, 154, 155, 0.08)" : "transparent",
-                                    color: activeIndex === idx ? "#149A9B" : "#6D758F"
                                 }}
                             >
-                                <div className="mt-1 p-2 rounded-lg" style={{ background: activeIndex === idx ? "rgba(20, 154, 155, 0.12)" : "rgba(241, 243, 247, 0.8)" }}>
-                                    <FileText size={18} style={{ color: activeIndex === idx ? "#149A9B" : "#9CA3AF" }} />
+                                <div className={`mt-1 p-2 rounded-lg ${activeIndex === idx ? "bg-theme-primary/10 shadow-neu-sunken-subtle" : "bg-bg-base shadow-neu-raised-sm"}`}>
+                                    <FileText size={18} className={activeIndex === idx ? "text-theme-primary" : "text-content-secondary"} />
                                 </div>
                                 <div className="flex-1">
                                     <div className="flex items-center gap-2 mb-1">
-                                        <span className="text-sm font-semibold text-gray-900">
+                                        <span className={`text-sm font-semibold ${activeIndex === idx ? "text-theme-primary" : "text-content-primary"}`}>
                                             {highlightMatch(result.item.title, result.matches, "title")}
                                         </span>
-                                        <ChevronRight size={14} className="text-gray-300" />
-                                        <span className="text-sm font-medium text-gray-500">
+                                        <ChevronRight size={14} className="text-content-secondary/40" />
+                                        <span className="text-sm font-medium text-content-secondary">
                                             {highlightMatch(result.item.section, result.matches, "section")}
                                         </span>
                                     </div>
-                                    <p className="text-sm text-gray-500 line-clamp-2 leading-relaxed">
+                                    <p className="text-sm text-content-secondary line-clamp-2 leading-relaxed">
                                         {highlightMatch(result.item.content, result.matches, "content")}
                                     </p>
                                 </div>
                             </div>
                         ))}
                     </div>
-                    <div className="p-3 flex justify-between items-center text-[10px] font-bold tracking-wider uppercase" style={{ background: "rgba(241, 243, 247, 0.6)", color: "#9CA3AF", borderTop: "1px solid rgba(209, 213, 219, 0.3)" }}>
+                    <div className="p-3 flex justify-between items-center text-[10px] font-bold tracking-wider uppercase bg-bg-sunken/60 text-content-secondary border-t border-theme-border/40">
                         <span>{results.length} results found</span>
                         <div className="flex gap-3">
                             <span className="flex items-center gap-1">
-                                <kbd className="px-1 py-0.5 rounded" style={{ background: "rgba(255, 255, 255, 0.8)", border: "1px solid rgba(209, 213, 219, 0.3)" }}>↑↓</kbd> Navigate
+                                <kbd className="px-1 py-0.5 rounded bg-bg-base border border-theme-border/40 text-content-primary">↑↓</kbd> Navigate
                             </span>
                             <span className="flex items-center gap-1">
-                                <kbd className="px-1 py-0.5 rounded" style={{ background: "rgba(255, 255, 255, 0.8)", border: "1px solid rgba(209, 213, 219, 0.3)" }}>↵</kbd> Select
+                                <kbd className="px-1 py-0.5 rounded bg-bg-base border border-theme-border/40 text-content-primary">↵</kbd> Select
                             </span>
                         </div>
                     </div>
@@ -188,9 +188,9 @@ export default function DocsSearchBar() {
             )}
 
             {isOpen && query.length > 1 && results.length === 0 && (
-                <div className="absolute top-full mt-3 w-full rounded-2xl p-8 text-center z-[100] shadow-[0_20px_50px_rgba(0,0,0,0.15),0_0_0_1px_rgba(0,0,0,0.05)] animate-in fade-in slide-in-from-top-2" style={{ background: "rgba(255, 255, 255, 0.98)", backdropFilter: "blur(16px)" }}>
-                    <p style={{ color: "#6D758F" }}>No results found for &quot;<span className="font-semibold">{query}</span>&quot;</p>
-                    <p className="text-sm mt-1" style={{ color: "#9CA3AF" }}>Try a different search term</p>
+                <div className="absolute top-full mt-3 w-full rounded-2xl p-8 text-center z-[100] animate-in fade-in slide-in-from-top-2 bg-bg-elevated/95 border border-theme-border/40 shadow-neu-raised backdrop-blur-xl">
+                    <p className="text-content-secondary">No results found for &quot;<span className="font-semibold text-content-primary">{query}</span>&quot;</p>
+                    <p className="text-sm mt-1 text-content-secondary/80">Try a different search term</p>
                 </div>
             )}
         </div>

--- a/src/components/docs/DocsSidebar.tsx
+++ b/src/components/docs/DocsSidebar.tsx
@@ -20,19 +20,19 @@ interface DocsSidebarProps {
 
 const getIconForSlug = (slug: string, isActive: boolean) => {
   const s = slug.toLowerCase();
-  const color = isActive ? "#149A9B" : "#6D758F";
+  const iconClass = isActive ? "text-theme-primary" : "text-content-secondary";
 
-  if (s.includes("api") || s.includes("dev") || s.includes("code")) return <Code size={16} color={color} />;
-  if (s.includes("start") || s.includes("intro") || s.includes("welcome")) return <Rocket size={16} color={color} />;
-  if (s.includes("escrow") || s.includes("contract")) return <Shield size={16} color={color} />;
-  if (s.includes("sdk") || s.includes("tool")) return <Box size={16} color={color} />;
-  if (s.includes("config") || s.includes("setting")) return <Settings size={16} color={color} />;
-  if (s.includes("flow") || s.includes("lifecycle")) return <Workflow size={16} color={color} />;
-  if (s.includes("helper") || s.includes("util")) return <Zap size={16} color={color} />;
-  if (s.includes("design") || s.includes("ui") || s.includes("view")) return <Layers size={16} color={color} />;
-  if (s.includes("network") || s.includes("stellar")) return <Compass size={16} color={color} />;
+  if (s.includes("api") || s.includes("dev") || s.includes("code")) return <Code size={16} className={iconClass} />;
+  if (s.includes("start") || s.includes("intro") || s.includes("welcome")) return <Rocket size={16} className={iconClass} />;
+  if (s.includes("escrow") || s.includes("contract")) return <Shield size={16} className={iconClass} />;
+  if (s.includes("sdk") || s.includes("tool")) return <Box size={16} className={iconClass} />;
+  if (s.includes("config") || s.includes("setting")) return <Settings size={16} className={iconClass} />;
+  if (s.includes("flow") || s.includes("lifecycle")) return <Workflow size={16} className={iconClass} />;
+  if (s.includes("helper") || s.includes("util")) return <Zap size={16} className={iconClass} />;
+  if (s.includes("design") || s.includes("ui") || s.includes("view")) return <Layers size={16} className={iconClass} />;
+  if (s.includes("network") || s.includes("stellar")) return <Compass size={16} className={iconClass} />;
 
-  return <FileText size={16} color={color} />;
+  return <FileText size={16} className={iconClass} />;
 };
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -50,13 +50,13 @@ export function DocsSidebar({ nav, className }: DocsSidebarProps) {
     <nav
       aria-label="Documentation navigation"
       className={cn(
-        "w-full rounded-3xl p-5 shadow-[8px_8px_16px_#d1d5db,-8px_-8px_16px_#ffffff] bg-[#F1F3F7] flex flex-col",
+        "w-full rounded-3xl p-5 shadow-neu-raised bg-bg-base flex flex-col",
         className
       )}
     >
       <div className="flex-1 space-y-6 overflow-y-auto scrollbar-thin pr-1">
         <div>
-          <div className="px-5 mb-3 text-[11px] font-extrabold uppercase tracking-widest text-[#6D758F]">
+          <div className="px-5 mb-3 text-[11px] font-extrabold uppercase tracking-widest text-content-primary">
             Overview
           </div>
           <ul role="list" className="space-y-1.5">
@@ -82,7 +82,7 @@ export function DocsSidebar({ nav, className }: DocsSidebarProps) {
 
           return (
             <div key={section.section} className="mt-6">
-              <div className="px-5 mb-3 text-[11px] font-extrabold uppercase tracking-widest text-[#6D758F]">
+              <div className="px-5 mb-3 text-[11px] font-extrabold uppercase tracking-widest text-content-primary">
                 {section.section}
               </div>
               <ul role="list" className="space-y-1.5">
@@ -112,14 +112,14 @@ function SidebarItem({ href, icon, label, isActive }: { href: string; icon: Reac
         aria-current={isActive ? "page" : undefined}
         className={cn(
           "group flex items-center gap-3.5 text-sm py-2.5 px-5 rounded-2xl transition-all duration-300 font-medium",
-          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#149A9B] focus-visible:ring-offset-2",
-          "bg-[#F1F3F7]",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-theme-primary focus-visible:ring-offset-2 focus-visible:ring-offset-bg-base",
+          "bg-bg-base",
           isActive
-            ? "shadow-[inset_4px_4px_8px_#d1d5db,inset_-4px_-4px_8px_#ffffff] text-[#149A9B]"
-            : "text-[#6D758F] shadow-none hover:shadow-[4px_4px_8px_#d1d5db,-4px_-4px_8px_#ffffff] hover:text-[#19213D]"
+            ? "bg-bg-sunken shadow-neu-sunken-subtle text-theme-primary"
+            : "text-content-secondary shadow-none hover:shadow-neu-raised-sm hover:text-content-primary"
         )}
       >
-        <span className={cn("flex-shrink-0 transition-colors duration-300", isActive ? "text-[#149A9B]" : "text-[#6D758F] group-hover:text-[#19213D]")}>
+        <span className={cn("flex-shrink-0 transition-colors duration-300", isActive ? "text-theme-primary" : "text-content-secondary group-hover:text-content-primary")}>
           {icon}
         </span>
         <span className="truncate">{label}</span>

--- a/src/components/docs/TableOfContents.tsx
+++ b/src/components/docs/TableOfContents.tsx
@@ -78,7 +78,7 @@ export function TableOfContents({ headings }: TableOfContentsProps) {
   return (
     <nav className="w-full">
       <div className="flex flex-col">
-        <p className="text-[10px] font-bold uppercase tracking-[0.15em] mb-6 px-4 text-[#6D758F]/60">
+        <p className="text-[10px] font-bold uppercase tracking-[0.15em] mb-6 px-4 text-content-secondary/70">
           On this page
         </p>
         <ul className="flex flex-col gap-1">
@@ -93,8 +93,8 @@ export function TableOfContents({ headings }: TableOfContentsProps) {
                 className={cn(
                   "text-[13px] transition-all duration-200 block py-1.5 px-4 rounded-lg font-medium",
                   activeId === heading.id
-                    ? "text-[#149A9B] bg-[#149A9B]/5"
-                    : "text-[#6D758F] hover:text-[#19213D] hover:bg-[#19213D]/5"
+                    ? "text-theme-primary bg-bg-sunken shadow-neu-sunken-subtle"
+                    : "text-content-secondary hover:text-content-primary hover:bg-bg-elevated"
                 )}
               >
                 {heading.text}


### PR DESCRIPTION

Closes #1121

## Changes
- Updated docs layout shell to use theme-aware base background (`bg-bg-base`).
- Updated docs sidebar to support dark mode neumorphic styling:
  - Sidebar container uses theme-aware background/shadow.
  - Section headings use `text-content-primary`.
  - Links use `text-content-secondary`.
  - Active link uses `text-theme-primary` with sunken neumorphic styling.
- Updated table of contents link colors:
  - Default links use `text-content-secondary`.
  - Active link uses `text-theme-primary`.
- Updated docs search bar styling:
  - Search input now uses `bg-bg-sunken` and `shadow-neu-sunken-subtle`.
  - Search text and placeholder are theme-aware and visible in dark mode.
  - Search results panel and keyboard hints use theme-aware colors/shadows.
- Updated docs pagination to neumorphic, theme-aware button styling.

## Testing
- Verified only issue-scoped files were changed:
  - `src/components/docs/DocsLayoutShell.tsx`
  - `src/components/docs/DocsSidebar.tsx`
  - `src/components/docs/TableOfContents.tsx`
  - `src/components/docs/DocsPagination.tsx`
  - `src/components/docs/DocsSearchBar.tsx`
- Attempted to run lint:
  - `npm run lint` failed in this environment because `next` is not installed (`next: command not found`).

## Scope
- No unrelated refactors.
- No additional features outside issue #1121.
