### PR TITLE
feat(community): add dark mode support for Community Info sections (#1120)

### DIFF
--- a/src/components/community/CommunityChannelsSection.tsx
+++ b/src/components/community/CommunityChannelsSection.tsx
@@ -56,16 +56,16 @@ const CommunityChannelsSection = () => {
                 href={channel.href}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="flex h-full flex-col rounded-2xl bg-background p-6 shadow-raised transition-transform duration-300 hover:-translate-y-1"
+                className="flex h-full flex-col rounded-2xl bg-bg-elevated p-6 shadow-neu-raised transition-all duration-300 hover:-translate-y-1 hover:shadow-neu-raised-hover"
               >
-                <Icon size={18} className="text-primary" />
-                <h3 className="mt-4 text-xl font-bold text-text-primary">
+                <Icon size={18} className="text-theme-primary" />
+                <h3 className="mt-4 text-xl font-bold text-content-primary">
                   {channel.name}
                 </h3>
-                <p className="mt-2 text-sm font-light leading-relaxed text-text-secondary">
+                <p className="mt-2 text-sm font-light leading-relaxed text-content-secondary">
                   {channel.description}
                 </p>
-                <span className="mt-auto pt-6 inline-flex items-center gap-2 text-sm font-semibold text-text-primary">
+                <span className="mt-auto pt-6 inline-flex items-center gap-2 text-sm font-semibold text-content-primary">
                   Join channel <ArrowUpRight size={16} />
                 </span>
               </a>

--- a/src/components/community/HowToContribute.tsx
+++ b/src/components/community/HowToContribute.tsx
@@ -24,13 +24,13 @@ export default function HowToContribute() {
             <div className="max-w-7xl mx-auto px-6 lg:px-8">
                 {/* Heading */}
                 <div className="text-center mb-16">
-                    <p className="text-xs font-medium uppercase tracking-[0.4em] mb-4" style={{ color: "#149A9B" }}>
+                    <p className="text-xs font-medium uppercase tracking-[0.4em] mb-4 text-theme-primary">
                         How to Contribute
                     </p>
-                    <h2 className="text-4xl md:text-5xl font-black tracking-tight mb-6" style={{ color: "#19213D" }}>
+                    <h2 className="text-4xl md:text-5xl font-black tracking-tight mb-6 text-content-primary">
                         Join the OFFER HUB Community
                     </h2>
-                    <p className="text-lg text-secondary max-w-2xl mx-auto" style={{ color: "#6D758F" }}>
+                    <p className="text-lg max-w-2xl mx-auto text-content-secondary">
                         We welcome all types of contributions! Here is a step-by-step guide to help you build with us.
                     </p>
                 </div>
@@ -40,17 +40,14 @@ export default function HowToContribute() {
                     <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-8 justify-center">
                         {steps.map((step) => (
                             <div key={step.number} className="flex flex-col items-center text-center gap-6">
-                                <div
-                                    className="w-24 h-24 rounded-full shadow-raised flex items-center justify-center flex-shrink-0 relative z-10"
-                                    style={{ background: "#F1F3F7" }}
-                                >
-                                    <span className="text-2xl font-black" style={{ color: "#149A9B" }}>
+                                <div className="w-24 h-24 rounded-full bg-bg-elevated shadow-neu-raised flex items-center justify-center flex-shrink-0 relative z-10">
+                                    <span className="text-2xl font-black text-theme-primary">
                                         {step.number}
                                     </span>
                                 </div>
                                 <div className="flex flex-col gap-3">
-                                    <h3 className="text-xl font-bold" style={{ color: "#19213D" }}>{step.title}</h3>
-                                    <p className="text-sm font-light leading-relaxed max-w-xs mx-auto" style={{ color: "#6D758F" }}>
+                                    <h3 className="text-xl font-bold text-content-primary">{step.title}</h3>
+                                    <p className="text-sm font-light leading-relaxed max-w-xs mx-auto text-content-secondary">
                                         {step.description}
                                     </p>
                                 </div>
@@ -61,7 +58,7 @@ export default function HowToContribute() {
 
                 {/* Contribution Types */}
                 <div className="mb-24">
-                    <h3 className="text-2xl font-bold tracking-tight text-center mb-12" style={{ color: "#19213D" }}>
+                    <h3 className="text-2xl font-bold tracking-tight text-center mb-12 text-content-primary">
                         Ways to Contribute
                     </h3>
                     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
@@ -70,14 +67,13 @@ export default function HowToContribute() {
                             return (
                                 <div
                                     key={type.title}
-                                    className="rounded-2xl p-6 shadow-raised flex flex-col gap-4"
-                                    style={{ background: "#F1F3F7" }}
+                                    className="rounded-2xl p-6 bg-bg-elevated shadow-neu-raised flex flex-col gap-4"
                                 >
-                                    <div className="w-12 h-12 rounded-full flex items-center justify-center shadow-sunken" style={{ background: "#F1F3F7" }}>
-                                        <Icon className="w-5 h-5" style={{ color: "#149A9B" }} />
+                                    <div className="w-12 h-12 rounded-full flex items-center justify-center bg-bg-sunken shadow-neu-sunken-subtle">
+                                        <Icon className="w-5 h-5 text-theme-primary" />
                                     </div>
-                                    <h4 className="text-lg font-bold" style={{ color: "#19213D" }}>{type.title}</h4>
-                                    <p className="text-sm font-light leading-relaxed" style={{ color: "#6D758F" }}>
+                                    <h4 className="text-lg font-bold text-content-primary">{type.title}</h4>
+                                    <p className="text-sm font-light leading-relaxed text-content-secondary">
                                         {type.description}
                                     </p>
                                 </div>
@@ -92,16 +88,14 @@ export default function HowToContribute() {
                         href="https://github.com/OFFER-HUB/offer-hub-monorepo/issues"
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="px-8 py-4 rounded-xl font-medium shadow-raised hover:shadow-raised-hover transition-all duration-300 flex items-center gap-2"
-                        style={{ background: "#149A9B", color: "#FFFFFF" }}
+                        className="btn-neumorphic-primary px-8 py-4 rounded-xl font-medium flex items-center gap-2"
                     >
                         View open issues
                         <Bug className="w-4 h-4" />
                     </Link>
                     <Link
                         href="/docs"
-                        className="px-8 py-4 rounded-xl font-medium shadow-raised hover:shadow-raised-hover transition-all duration-300 flex items-center gap-2"
-                        style={{ background: "#F1F3F7", color: "#19213D" }}
+                        className="btn-neumorphic-secondary px-8 py-4 rounded-xl font-medium flex items-center gap-2"
                     >
                         Read contribution guide
                         <BookOpen className="w-4 h-4" />

--- a/src/components/community/HowToContributeSection.tsx
+++ b/src/components/community/HowToContributeSection.tsx
@@ -22,11 +22,11 @@ const HowToContributeSection = () => {
           {contributionSteps.map((step) => (
             <article
               key={step}
-              className="rounded-2xl bg-background p-6 shadow-raised"
+              className="rounded-2xl bg-bg-elevated p-6 shadow-neu-raised"
             >
               <div className="flex items-start gap-3">
-                <CheckCircle2 size={18} className="mt-1 text-primary" />
-                <p className="text-base font-light leading-relaxed text-text-primary">
+                <CheckCircle2 size={18} className="mt-1 text-theme-primary flex-shrink-0" />
+                <p className="text-base font-light leading-relaxed text-content-primary">
                   {step}
                 </p>
               </div>

--- a/src/components/community/RegistrationForm.tsx
+++ b/src/components/community/RegistrationForm.tsx
@@ -65,11 +65,11 @@ export default function RegistrationForm() {
     if (isSubmitted) {
         return (
             <div className="py-24 bg-transparent flex flex-col items-center justify-center text-center px-6">
-                <div className="w-20 h-20 rounded-3xl bg-[#F1F3F7] shadow-raised flex items-center justify-center mb-8 animate-fadeInScale">
-                    <CheckCircle2 size={40} className="text-[#149A9B]" />
+                <div className="w-20 h-20 rounded-3xl bg-bg-elevated shadow-neu-raised flex items-center justify-center mb-8 animate-fadeInScale">
+                    <CheckCircle2 size={40} className="text-theme-primary" />
                 </div>
-                <h2 className="text-3xl font-black text-[#19213D] tracking-tight mb-4">You&apos;re on the list!</h2>
-                <p className="text-[#6D758F] max-w-sm font-medium">We&apos;ll reach out shortly to discuss your integration with Offer Hub.</p>
+                <h2 className="text-3xl font-black text-content-primary tracking-tight mb-4">You&apos;re on the list!</h2>
+                <p className="text-content-secondary max-w-sm font-medium">We&apos;ll reach out shortly to discuss your integration with Offer Hub.</p>
             </div>
         );
     }
@@ -78,62 +78,62 @@ export default function RegistrationForm() {
         <section id="waitlist-form" className="py-32 bg-transparent relative">
             <div className="mx-auto max-w-2xl px-6">
                 <div className="text-center mb-16">
-                    <p className="text-[11px] font-black uppercase tracking-[0.4em] text-[#149A9B] mb-4">Join the ecosystem</p>
-                    <h2 className="text-4xl font-black text-[#19213D] tracking-tighter sm:text-5xl leading-none">
-                        Scale your <span className="text-[#149A9B]">Vision</span>
+                    <p className="text-[11px] font-black uppercase tracking-[0.4em] text-theme-primary mb-4">Join the ecosystem</p>
+                    <h2 className="text-4xl font-black text-content-primary tracking-tighter sm:text-5xl leading-none">
+                        Scale your <span className="text-theme-primary">Vision</span>
                     </h2>
-                    <p className="mt-6 text-lg text-[#6D758F] font-medium leading-relaxed">
+                    <p className="mt-6 text-lg text-content-secondary font-medium leading-relaxed">
                         Ready to integrate? Leave your details and join the next wave of payments.
                     </p>
                 </div>
 
                 <form
                     onSubmit={handleSubmit}
-                    className="p-10 rounded-[2.5rem] bg-[#F1F3F7] shadow-raised flex flex-col gap-8"
+                    className="p-10 rounded-[2.5rem] bg-bg-elevated shadow-neu-raised flex flex-col gap-8"
                 >
                     {error && (
-                        <div className="p-4 rounded-2xl bg-red-50 border border-red-200 flex items-start gap-3 animate-fadeIn">
+                        <div className="p-4 rounded-2xl bg-red-50 dark:bg-red-950/50 border border-red-200 dark:border-red-800 flex items-start gap-3 animate-fadeIn">
                             <AlertCircle size={20} className="text-red-500 flex-shrink-0 mt-0.5" />
-                            <p className="text-sm text-red-700 font-medium">{error}</p>
+                            <p className="text-sm text-red-700 dark:text-red-400 font-medium">{error}</p>
                         </div>
                     )}
 
                     <div className="flex flex-col gap-2">
-                        <label className="text-[10px] font-black uppercase tracking-widest text-[#6D758F] ml-2">Full Name</label>
+                        <label className="text-[10px] font-black uppercase tracking-widest text-content-secondary ml-2">Full Name</label>
                         <div className="relative group">
-                            <User size={16} className="absolute left-5 top-1/2 -translate-y-1/2 text-[#6D758F]/40 group-focus-within:text-[#149A9B] transition-colors" />
-                            <input required type="text" name="name" value={formData.name} onChange={handleInputChange} placeholder="John Doe" disabled={isLoading} className="w-full pl-12 pr-6 py-4 rounded-2xl bg-[#F1F3F7] shadow-sunken-subtle text-sm text-[#19213D] placeholder-[#6D758F]/30 focus:outline-none focus:shadow-sunken transition-all font-medium disabled:opacity-50 disabled:cursor-not-allowed" />
+                            <User size={16} className="absolute left-5 top-1/2 -translate-y-1/2 text-content-muted group-focus-within:text-theme-primary transition-colors" />
+                            <input required type="text" name="name" value={formData.name} onChange={handleInputChange} placeholder="John Doe" disabled={isLoading} className="w-full pl-12 pr-6 py-4 rounded-2xl bg-bg-sunken shadow-neu-sunken-subtle text-sm text-content-primary placeholder:text-content-muted focus:outline-none focus:shadow-neu-sunken transition-all font-medium disabled:opacity-50 disabled:cursor-not-allowed" />
                         </div>
                     </div>
 
                     <div className="flex flex-col gap-2">
-                        <label className="text-[10px] font-black uppercase tracking-widest text-[#6D758F] ml-2">Email Address</label>
+                        <label className="text-[10px] font-black uppercase tracking-widest text-content-secondary ml-2">Email Address</label>
                         <div className="relative group">
-                            <Mail size={16} className="absolute left-5 top-1/2 -translate-y-1/2 text-[#6D758F]/40 group-focus-within:text-[#149A9B] transition-colors" />
-                            <input required type="email" name="email" value={formData.email} onChange={handleInputChange} placeholder="john@example.com" disabled={isLoading} className="w-full pl-12 pr-6 py-4 rounded-2xl bg-[#F1F3F7] shadow-sunken-subtle text-sm text-[#19213D] placeholder-[#6D758F]/30 focus:outline-none focus:shadow-sunken transition-all font-medium disabled:opacity-50 disabled:cursor-not-allowed" />
+                            <Mail size={16} className="absolute left-5 top-1/2 -translate-y-1/2 text-content-muted group-focus-within:text-theme-primary transition-colors" />
+                            <input required type="email" name="email" value={formData.email} onChange={handleInputChange} placeholder="john@example.com" disabled={isLoading} className="w-full pl-12 pr-6 py-4 rounded-2xl bg-bg-sunken shadow-neu-sunken-subtle text-sm text-content-primary placeholder:text-content-muted focus:outline-none focus:shadow-neu-sunken transition-all font-medium disabled:opacity-50 disabled:cursor-not-allowed" />
                         </div>
                     </div>
 
                     <div className="flex flex-col gap-2">
-                        <label className="text-[10px] font-black uppercase tracking-widest text-[#6D758F] ml-2">For what would you use Offer Hub?</label>
+                        <label className="text-[10px] font-black uppercase tracking-widest text-content-secondary ml-2">For what would you use Offer Hub?</label>
                         <div className="relative group">
-                            <MessageSquare size={16} className="absolute left-5 top-6 text-[#6D758F]/40 group-focus-within:text-[#149A9B] transition-colors" />
-                            <textarea required rows={3} name="purpose" value={formData.purpose} onChange={handleInputChange} placeholder="Tell us about your marketplace or project..." disabled={isLoading} className="w-full pl-12 pr-6 py-4 rounded-2xl bg-[#F1F3F7] shadow-sunken-subtle text-sm text-[#19213D] placeholder-[#6D758F]/30 focus:outline-none focus:shadow-sunken transition-all font-medium resize-none disabled:opacity-50 disabled:cursor-not-allowed" />
+                            <MessageSquare size={16} className="absolute left-5 top-6 text-content-muted group-focus-within:text-theme-primary transition-colors" />
+                            <textarea required rows={3} name="purpose" value={formData.purpose} onChange={handleInputChange} placeholder="Tell us about your marketplace or project..." disabled={isLoading} className="w-full pl-12 pr-6 py-4 rounded-2xl bg-bg-sunken shadow-neu-sunken-subtle text-sm text-content-primary placeholder:text-content-muted focus:outline-none focus:shadow-neu-sunken transition-all font-medium resize-none disabled:opacity-50 disabled:cursor-not-allowed" />
                         </div>
                     </div>
 
                     <div className="flex flex-col gap-2">
-                        <label className="text-[10px] font-black uppercase tracking-widest text-[#6D758F] ml-2">How did you hear about us?</label>
+                        <label className="text-[10px] font-black uppercase tracking-widest text-content-secondary ml-2">How did you hear about us?</label>
                         <div className="relative group">
-                            <Send size={16} className="absolute left-5 top-1/2 -translate-y-1/2 text-[#6D758F]/40 group-focus-within:text-[#149A9B] transition-colors" />
-                            <input required type="text" name="referral" value={formData.referral} onChange={handleInputChange} placeholder="X, Telegram, Friend, etc." disabled={isLoading} className="w-full pl-12 pr-6 py-4 rounded-2xl bg-[#F1F3F7] shadow-sunken-subtle text-sm text-[#19213D] placeholder-[#6D758F]/30 focus:outline-none focus:shadow-sunken transition-all font-medium disabled:opacity-50 disabled:cursor-not-allowed" />
+                            <Send size={16} className="absolute left-5 top-1/2 -translate-y-1/2 text-content-muted group-focus-within:text-theme-primary transition-colors" />
+                            <input required type="text" name="referral" value={formData.referral} onChange={handleInputChange} placeholder="X, Telegram, Friend, etc." disabled={isLoading} className="w-full pl-12 pr-6 py-4 rounded-2xl bg-bg-sunken shadow-neu-sunken-subtle text-sm text-content-primary placeholder:text-content-muted focus:outline-none focus:shadow-neu-sunken transition-all font-medium disabled:opacity-50 disabled:cursor-not-allowed" />
                         </div>
                     </div>
 
                     <button
                         type="submit"
                         disabled={isLoading}
-                        className="mt-4 w-full py-5 rounded-2xl bg-black text-white text-[11px] font-black uppercase tracking-[0.25em] shadow-xl shadow-black/20 hover:bg-[#149A9B] hover:shadow-[#149A9B]/30 transition-all flex items-center justify-center gap-3 group disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-black"
+                        className="btn-neumorphic-primary mt-4 w-full py-5 rounded-2xl text-[11px] font-black uppercase tracking-[0.25em] flex items-center justify-center gap-3 group disabled:opacity-50 disabled:cursor-not-allowed"
                     >
                         {isLoading ? 'Submitting...' : 'Submit Application'}
                         <Send size={14} className="group-hover:translate-x-1 group-hover:-translate-y-1 transition-transform" />


### PR DESCRIPTION
## Summary
Implements dark mode support for the Community page sections: How to Contribute, Community Channels, and Registration Form per issue #1120.

## Changes
- **HowToContribute.tsx**: Replaced hardcoded colors with theme-aware classes (`bg-bg-elevated`, `shadow-neu-raised`, `text-content-primary/secondary`, `btn-neumorphic-primary`)
- **HowToContributeSection.tsx**: Step cards use `bg-bg-elevated` and `shadow-neu-raised`; step numbers/icons use `text-theme-primary`
- **CommunityChannelsSection.tsx**: Channel cards use `bg-bg-elevated` with `shadow-neu-raised` and hover effects; icons and text adapt to dark mode
- **RegistrationForm.tsx**: Form inputs use `bg-bg-sunken` and `shadow-neu-sunken-subtle`; labels use `text-content-secondary`; submit button uses `btn-neumorphic-primary`; error state has dark mode styling

## Acceptance Criteria
- [x] How to Contribute steps are clearly readable
- [x] Step numbers/icons are visible in dark mode
- [x] Community channel cards adapt to dark mode
- [x] Channel icons are visible with proper contrast
- [x] Registration form inputs have inset neumorphic styling
- [x] Form labels use `text-content-secondary`
- [x] Submit button uses theme-aware neumorphic primary style

## Testing
1. Toggle dark mode via the theme toggle (if available in navbar)
2. Visit `/community` page
3. Verify How to Contribute section, Community Channels, and Registration Form all render correctly in both light and dark modes
4. Check form inputs have proper contrast and neumorphic inset styling

Closes #1120