### PR TITLE
feat: dark mode for Supported By + Stats Cards + z-index fix

### DIFF
--- a/src/components/StatsSection.tsx
+++ b/src/components/StatsSection.tsx
@@ -7,25 +7,18 @@ const stats = [
 
 export default function StatsSection() {
   return (
-    <section className="py-20">
+    <section className="relative py-20">
       <div className="max-w-7xl mx-auto px-6 lg:px-8">
         <div className="grid grid-cols-2 md:grid-cols-4 gap-6">
           {stats.map((stat) => (
             <div
               key={stat.label}
-              className="flex flex-col items-center text-center p-8 rounded-2xl shadow-raised"
-              style={{ background: "#F1F3F7" }}
+              className="relative z-10 flex flex-col items-center text-center p-8 rounded-2xl bg-bg-elevated shadow-neu-raised transition-shadow duration-300 hover:shadow-neu-raised-hover"
             >
-              <span
-                className="text-5xl font-black tracking-tight"
-                style={{ color: "#149A9B" }}
-              >
+              <span className="text-5xl font-black tracking-tight text-theme-primary">
                 {stat.value}
               </span>
-              <span
-                className="text-sm font-medium mt-3 uppercase tracking-widest"
-                style={{ color: "#6D758F" }}
-              >
+              <span className="text-sm font-medium mt-3 uppercase tracking-widest text-content-secondary">
                 {stat.label}
               </span>
             </div>

--- a/src/components/SupportedBySection.tsx
+++ b/src/components/SupportedBySection.tsx
@@ -20,16 +20,16 @@ const partners = [
 
 export default function SupportedBySection() {
   return (
-    <section className="py-8 bg-transparent">
+    <section className="relative py-8 bg-transparent">
       <div className="container mx-auto px-6">
         <div className="flex flex-col items-center gap-4 animate-fadeIn">
           {/* Small Label */}
-          <p className="text-[9px] font-semibold uppercase tracking-[0.2em] text-[#6D758F]/60">
+          <p className="text-[9px] font-semibold uppercase tracking-[0.2em] text-content-muted">
             Supported by
           </p>
 
           {/* Partner Logos - Inline */}
-          <div className="flex items-center gap-6">
+          <div className="relative z-10 flex items-center gap-6">
             {partners.map((partner) => (
               <Link
                 key={partner.name}
@@ -43,7 +43,7 @@ export default function SupportedBySection() {
                   alt={`${partner.name} logo`}
                   width={partner.width}
                   height={partner.height}
-                  className="object-contain"
+                  className="object-contain dark:invert dark:brightness-0 dark:invert"
                   priority
                 />
               </Link>


### PR DESCRIPTION
# Title

Implement dark mode for Supported By + Stats Cards + z-index fix. closes #1110 

## Summary

This PR implements dark mode support for the `SupportedBySection` and `StatsSection` components. All hardcoded light-mode hex colors and background values have been replaced with theme-aware Tailwind tokens that resolve to CSS variables, enabling full light/dark adaptability. A z-index bug where the dot grid background rendered on top of the cards has also been fixed.

## Changes

- Replaced hardcoded `style={{ background: "#F1F3F7" }}` and `style={{ color }}` with theme-aware classes (`bg-bg-elevated`, `text-theme-primary`, `text-content-secondary`, `text-content-muted`) in `src/components/StatsSection.tsx`
- Applied neumorphic shadow tokens: `shadow-neu-raised` on stat cards with `hover:shadow-neu-raised-hover transition-shadow duration-300`
- Fixed z-index issue in `StatsSection` by adding `relative` to `<section>` and `relative z-10` to each card
- Replaced hardcoded `text-[#6D758F]/60` with `text-content-muted` for the "Supported by" label in `src/components/SupportedBySection.tsx`
- Added `dark:invert dark:brightness-0 dark:invert` to partner logos (Stellar, Trustless Work) so they remain visible on dark backgrounds
- Fixed z-index issue in `SupportedBySection` by adding `relative` to `<section>` and `relative z-10` to the logo wrapper

## Checklist

- [x] Stat cards use `bg-bg-elevated` instead of hardcoded `#F1F3F7`
- [x] Neumorphic shadows use CSS variable tokens (`shadow-neu-raised`)
- [x] Stats numbers use `text-theme-primary`, labels use `text-content-secondary`
- [x] Fixed z-index: cards appear above the dot grid background
- [x] Partner logos (Stellar, Trustless Work) remain visible in dark mode via CSS filter
- [x] All text has proper contrast ratios (WCAG AA)
- [x] Tested in both light and dark modes

<img width="1334" height="380" alt="image" src="https://github.com/user-attachments/assets/f03cd966-b5b8-4936-9841-faf14774922d" />

<img width="1304" height="358" alt="image" src="https://github.com/user-attachments/assets/71df94fb-d93e-4eac-8d83-828bdb956022" />


## How to test locally

```bash
# from repository root
npm run dev
# Toggle dark mode and scroll to the Supported By and Stats sections
# Verify cards, logos, and text render correctly in both themes