### PR TITLE
Adding new style in the PR section

### DIFF
--- a/src/app/community/page.tsx
+++ b/src/app/community/page.tsx
@@ -1,7 +1,7 @@
 import HeroRepoStatsSection from "@/components/community/HeroRepoStatsSection";
 import ContributorsSection from "@/components/community/ContributorsSection";
 import HowToContribute from "@/components/community/HowToContribute";
-import RecentPRsSection from "@/components/community/RecentPRsSection";
+import RecentPRsSection, { PullRequestData } from "@/components/community/RecentPRsSection";
 import OpenIssuesSection from "@/components/community/OpenIssuesSection";
 import RepoLinksSection from "@/components/community/RepoLinksSection";
 import CommunityChannelsSection from "@/components/community/CommunityChannelsSection";
@@ -32,15 +32,6 @@ interface ContributorData {
   profileUrl: string;
 }
 
-interface PullRequestData {
-  number: number;
-  title: string;
-  author: string;
-  mergedAt: string;
-  url: string;
-  status: string;
-}
-
 interface IssueData {
   number: number;
   title: string;
@@ -59,6 +50,8 @@ interface GitHubPullRequest {
   number: number;
   title: string;
   html_url: string;
+  state: string;
+  created_at: string;
   merged_at: string | null;
   user: {
     login: string;
@@ -138,10 +131,17 @@ function processGitHubData(validData: NonNullable<Awaited<ReturnType<typeof fetc
   };
 
   const allPRs = validData.flatMap(d => d.pullRequests)
-    .filter(pr => pr.merged_at !== null)
-    .map(pr => ({ number: pr.number, title: pr.title, author: pr.user?.login || "Unknown", mergedAt: pr.merged_at!, url: pr.html_url, status: "Merged" }))
-    .sort((a, b) => new Date(b.mergedAt).getTime() - new Date(a.mergedAt).getTime());
-  const pullRequests: PullRequestData[] = allPRs.slice(0, 30).map(pr => ({ ...pr, mergedAt: formatTimeAgo(pr.mergedAt) }));
+    .map(pr => ({
+      number: pr.number,
+      title: pr.title,
+      author: pr.user?.login || "Unknown",
+      timestamp: pr.state === 'open' ? pr.created_at : pr.merged_at || pr.created_at,
+      url: pr.html_url,
+      status: (pr.state === 'open' ? 'Open' : 'Merged') as 'Open' | 'Merged' | 'Closed'
+    }))
+    .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
+
+  const pullRequests: PullRequestData[] = allPRs.slice(0, 30).map(pr => ({ ...pr, timestamp: formatTimeAgo(pr.timestamp) }));
 
   const allIssues = validData.flatMap(d => d.issues)
     .filter(issue => !issue.pull_request)
@@ -166,7 +166,7 @@ async function fetchRepoData(repo: string) {
   const [repoRes, contribRes, prRes, issueRes] = await Promise.all([
     fetch(`https://api.github.com/repos/${repo}`, cacheOpts),
     fetch(`https://api.github.com/repos/${repo}/contributors?per_page=100`, cacheOpts),
-    fetch(`https://api.github.com/repos/${repo}/pulls?state=closed&sort=updated&direction=desc&per_page=10`, cacheOpts),
+    fetch(`https://api.github.com/repos/${repo}/pulls?state=all&sort=updated&direction=desc&per_page=20`, cacheOpts),
     fetch(`https://api.github.com/repos/${repo}/issues?state=open&sort=created&direction=desc&per_page=20`, cacheOpts),
   ]);
 
@@ -214,10 +214,10 @@ async function fetchGitHubData() {
         { name: "Tomi A.", username: "tomi-a", avatar: "", commits: 70, profileUrl: "" },
       ],
       pullRequests: [
-        { number: 1042, title: "feat: add account-level escrow analytics", author: "contributor1", mergedAt: "2 days ago", url: "", status: "Merged" },
-        { number: 1039, title: "refactor: simplify wallet sync flow", author: "contributor2", mergedAt: "3 days ago", url: "", status: "Merged" },
-        { number: 1036, title: "fix: resolve pagination edge case in jobs feed", author: "contributor3", mergedAt: "5 days ago", url: "", status: "Merged" },
-        { number: 1033, title: "docs: add validator onboarding guide", author: "contributor4", mergedAt: "1 week ago", url: "", status: "Merged" },
+        { number: 1042, title: "feat: add account-level escrow analytics", author: "contributor1", timestamp: "2 days ago", url: "", status: "Merged" },
+        { number: 1039, title: "refactor: simplify wallet sync flow", author: "contributor2", timestamp: "3 days ago", url: "", status: "Merged" },
+        { number: 1036, title: "fix: resolve pagination edge case in jobs feed", author: "contributor3", timestamp: "5 days ago", url: "", status: "Merged" },
+        { number: 1033, title: "docs: add validator onboarding guide", author: "contributor4", timestamp: "1 week ago", url: "", status: "Merged" },
       ],
       issues: [
         { number: 1055, title: "Improve CI cache invalidation strategy", priority: "Medium", url: "", labels: [] },
@@ -225,7 +225,7 @@ async function fetchGitHubData() {
         { number: 1048, title: "Expose webhook replay in dashboard", priority: "Low", url: "", labels: [] },
         { number: 1046, title: "Polish mobile nav focus styles", priority: "Low", url: "", labels: [] },
       ],
-    };
+    } as { stats: RepoStats; contributors: ContributorData[]; pullRequests: PullRequestData[]; issues: IssueData[] };
   }
 }
 

--- a/src/components/community/CommunityChannelsSection.tsx
+++ b/src/components/community/CommunityChannelsSection.tsx
@@ -56,17 +56,19 @@ const CommunityChannelsSection = () => {
                 href={channel.href}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="flex h-full flex-col rounded-2xl bg-bg-elevated p-6 shadow-neu-raised transition-all duration-300 hover:-translate-y-1 hover:shadow-neu-raised-hover"
+                className="group flex h-full flex-col rounded-3xl bg-bg-base p-8 shadow-neu-raised transition-all duration-300 hover:-translate-y-1 hover:shadow-neu-raised-hover"
               >
-                <Icon size={18} className="text-theme-primary" />
-                <h3 className="mt-4 text-xl font-bold text-content-primary">
+                <div className="w-12 h-12 rounded-xl bg-bg-base shadow-neu-sunken-subtle flex items-center justify-center mb-6 group-hover:scale-110 transition-transform">
+                  <Icon size={20} className="text-theme-primary" />
+                </div>
+                <h3 className="text-xl font-black text-content-primary tracking-tight">
                   {channel.name}
                 </h3>
-                <p className="mt-2 text-sm font-light leading-relaxed text-content-secondary">
+                <p className="mt-4 text-sm font-medium leading-relaxed text-content-secondary">
                   {channel.description}
                 </p>
-                <span className="mt-auto pt-6 inline-flex items-center gap-2 text-sm font-semibold text-content-primary">
-                  Join channel <ArrowUpRight size={16} />
+                <span className="mt-8 pt-6 border-t border-theme-border/10 inline-flex items-center gap-2 text-[11px] font-black uppercase tracking-widest text-theme-primary group-hover:gap-3 transition-all">
+                  Join channel <ArrowUpRight size={14} />
                 </span>
               </a>
             );

--- a/src/components/community/ContributorsSection.tsx
+++ b/src/components/community/ContributorsSection.tsx
@@ -19,33 +19,35 @@ interface ContributorsSectionProps {
 // Memoized contributor card to prevent unnecessary re-renders
 const ContributorCard = memo(function ContributorCard({ person }: { person: ContributorData }) {
   return (
-    <article className="group relative rounded-2xl bg-bg-elevated p-5 shadow-neu-raised transition-shadow duration-300 hover:shadow-neu-raised-hover">
-      <div className="flex flex-col items-center text-center gap-3">
+    <article className="group relative rounded-3xl bg-bg-base p-6 shadow-neu-raised transition-all duration-300 hover:shadow-neu-raised-hover hover:-translate-y-1">
+      <div className="flex flex-col items-center text-center gap-4">
         {person.avatar ? (
-          <img
-            src={person.avatar}
-            alt={person.name}
-            loading="lazy"
-            decoding="async"
-            className="w-16 h-16 rounded-full object-cover shadow-neu-sunken-subtle"
-          />
+          <div className="p-1 rounded-full bg-bg-base shadow-neu-sunken-subtle group-hover:shadow-neu-sunken transition-shadow">
+            <img
+              src={person.avatar}
+              alt={person.name}
+              loading="lazy"
+              decoding="async"
+              className="w-16 h-16 rounded-full object-cover"
+            />
+          </div>
         ) : (
-          <div className="w-14 h-14 rounded-full bg-bg-elevated flex items-center justify-center shadow-neu-sunken-subtle">
-            <Users size={20} className="text-content-secondary" />
+          <div className="w-16 h-16 rounded-full bg-bg-base flex items-center justify-center shadow-neu-sunken-subtle">
+            <Users size={24} className="text-content-secondary" />
           </div>
         )}
 
         <div className="min-w-0">
-          <h3 className="text-base font-bold text-content-primary truncate tracking-tight">
+          <h3 className="text-base font-black text-content-primary truncate tracking-tight">
             {person.name || person.username}
           </h3>
-          <p className="text-xs font-medium text-theme-primary">
+          <p className="text-[11px] font-black uppercase tracking-widest text-theme-primary mt-1">
             @{person.username}
           </p>
         </div>
 
-        <div className="flex items-center gap-1.5 text-[10px] font-bold uppercase tracking-wider text-content-secondary">
-          <GitCommit size={12} />
+        <div className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-bg-base shadow-neu-sunken-subtle text-[10px] font-bold uppercase tracking-wider text-content-secondary">
+          <GitCommit size={14} className="text-theme-primary/60" />
           <span>{person.commits} commits</span>
         </div>
 
@@ -54,9 +56,9 @@ const ContributorCard = memo(function ContributorCard({ person }: { person: Cont
             href={person.profileUrl}
             target="_blank"
             rel="noopener noreferrer"
-            className="mt-1 text-[10px] font-bold text-theme-primary hover:underline"
+            className="mt-1 p-2 rounded-lg bg-bg-base shadow-neu-raised-sm text-[10px] font-black uppercase tracking-widest text-theme-primary hover:shadow-neu-sunken-subtle active:shadow-neu-sunken transition-all"
           >
-            View Profile
+            Profile
           </a>
         )}
       </div>
@@ -91,16 +93,16 @@ const ContributorsSection = ({ contributors }: ContributorsSectionProps) => {
         </div>
 
         {hasMore && (
-          <div className="mt-12 text-center">
+          <div className="mt-16 text-center">
             <button
               onClick={handleLoadMore}
-              className="inline-flex items-center gap-2.5 px-7 py-3 rounded-xl text-sm font-semibold text-white transition-all duration-300 shadow-neu-raised hover:shadow-neu-raised-hover active:shadow-neu-sunken-subtle bg-theme-primary"
+              className="inline-flex items-center gap-3 px-8 py-4 rounded-2xl text-[11px] font-black uppercase tracking-widest text-white transition-all duration-300 btn-neumorphic-primary group"
             >
-              Show more ({totalContributors - displayCount} remaining)
-              <ChevronDown size={16} />
+              Show more creators
+              <ChevronDown size={14} className="group-hover:translate-y-1 transition-transform" />
             </button>
-            <p className="mt-3 text-xs text-content-secondary">
-              Showing {displayCount} of {totalContributors} contributors
+            <p className="mt-6 text-[10px] font-bold uppercase tracking-widest text-content-muted">
+              Displaying {displayCount} of {totalContributors} contributors
             </p>
           </div>
         )}

--- a/src/components/community/OpenIssuesSection.tsx
+++ b/src/components/community/OpenIssuesSection.tsx
@@ -22,14 +22,14 @@ const IssueCard = memo(function IssueCard({ issue }: { issue: IssueData }) {
   const isGoodFirstIssue = issue.labels.some(l => l.toLowerCase().includes('good') || l.toLowerCase().includes('help'));
 
   return (
-    <article className="group relative flex flex-col justify-between rounded-2xl bg-bg-base p-6 shadow-neu-raised transition-shadow duration-300 hover:shadow-neu-raised-hover">
+    <article className="group relative flex flex-col justify-between rounded-3xl bg-bg-base p-6 shadow-neu-raised transition-all duration-300 hover:shadow-neu-raised-hover">
       <div>
         <div className="flex items-center justify-between mb-4">
-          <div className="flex items-center gap-2 px-2.5 py-1 rounded-lg bg-bg-base text-[10px] font-semibold text-content-secondary tracking-wider shadow-neu-sunken-subtle uppercase">
+          <div className="flex items-center gap-2 px-3 py-1.5 rounded-xl bg-bg-base text-[10px] font-bold text-content-secondary tracking-wider shadow-neu-sunken-subtle uppercase">
             #{issue.number}
           </div>
           {isGoodFirstIssue && (
-            <span className="text-[9px] font-bold text-theme-primary uppercase tracking-widest bg-green-500/10 dark:bg-green-500/20 px-1.5 py-0.5 rounded shadow-sm">
+            <span className="text-[10px] font-black text-theme-primary uppercase tracking-widest bg-theme-primary/10 px-2 py-1 rounded-lg shadow-sm">
               Starter
             </span>
           )}
@@ -39,19 +39,19 @@ const IssueCard = memo(function IssueCard({ issue }: { issue: IssueData }) {
           href={issue.url}
           target="_blank"
           rel="noopener noreferrer"
-          className="block text-[15px] font-semibold text-content-primary hover:text-theme-primary transition-colors leading-snug line-clamp-2 mb-4 tracking-tight"
+          className="block text-base font-black text-content-primary hover:text-theme-primary transition-colors leading-tight line-clamp-2 mb-4 tracking-tight"
         >
           {issue.title}
         </a>
 
         {issue.labels.length > 0 && (
-          <div className="flex flex-wrap gap-1.5 mb-6">
+          <div className="flex flex-wrap gap-2 mb-6">
             {issue.labels.slice(0, 2).map((label) => (
               <span
                 key={label}
-                className="flex items-center gap-1 text-[10px] font-medium text-content-secondary px-2 py-1 bg-bg-base rounded-lg shadow-neu-raised-sm"
+                className="flex items-center gap-1.5 text-[10px] font-bold text-content-secondary px-3 py-1.5 bg-bg-base rounded-xl shadow-neu-raised-sm"
               >
-                <Tag size={9} className="text-theme-primary" />
+                <Tag size={10} className="text-theme-primary" />
                 {label}
               </span>
             ))}
@@ -59,26 +59,28 @@ const IssueCard = memo(function IssueCard({ issue }: { issue: IssueData }) {
         )}
       </div>
 
-      <div className="flex items-center justify-between pt-4 border-t border-theme-border/20">
+      <div className="flex items-center justify-between pt-6 mt-2">
         <div className="flex flex-col">
-          <span className="text-[9px] font-bold uppercase tracking-widest text-content-muted mb-0.5">Priority</span>
-          <span className={cn(
-            "text-[10px] font-bold uppercase tracking-widest",
-            issue.priority === 'High' ? 'text-red-500' :
-              issue.priority === 'Low' ? 'text-emerald-500' :
-                'text-theme-primary'
-          )}>
-            {issue.priority}
-          </span>
+          <span className="text-[9px] font-black uppercase tracking-widest text-content-muted mb-1">Priority</span>
+          <div className="px-3 py-1 rounded-lg bg-bg-base shadow-neu-sunken-subtle">
+            <span className={cn(
+              "text-[10px] font-black uppercase tracking-widest",
+              issue.priority === 'High' ? 'text-red-500' :
+                issue.priority === 'Low' ? 'text-emerald-500' :
+                  'text-theme-primary'
+            )}>
+              {issue.priority}
+            </span>
+          </div>
         </div>
 
         <a
           href={issue.url}
           target="_blank"
           rel="noopener noreferrer"
-          className="p-2 rounded-xl text-white transition-all btn-neumorphic-primary flex items-center justify-center"
+          className="w-10 h-10 rounded-xl text-white transition-all btn-neumorphic-primary flex items-center justify-center shadow-neu-raised-sm hover:scale-105"
         >
-          <ArrowUpRight size={16} />
+          <ArrowUpRight size={18} />
         </a>
       </div>
     </article>

--- a/src/components/community/RecentPRsSection.tsx
+++ b/src/components/community/RecentPRsSection.tsx
@@ -4,46 +4,56 @@ import { memo } from "react";
 import { GitPullRequest, Timer, User, ArrowUpRight } from "lucide-react";
 import SectionHeading from "@/components/community/SectionHeading";
 
-interface PullRequestData {
+export interface PullRequestData {
   number: number;
   title: string;
   author: string;
-  mergedAt: string;
+  timestamp: string;
   url: string;
-  status: string;
+  status: 'Open' | 'Merged' | 'Closed';
 }
 
-interface RecentPRsSectionProps {
+export interface RecentPRsSectionProps {
   pullRequests: PullRequestData[];
 }
 
 // Memoized PR card component
 const PRCard = memo(function PRCard({ pr }: { pr: PullRequestData }) {
+  const isMerged = pr.status === 'Merged';
+
   return (
-    <article className="flex flex-col gap-4 rounded-3xl bg-bg-base/40 p-5 border border-theme-border/10 hover:bg-bg-elevated hover:shadow-neu-raised-hover hover:border-theme-primary/20 transition-all duration-300">
+    <article className="flex flex-col gap-4 rounded-3xl bg-bg-base p-5 shadow-neu-raised-sm hover:shadow-neu-raised transition-all duration-300 group/card">
       <div className="flex items-start justify-between gap-4">
         <div className="flex items-start gap-3">
-          <div className="mt-1 w-8 h-8 rounded-lg bg-bg-elevated border border-theme-border/20 flex items-center justify-center shadow-neu-raised-sm">
-            <GitPullRequest size={14} className="text-theme-primary" />
+          <div className="mt-1 w-8 h-8 rounded-lg bg-bg-base flex items-center justify-center shadow-neu-sunken-subtle transition-transform group-hover/card:scale-110">
+            <GitPullRequest size={14} className={isMerged ? "text-purple-500" : "text-theme-primary"} />
           </div>
           <div>
             <a
               href={pr.url}
               target="_blank"
               rel="noopener noreferrer"
-              className="text-sm font-black text-content-primary leading-tight hover:text-theme-primary transition-colors"
+              className="text-sm font-black text-content-primary leading-tight hover:text-theme-primary transition-colors block mb-2"
             >
               {pr.title}
             </a>
-            <div className="mt-2 flex flex-wrap items-center gap-3">
+            <div className="flex flex-wrap items-center gap-3">
               <div className="flex items-center gap-1.5 text-[10px] font-bold text-content-secondary">
                 <User size={12} className="text-theme-primary/40" />
                 @{pr.author}
               </div>
               <div className="w-1 h-1 rounded-full bg-content-muted/30" />
               <div className="text-[10px] font-bold text-content-secondary lowercase">
-                merged {pr.mergedAt}
+                {isMerged ? `merged ${pr.timestamp}` : `opened ${pr.timestamp}`}
               </div>
+              {!isMerged && (
+                <>
+                  <div className="w-1 h-1 rounded-full bg-content-muted/30" />
+                  <span className="text-[9px] font-black uppercase tracking-widest text-theme-primary px-1.5 py-0.5 rounded bg-theme-primary/10 shadow-sm">
+                    Open
+                  </span>
+                </>
+              )}
             </div>
           </div>
         </div>
@@ -52,7 +62,7 @@ const PRCard = memo(function PRCard({ pr }: { pr: PullRequestData }) {
           href={pr.url}
           target="_blank"
           rel="noopener noreferrer"
-          className="p-2 rounded-lg bg-bg-elevated border border-theme-border/20 text-theme-primary hover:scale-110 transition-transform"
+          className="p-2 rounded-lg bg-bg-base shadow-neu-raised-sm text-theme-primary hover:shadow-neu-sunken-subtle active:shadow-neu-sunken transition-all"
         >
           <ArrowUpRight size={14} />
         </a>
@@ -62,7 +72,7 @@ const PRCard = memo(function PRCard({ pr }: { pr: PullRequestData }) {
 });
 
 const RecentPRsSection = ({ pullRequests }: RecentPRsSectionProps) => {
-  // Double the list for seamless loop (not triple - reduces DOM elements)
+  // Double the list for seamless loop
   const doublePRs = [...pullRequests, ...pullRequests];
 
   return (
@@ -73,19 +83,19 @@ const RecentPRsSection = ({ pullRequests }: RecentPRsSectionProps) => {
           {/* Left Side: Context */}
           <div className="lg:col-span-4">
             <SectionHeading
-              eyebrow="Activity Stream"
-              title="Real-time growth"
-              subtitle="Watch as the global developer community continuously pushes the boundaries of Offer Hub."
+              eyebrow="Collaboration"
+              title="Open for review"
+              subtitle="Help the community move faster by reviewing these open contributions and verifying the latest features."
             />
 
             <div className="mt-10 flex flex-col gap-6">
-              <div className="flex items-start gap-4 p-5 rounded-[2rem] bg-bg-base/50 border border-theme-border/20">
-                <div className="w-10 h-10 rounded-xl bg-bg-elevated flex items-center justify-center shadow-neu-raised-sm">
+              <div className="flex items-start gap-4 p-5 rounded-[2rem] bg-bg-base shadow-neu-sunken-subtle">
+                <div className="w-10 h-10 rounded-xl bg-bg-base flex items-center justify-center shadow-neu-raised-sm">
                   <Timer size={18} className="text-theme-primary" />
                 </div>
                 <div>
-                  <p className="text-[11px] font-black uppercase tracking-widest text-content-primary mb-1">Update Frequency</p>
-                  <p className="text-sm font-medium text-content-secondary">New commits merged every 2.4 hours on average.</p>
+                  <p className="text-[11px] font-black uppercase tracking-widest text-content-primary mb-1">Impact Factor</p>
+                  <p className="text-sm font-medium text-content-secondary">Every open PR brings us closer to the next milestone.</p>
                 </div>
               </div>
             </div>
@@ -98,7 +108,7 @@ const RecentPRsSection = ({ pullRequests }: RecentPRsSectionProps) => {
             <div className="absolute bottom-0 inset-x-0 h-40 bg-gradient-to-t from-bg-base/90 to-transparent z-10 pointer-events-none" />
 
             <div
-              className="flex flex-col gap-4 py-10 animate-marquee-vertical group-hover:[animation-play-state:paused]"
+              className="flex flex-col gap-6 px-6 sm:px-12 py-10 animate-marquee-vertical group-hover:[animation-play-state:paused]"
               style={{ willChange: "transform" }}
             >
               {doublePRs.map((pr, index) => (


### PR DESCRIPTION
# 📝 Pull Request 

## 🔧 Title: 

- Refine Recent PRs section marquee layout and spacing

## 🛠️ Issue

- UI Refinement (No specific issue ID)

## 📚 Description

- Improved the visual presentation of the vertical marquee in the Recent Pull Requests section on the community page. The cards were previously touching the edges of their container, causing their neumorphic shadows to be clipped and the overall layout to feel cramped.

## ✅ Changes applied

- Added responsive horizontal padding (`px-6 sm:px-12`) to the vertical marquee container in [RecentPRsSection.tsx](cci:7://file:///Users/josue/OSS/offer-hub-monorepo/src/components/community/RecentPRsSection.tsx:0:0-0:0).
- Ensured enough breathing room for neumorphic shadows to be fully visible.
- Improved visual consistency across different screen sizes (mobile and desktop).

## 🔍 Evidence/Media (screenshots/videos)

- (Add a screenshot of the community section here to show the new spacing)
