### PR TITLE
Terms of Service: Dark Mode Support and Theme Harmonization

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -145,7 +145,7 @@ body::before {
      Background base: #F1F3F7 · Dark shadow: #d1d5db · Light highlight: #ffffff */
 
   .shadow-raised {
-    box-shadow: 6px 6px 12px #d1d5db, -6px -6px 12px #ffffff;
+    box-shadow: 6px 6px 12px var(--shadow-dark), -6px -6px 12px var(--shadow-light);
   }
 
   .shadow-raised-hover {
@@ -165,7 +165,7 @@ body::before {
   }
 
   .shadow-sunken-subtle {
-    box-shadow: inset 2px 2px 4px #d1d5db, inset -2px -2px 4px #ffffff;
+    box-shadow: inset 2px 2px 4px var(--shadow-dark), inset -2px -2px 4px var(--shadow-light);
   }
 
   /* For the navbar: flat surface elevation (bottom-only) */

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -6,23 +6,23 @@ import { FileText, Shield, Scale, HelpCircle } from "lucide-react";
 
 export default function TermsOfServicePage() {
   return (
-    <div className="min-h-screen flex flex-col bg-[#F1F3F7]">
+    <div className="min-h-screen flex flex-col bg-bg-base text-content-primary">
       <Navbar />
 
       <main className="flex-grow pt-32 pb-24 px-6 lg:px-8">
         <div className="max-w-4xl mx-auto">
           {/* Header */}
           <header className="text-center mb-20 animate-fadeInUp">
-            <p className="text-[11px] font-black uppercase tracking-[0.4em] text-[#149A9B] mb-4">Legal Framework</p>
-            <h1 className="text-4xl md:text-6xl font-black text-[#19213D] tracking-tighter leading-none mb-6">
-              Platform <span className="text-[#149A9B]">Terms</span>
+            <p className="text-[11px] font-black uppercase tracking-[0.4em] text-theme-primary mb-4">Legal Framework</p>
+            <h1 className="text-4xl md:text-6xl font-black text-content-primary tracking-tighter leading-none mb-6">
+              Platform <span className="text-theme-primary">Terms</span>
             </h1>
-            <p className="text-lg text-[#6D758F] font-medium max-w-2xl mx-auto leading-relaxed">
+            <p className="text-lg text-content-secondary font-medium max-w-2xl mx-auto leading-relaxed">
               These terms outline the agreement between you and OFFER-HUB.
               By using our tools, you agree to these principles of operation.
             </p>
-            <div className="mt-8 inline-flex items-center gap-2 px-4 py-2 rounded-full bg-[#F1F3F7] shadow-raised-sm text-xs font-bold text-[#6D758F]">
-              Last updated: <span className="text-[#149A9B]">February 25, 2026</span>
+            <div className="mt-8 inline-flex items-center gap-2 px-4 py-2 rounded-full bg-bg-elevated shadow-raised-sm text-xs font-bold text-content-secondary">
+              Last updated: <span className="text-theme-primary">February 25, 2026</span>
             </div>
           </header>
 
@@ -79,24 +79,24 @@ export default function TermsOfServicePage() {
               return (
                 <section
                   key={section.id}
-                  className="p-8 md:p-12 rounded-[2.5rem] bg-[#F1F3F7] shadow-raised"
+                  className="p-8 md:p-12 rounded-[2.5rem] bg-bg-base shadow-raised"
                 >
                   <div className="flex items-center gap-5 mb-8">
-                    <div className="w-12 h-12 rounded-xl flex items-center justify-center bg-[#F1F3F7] shadow-sunken-subtle text-[#149A9B]">
+                    <div className="w-12 h-12 rounded-xl flex items-center justify-center bg-bg-base shadow-sunken-subtle text-theme-primary">
                       <Icon size={20} />
                     </div>
-                    <h2 className="text-2xl font-black text-[#19213D] tracking-tight">{section.title}</h2>
+                    <h2 className="text-2xl font-black text-content-primary tracking-tight">{section.title}</h2>
                   </div>
 
-                  <p className="text-base font-medium leading-relaxed text-[#6D758F] mb-6">
+                  <p className="text-base font-medium leading-relaxed text-content-secondary mb-6">
                     {section.content}
                   </p>
 
                   {section.bullets && (
                     <ul className="space-y-4">
                       {section.bullets.map((bullet, i) => (
-                        <li key={i} className="flex items-start gap-4 text-sm font-medium text-[#19213D]">
-                          <span className="mt-1.5 h-1.5 w-1.5 rounded-full bg-[#149A9B] shrink-0" />
+                        <li key={i} className="flex items-start gap-4 text-sm font-medium text-content-primary">
+                          <span className="mt-1.5 h-1.5 w-1.5 rounded-full bg-theme-primary shrink-0" />
                           <span>{bullet}</span>
                         </li>
                       ))}
@@ -107,10 +107,10 @@ export default function TermsOfServicePage() {
                     <a
                       key={i}
                       href={`mailto:${email.address}`}
-                      className="inline-flex flex-col gap-0.5 mt-4 mr-4 p-5 rounded-2xl bg-[#F1F3F7] shadow-sunken-subtle hover:shadow-sunken transition-all group"
+                      className="inline-flex flex-col gap-0.5 mt-4 mr-4 p-5 rounded-2xl bg-bg-base shadow-sunken-subtle hover:shadow-sunken transition-all group"
                     >
-                      <span className="text-[10px] font-black uppercase tracking-widest text-[#6D758F]">{email.label}</span>
-                      <span className="text-sm font-bold text-[#149A9B] group-hover:text-[#19213D] transition-colors">{email.address}</span>
+                      <span className="text-[10px] font-black uppercase tracking-widest text-content-secondary">{email.label}</span>
+                      <span className="text-sm font-bold text-theme-primary group-hover:text-content-primary transition-colors">{email.address}</span>
                     </a>
                   )))}
                 </section>


### PR DESCRIPTION
# 📝 Pull Request 

## 🔧 Title: 

- Terms of Service: Dark Mode Support and Theme Harmonization

## 🛠️ Issue

- Closes #1176 

## 📚 Description

- Refactors the Terms of Service experience to align with the premium Neumorphic design system in both Light and Dark themes.
- Replaces hardcoded color values with theme-aware utility classes backed by global CSS variables.
- Improves legal text readability by using semantic content color tokens and preserving strong contrast hierarchy.

## ✅ Changes applied

- Replaced hardcoded Terms page colors with theme tokens:
  - `bg-bg-base`
  - `text-content-primary`
  - `text-content-secondary`
  - `text-theme-primary`
- Updated visual elements to be theme-compatible:
  - Header labels, title accents, and section body text
  - Legal bullet markers and icon accents
  - Contact/email cards and hover text states
  - “Last updated” badge now uses theme-aware background and text colors
- Harmonized Neumorphic shadow utilities in global styles:
  - `.shadow-raised` now uses `var(--shadow-dark)` and `var(--shadow-light)`
  - `.shadow-sunken-subtle` now uses `var(--shadow-dark)` and `var(--shadow-light)`
- Ensured decorative background behavior remains non-interactive and visually secondary to legal content.
- Preserved mobile spacing/depth on card components (`p-8 md:p-12`, existing radius/shadow system retained).

## 🔍 Evidence/Media (screenshots/videos)

<img width="1901" height="974" alt="image" src="https://github.com/user-attachments/assets/fcea6318-5abe-4176-aa45-82a0f29088b4" />
<img width="1883" height="970" alt="image" src="https://github.com/user-attachments/assets/9d3554b9-71b7-441a-afa3-e81f1acf6512" />