### PR TITLE
feat(privacy): add dark mode support and fix background z-index #1177

### DIFF
--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -47,22 +47,22 @@ export default function PrivacyPage() {
         {/* Heading */}
         <div className="text-center mb-20 md:mb-28 animate-fadeInUp">
           <p
-            className="text-[11px] font-black uppercase tracking-[0.4em] mb-4 text-[#149A9B]">
+            className="text-[11px] font-black uppercase tracking-[0.4em] mb-4 text-theme-primary">
             Data Governance
           </p>
           <h1
-            className="text-4xl sm:text-5xl md:text-7xl font-black tracking-tighter text-[#19213D] leading-none mb-6"
+            className="text-4xl sm:text-5xl md:text-7xl font-black tracking-tighter text-content-primary leading-none mb-6"
           >
-            Privacy & <span className="text-[#149A9B]">Transparency</span>
+            Privacy & <span className="text-theme-primary">Transparency</span>
           </h1>
           <p
-            className="mt-4 text-lg sm:text-xl font-medium max-w-2xl mx-auto px-2 text-[#6D758F] leading-relaxed"
+            className="mt-4 text-lg sm:text-xl font-medium max-w-2xl mx-auto px-2 text-content-secondary leading-relaxed"
           >
             We believe in full transparency about how we handle your data.
             Privacy is a feature, not an afterthought.
           </p>
-          <div className="mt-8 inline-flex items-center gap-2 px-4 py-2 rounded-full bg-[#F1F3F7] shadow-raised-sm text-xs font-bold text-[#6D758F]">
-            Last updated: <span className="text-[#149A9B]">February 25, 2026</span>
+          <div className="mt-8 inline-flex items-center gap-2 px-4 py-2 rounded-full bg-bg-elevated shadow-neu-raised-sm text-xs font-bold text-content-secondary">
+            Last updated: <span className="text-theme-primary">February 25, 2026</span>
           </div>
         </div>
 
@@ -74,22 +74,21 @@ export default function PrivacyPage() {
               <div
                 key={feature.title}
                 className={`${feature.large ? "sm:col-span-2 md:col-span-2" : ""
-                  } p-10 rounded-[2.5rem] shadow-raised flex flex-col gap-6 group hover:shadow-raised-hover transition-all duration-500`}
-                style={{ background: "#F1F3F7" }}
+                  } p-10 rounded-[2.5rem] bg-bg-elevated shadow-neu-raised flex flex-col gap-6 group hover:shadow-neu-raised-hover transition-all duration-500`}
               >
                 <div
-                  className="w-14 h-14 rounded-2xl shadow-sunken-subtle flex items-center justify-center shrink-0 bg-[#F1F3F7] group-hover:shadow-sunken transition-all duration-300"
+                  className="w-14 h-14 rounded-2xl shadow-neu-sunken-subtle flex items-center justify-center shrink-0 bg-bg-elevated group-hover:shadow-neu-sunken transition-all duration-300"
                 >
-                  <Icon size={24} style={{ color: "#149A9B" }} />
+                  <Icon size={24} className="text-theme-primary" />
                 </div>
                 <div>
                   <h3
-                    className={`font-black tracking-tight mb-4 ${feature.large ? "text-2xl" : "text-xl"} text-[#19213D]`}
+                    className={`font-black tracking-tight mb-4 ${feature.large ? "text-2xl" : "text-xl"} text-content-primary`}
                   >
                     {feature.title}
                   </h3>
                   <p
-                    className={`font-medium leading-relaxed ${feature.large ? "text-base" : "text-sm"} text-[#6D758F]`}
+                    className={`font-medium leading-relaxed ${feature.large ? "text-base" : "text-sm"} text-content-secondary`}
                   >
                     {feature.description}
                   </p>
@@ -101,19 +100,19 @@ export default function PrivacyPage() {
 
         {/* Contact card */}
         <div
-          className="p-8 sm:p-12 md:p-14 rounded-[3rem] shadow-raised flex flex-col md:flex-row md:items-center md:justify-between gap-10 md:gap-14 mt-16 bg-[#F1F3F7]"
+          className="p-8 sm:p-12 md:p-14 rounded-[3rem] shadow-neu-raised flex flex-col md:flex-row md:items-center md:justify-between gap-10 md:gap-14 mt-16 bg-bg-elevated"
         >
           {/* Left: copy */}
           <div className="flex flex-col gap-6 md:max-w-md">
             <div
-              className="w-14 h-14 rounded-2xl flex items-center justify-center shrink-0 shadow-sunken-subtle bg-[#F1F3F7]"
+              className="w-14 h-14 rounded-2xl flex items-center justify-center shrink-0 shadow-neu-sunken-subtle bg-bg-elevated"
             >
-              <Mail size={24} className="text-[#149A9B]" />
+              <Mail size={24} className="text-theme-primary" />
             </div>
             <div>
-              <h2 className="text-3xl font-black text-[#19213D] tracking-tight mb-4">Get in Touch</h2>
+              <h2 className="text-3xl font-black text-content-primary tracking-tight mb-4">Get in Touch</h2>
               <p
-                className="font-medium leading-relaxed text-base text-[#6D758F]"
+                className="font-medium leading-relaxed text-base text-content-secondary"
               >
                 Questions about this policy or how we handle your data? Our privacy
                 team is here to help. We aim to respond to all inquiries within 2
@@ -131,21 +130,21 @@ export default function PrivacyPage() {
               <a
                 key={email}
                 href={`mailto:${email}`}
-                className="flex flex-col gap-1 rounded-2xl px-6 py-5 transition-all duration-300 shadow-sunken-subtle bg-[#F1F3F7] hover:shadow-sunken group"
+                className="flex flex-col gap-1 rounded-2xl px-6 py-5 transition-all duration-300 shadow-neu-sunken-subtle bg-bg-elevated hover:shadow-neu-sunken group"
               >
-                <span className="text-[10px] font-black uppercase tracking-widest text-[#6D758F]">
+                <span className="text-[10px] font-black uppercase tracking-widest text-content-secondary">
                   {label}
                 </span>
-                <span className="text-base font-bold text-[#149A9B] group-hover:text-[#19213D] transition-colors">
+                <span className="text-base font-bold text-theme-primary group-hover:text-content-primary transition-colors">
                   {email}
                 </span>
               </a>
             ))}
 
             <div
-              className="rounded-2xl px-6 py-5 shadow-raised-sm bg-[#F1F3F7]"
+              className="rounded-2xl px-6 py-5 shadow-neu-raised-sm bg-bg-elevated"
             >
-              <p className="text-xs leading-relaxed font-medium text-[#6D758F]">
+              <p className="text-xs leading-relaxed font-medium text-content-secondary">
                 Offer Hub Inc.
                 <br />
                 123 Market Street, Suite 400

--- a/src/components/ui/InteractiveDotGrid.tsx
+++ b/src/components/ui/InteractiveDotGrid.tsx
@@ -209,7 +209,7 @@ export function InteractiveDotGrid({
                 inset: 0,
                 width: "100vw",
                 height: "100vh",
-                zIndex: 0,
+                zIndex: -1,
                 display: "block",
             }}
         />


### PR DESCRIPTION
# Title: feat(privacy): add dark mode support and fix background z-index #1177

## 📘 Description
This PR resolves issue #1177 by migrating the Privacy Policy page to the project's dynamic theme system (supporting Dark/Light mode) and fixing a visual overlap issue with the background dot grid layer.

## ✅ Key Changes
- 🎨 **Dark Mode Support**: Replaced static Light Mode HEX values (#F1F3F7, #19213D) with standard layout tokens like `bg-bg-elevated`, `text-content-primary`, and `text-theme-primary`.
- 💎 **Neumorphic Card Refinement**: Updated Bento grid cards to use theme-aware shadow tokens: `shadow-neu-raised` and `hover:shadow-neu-raised-hover`.
- 🛡️ **Legibility & Icons**: Updated styling on `lucide-react` icons and the "Last updated" pill to remain perfectly visible across both theme environments.
- 🌫️ **Background Layering Fix**: Adjusted [InteractiveDotGrid](cci:1://file:///c:/Trabajos%20Progra/DRIPS-WAVE/offer-hub/src/components/ui/InteractiveDotGrid.tsx:19:0-216:1) canvas container `zIndex` from `0` to `-1` to guarantee it renders safely behind all visual interface layers.

## 📸 Testing Evidence

https://github.com/user-attachments/assets/66d09c1f-492e-451b-9c55-5a8e47eb9640


Closes #1177

