### PR TITLE
feat(changelog): replace hardcoded timeline with live GitHub Releases…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -856,7 +855,6 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -867,7 +865,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -877,14 +874,12 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -1115,7 +1110,6 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -1129,7 +1123,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -1139,7 +1132,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -1724,8 +1716,8 @@
       "version": "19.2.13",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.13.tgz",
       "integrity": "sha512-KkiJeU6VbYbUOp5ITMIc7kBfqlYkKA5KhEHVrGMmUUMt7NeaZg65ojdPk+FtNrBAOXNVM5QM72jnADjM+XVRAQ==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1807,6 +1799,7 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -2298,6 +2291,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2351,14 +2345,12 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -2372,7 +2364,6 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/argparse": {
@@ -2691,7 +2682,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2715,7 +2705,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -2744,6 +2733,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2822,7 +2812,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -2940,6 +2929,7 @@
       "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.1.1.tgz",
       "integrity": "sha512-f0yv5CPKaFxfsPTBzX7vGuim4oIC1/gcS7LUGdBSwl2dU6+FON6LVUksdOo1qJjoUvXNn45urgh8C+0a24pACQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@chevrotain/cst-dts-gen": "11.1.1",
         "@chevrotain/gast": "11.1.1",
@@ -2965,7 +2955,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
@@ -2990,7 +2979,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -3058,7 +3046,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -3138,7 +3125,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cytoscape": {
@@ -3146,6 +3132,7 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
       "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -3555,6 +3542,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -3834,14 +3822,12 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/doctrine": {
@@ -4136,6 +4122,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4309,6 +4296,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -4743,7 +4731,6 @@
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
       "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -4772,7 +4759,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -4880,7 +4866,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -4895,7 +4880,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5025,7 +5009,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -5205,7 +5188,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -5515,7 +5497,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
@@ -5568,7 +5549,6 @@
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
       "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
@@ -5638,7 +5618,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5684,7 +5663,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -5733,7 +5711,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -5949,8 +5926,8 @@
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -6151,7 +6128,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
       "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -6164,7 +6140,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/locate-path": {
@@ -6575,7 +6550,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -7330,7 +7304,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -7400,7 +7373,6 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0",
@@ -7562,7 +7534,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7572,7 +7543,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7582,7 +7552,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -7866,7 +7835,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/pathe": {
@@ -7892,7 +7860,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -7905,7 +7872,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7915,7 +7881,6 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
       "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -7962,7 +7927,6 @@
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
       "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -7978,6 +7942,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -7991,7 +7956,6 @@
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
       "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
@@ -8009,7 +7973,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
       "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -8035,7 +7998,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
       "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -8078,7 +8040,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
       "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -8104,7 +8065,6 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -8118,7 +8078,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/prelude-ls": {
@@ -8167,7 +8126,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -8199,6 +8157,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8208,6 +8167,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -8226,7 +8186,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
       "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
@@ -8236,7 +8195,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
@@ -8486,7 +8444,6 @@
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
       "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-core-module": "^2.16.1",
@@ -8527,7 +8484,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -8566,7 +8522,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9169,7 +9124,6 @@
       "version": "3.35.1",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
       "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -9205,7 +9159,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9238,8 +9191,8 @@
       "version": "3.4.19",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -9276,7 +9229,6 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -9293,7 +9245,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -9315,7 +9266,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
       "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0"
@@ -9325,7 +9275,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "thenify": ">= 3.1.0 < 4"
@@ -9347,7 +9296,6 @@
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -9364,7 +9312,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -9382,8 +9329,8 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9395,7 +9342,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -9450,7 +9396,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/tsconfig-paths": {
@@ -9569,6 +9514,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/app/changelog/loading.tsx
+++ b/src/app/changelog/loading.tsx
@@ -1,0 +1,71 @@
+import { Navbar } from "@/components/layout/Navbar";
+import { Footer } from "@/components/layout/Footer";
+
+function TimelineEntrySkeleton({ reverse = false }: { reverse?: boolean }) {
+  return (
+    <div
+      className={`relative flex flex-col md:flex-row items-start md:items-center md:justify-between ${reverse ? "md:flex-row-reverse" : ""}`}
+    >
+      <div className="absolute left-6 md:left-1/2 transform -translate-x-1/2 w-6 h-6 rounded-full bg-bg-base shadow-neu-raised-sm z-10 flex items-center justify-center">
+        <div className="w-2 h-2 rounded-full bg-theme-primary/40" />
+      </div>
+
+      <div className={`hidden md:block w-5/12 ${reverse ? "text-left" : "text-right"}`}>
+        <div className="h-3 w-28 bg-bg-elevated rounded-full shadow-neu-raised-sm animate-pulse inline-block" />
+      </div>
+
+      <div className="w-full md:w-5/12 pl-12 md:pl-0">
+        <div className="bg-bg-elevated rounded-[2.5rem] p-8 md:p-10 shadow-neu-raised animate-pulse">
+          <div className="flex items-center justify-between mb-6 gap-3">
+            <div className="flex items-center gap-3">
+              <div className="h-8 w-20 rounded bg-bg-base" />
+              <div className="h-5 w-16 rounded-full bg-bg-base" />
+            </div>
+            <div className="h-4 w-20 rounded bg-bg-base md:hidden" />
+          </div>
+
+          <div className="h-6 w-2/3 rounded bg-bg-base mb-4" />
+          <div className="h-4 w-full rounded bg-bg-base mb-2" />
+          <div className="h-4 w-5/6 rounded bg-bg-base mb-6" />
+
+          <div className="space-y-3">
+            {[1, 2, 3].map((item) => (
+              <div key={item} className="flex items-start gap-3">
+                <span className="mt-2 h-1 w-1 rounded-full bg-theme-primary/40 shrink-0" />
+                <div className="h-4 w-4/5 rounded bg-bg-base" />
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function ChangelogLoading() {
+  return (
+    <div className="min-h-screen flex flex-col bg-transparent">
+      <Navbar />
+      <main className="flex-grow pt-32 pb-24 px-6 md:px-8">
+        <div className="max-w-4xl mx-auto">
+          <header className="text-center mb-24">
+            <div className="h-3 w-24 rounded mx-auto bg-bg-elevated shadow-neu-raised-sm mb-4 animate-pulse" />
+            <div className="h-12 md:h-14 w-2/3 mx-auto rounded bg-bg-elevated shadow-neu-raised mb-6 animate-pulse" />
+            <div className="h-5 w-5/6 md:w-2/3 mx-auto rounded bg-bg-elevated shadow-neu-raised-sm animate-pulse" />
+          </header>
+
+          <div className="relative">
+            <div className="absolute left-6 md:left-1/2 top-4 bottom-4 w-1 transform md:-translate-x-1/2 bg-theme-primary/10 dark:bg-theme-primary/30 rounded-full" />
+
+            <div className="space-y-16 md:space-y-24">
+              <TimelineEntrySkeleton reverse />
+              <TimelineEntrySkeleton />
+              <TimelineEntrySkeleton reverse />
+            </div>
+          </div>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/app/changelog/page.tsx
+++ b/src/app/changelog/page.tsx
@@ -1,64 +1,145 @@
-"use client";
-
 import { Navbar } from "@/components/layout/Navbar";
 import { Footer } from "@/components/layout/Footer";
 
-const changelogEntries = [
-  {
-    version: "v0.3.0",
-    date: "March 2024",
-    title: "New UI Components",
-    badge: "Feature",
-    badgeColor: "bg-theme-primary/10 text-theme-primary",
-    description:
-      "Introduced a new set of neumorphic UI components, improved accessibility, and updated the brand palette for better consistency.",
-    changes: [
-      "Added Neumorphic Card component",
-      "Enhanced mobile navigation",
-      "New icon set integration",
-    ],
-  },
-  {
-    version: "v0.2.0",
-    date: "February 2024",
-    title: "Performance Updates",
-    badge: "Fix",
-    badgeColor: "bg-theme-success/10 text-theme-success",
-    description:
-      "Optimized bundle size and improved page load times by implementing better code splitting and image optimization strategies.",
-    changes: [
-      "Reduced main bundle size by 15%",
-      "Improved LCP scores",
-      "Fixed memory leaks in dashboard charts",
-    ],
-  },
-  {
-    version: "v0.1.0",
-    date: "January 2024",
-    title: "Initial Launch",
-    badge: "Breaking",
-    badgeColor: "bg-theme-error/10 text-theme-error",
-    description:
-      "The first official release of Offer Hub, featuring secure escrow payments and marketplace integration tools.",
-    changes: [
-      "Core escrow protocol implementation",
-      "Marketplace API v1 release",
-      "Initial landing page and docs",
-    ],
-  },
-];
+interface GitHubRelease {
+  tag_name: string;
+  name: string | null;
+  body: string | null;
+  draft: boolean;
+  prerelease: boolean;
+  published_at: string | null;
+  created_at: string;
+}
 
-export default function ChangelogPage() {
+interface ChangelogEntry {
+  version: string;
+  date: string;
+  title: string;
+  badge: string;
+  badgeColor: string;
+  description: string;
+  changes: string[];
+}
+
+const RELEASES_API_URL = "https://api.github.com/repos/OFFER-HUB/offer-hub-monorepo/releases";
+
+function formatReleaseDate(dateString: string): string {
+  return new Intl.DateTimeFormat("en-US", {
+    month: "long",
+    year: "numeric",
+  }).format(new Date(dateString));
+}
+
+function removeMarkdownInlineSyntax(text: string): string {
+  return text
+    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, "$1")
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/\*\*([^*]+)\*\*/g, "$1")
+    .replace(/\*([^*]+)\*/g, "$1")
+    .replace(/__([^_]+)__/g, "$1")
+    .replace(/_([^_]+)_/g, "$1")
+    .trim();
+}
+
+function parseReleaseBody(body: string | null): Pick<ChangelogEntry, "description" | "changes"> {
+  const rawBody = body?.trim();
+
+  if (!rawBody) {
+    return {
+      description: "No release notes were provided for this version.",
+      changes: ["See full release details on GitHub."],
+    };
+  }
+
+  const lines = rawBody
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  const changes = lines
+    .map((line) => line.match(/^[-*+]\s+(.+)$/)?.[1] ?? line.match(/^\d+\.\s+(.+)$/)?.[1] ?? null)
+    .filter((line): line is string => Boolean(line))
+    .map(removeMarkdownInlineSyntax);
+
+  const firstMeaningfulLine = lines.find(
+    (line) => !/^[-*+]\s+/.test(line) && !/^\d+\.\s+/.test(line) && !/^#+\s+/.test(line),
+  );
+
+  return {
+    description: firstMeaningfulLine
+      ? removeMarkdownInlineSyntax(firstMeaningfulLine)
+      : "Release notes are available in the full GitHub release details.",
+    changes: changes.length > 0 ? changes : ["See full release details on GitHub."],
+  };
+}
+
+function getReleaseBadge(release: Pick<GitHubRelease, "draft" | "prerelease">): Pick<ChangelogEntry, "badge" | "badgeColor"> {
+  if (release.draft) {
+    return {
+      badge: "Draft",
+      badgeColor: "bg-content-secondary/10 text-content-secondary",
+    };
+  }
+
+  if (release.prerelease) {
+    return {
+      badge: "Pre-release",
+      badgeColor: "bg-theme-warning/10 text-theme-warning",
+    };
+  }
+
+  return {
+    badge: "Release",
+    badgeColor: "bg-theme-success/10 text-theme-success",
+  };
+}
+
+function mapReleaseToEntry(release: GitHubRelease): ChangelogEntry {
+  const { description, changes } = parseReleaseBody(release.body);
+  const badge = getReleaseBadge(release);
+
+  return {
+    version: release.tag_name,
+    date: formatReleaseDate(release.published_at ?? release.created_at),
+    title: release.name?.trim() || `Release ${release.tag_name}`,
+    description,
+    changes,
+    ...badge,
+  };
+}
+
+async function fetchChangelogEntries(): Promise<{ entries: ChangelogEntry[]; hasError: boolean }> {
+  try {
+    const response = await fetch(RELEASES_API_URL, {
+      next: { revalidate: 3600 },
+      headers: {
+        Accept: "application/vnd.github+json",
+      },
+    });
+
+    if (!response.ok) {
+      return { entries: [], hasError: true };
+    }
+
+    const releases = (await response.json()) as GitHubRelease[];
+
+    return {
+      entries: releases.map(mapReleaseToEntry),
+      hasError: false,
+    };
+  } catch (error) {
+    console.error("Failed to fetch GitHub releases:", error);
+    return { entries: [], hasError: true };
+  }
+}
+
+export default async function ChangelogPage() {
+  const { entries: changelogEntries, hasError } = await fetchChangelogEntries();
+
   return (
     <div className="min-h-screen flex flex-col bg-transparent">
       {/* Subtle teal glow centered */}
-      <div
-        className="absolute inset-0 pointer-events-none"
-        style={{
-          background:
-            "radial-gradient(ellipse 60% 45% at 50% 50%, rgba(20,154,155,0.07) 0%, transparent 70%)",
-        }}
-      />
+      <div className="absolute inset-0 pointer-events-none bg-[radial-gradient(ellipse_60%_45%_at_50%_50%,rgba(20,154,155,0.07)_0%,transparent_70%)]" />
       <Navbar />
 
       <main className="flex-grow pt-32 pb-24 px-6 md:px-8">
@@ -79,8 +160,22 @@ export default function ChangelogPage() {
             {/* Improved Timeline Line */}
             <div className="absolute left-6 md:left-1/2 top-4 bottom-4 w-1 transform md:-translate-x-1/2 bg-theme-primary/10 dark:bg-theme-primary/30 rounded-full" />
 
-            <div className="space-y-16 md:space-y-24">
-              {changelogEntries.map((entry, index) => (
+            {changelogEntries.length === 0 ? (
+              <div className="pl-12 md:pl-0">
+                <div className="max-w-2xl mx-auto bg-bg-elevated rounded-[2.5rem] p-8 md:p-10 shadow-neu-raised text-center">
+                  <h2 className="text-2xl font-black text-content-primary tracking-tight mb-4">
+                    No releases published yet
+                  </h2>
+                  <p className="text-content-secondary text-sm md:text-base font-medium leading-relaxed">
+                    {hasError
+                      ? "We couldn’t load GitHub Releases right now. Please try again shortly."
+                      : "As soon as a GitHub release is published, it will appear here automatically."}
+                  </p>
+                </div>
+              </div>
+            ) : (
+              <div className="space-y-16 md:space-y-24">
+                {changelogEntries.map((entry, index) => (
                 <div
                   key={entry.version}
                   className={`relative flex flex-col md:flex-row items-start md:items-center md:justify-between ${index % 2 === 0 ? "md:flex-row-reverse" : ""
@@ -140,8 +235,9 @@ export default function ChangelogPage() {
                     </div>
                   </div>
                 </div>
-              ))}
-            </div>
+                ))}
+              </div>
+            )}
           </div>
         </div>
       </main>

--- a/src/app/community/page.tsx
+++ b/src/app/community/page.tsx
@@ -156,7 +156,13 @@ function processGitHubData(validData: NonNullable<Awaited<ReturnType<typeof fetc
       return { number: issue.number, title: issue.title, priority, url: issue.html_url, labels: issue.labels.map(l => l.name), createdAt: issue.created_at || "" };
     })
     .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
-  const issues: IssueData[] = allIssues.slice(0, 50).map(({ createdAt: _createdAt, ...rest }) => rest);
+  const issues: IssueData[] = allIssues.slice(0, 50).map(({ number, title, priority, url, labels }) => ({
+    number,
+    title,
+    priority,
+    url,
+    labels,
+  }));
 
   return { stats, contributors, pullRequests, issues };
 }

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -2,7 +2,7 @@
 
 import { useRef, useEffect } from "react";
 import DocsSearchBar from "@/components/docs/DocsSearchBar";
-import { Book, Code, Shield, LifeBuoy, Terminal, Zap, Home } from "lucide-react";
+import { Book, Code, Shield, LifeBuoy, Terminal, Zap } from "lucide-react";
 import Link from "next/link";
 import { cn } from "@/lib/cn";
 

--- a/src/components/community/ContributorsSection.tsx
+++ b/src/components/community/ContributorsSection.tsx
@@ -3,6 +3,7 @@
 import { useState, memo } from "react";
 import { Users, GitCommit, ChevronDown } from "lucide-react";
 import SectionHeading from "@/components/community/SectionHeading";
+import Image from "next/image";
 
 interface ContributorData {
   name: string;
@@ -23,11 +24,11 @@ const ContributorCard = memo(function ContributorCard({ person }: { person: Cont
       <div className="flex flex-col items-center text-center gap-4">
         {person.avatar ? (
           <div className="p-1 rounded-full bg-bg-base shadow-neu-sunken-subtle group-hover:shadow-neu-sunken transition-shadow">
-            <img
+            <Image
               src={person.avatar}
               alt={person.name}
-              loading="lazy"
-              decoding="async"
+              width={64}
+              height={64}
               className="w-16 h-16 rounded-full object-cover"
             />
           </div>

--- a/src/components/community/PRCard.tsx
+++ b/src/components/community/PRCard.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import Image from "next/image";
 
 export interface PRCardProps {
   title: string;
@@ -45,6 +46,7 @@ export default function PRCard({
   labels,
 }: PRCardProps) {
   const mergedDate = formatMergedAt(mergedAt);
+  const hasAvatar = Boolean(authorAvatar);
 
   return (
     <article
@@ -67,12 +69,17 @@ export default function PRCard({
       </div>
 
       <div className="mt-4 flex items-center gap-2">
-        <img
-          src={authorAvatar}
-          alt={`${author} avatar`}
-          className="h-8 w-8 rounded-full object-cover shadow-neu-raised-sm"
-          loading="lazy"
-        />
+        {hasAvatar ? (
+          <Image
+            src={authorAvatar}
+            alt={`${author} avatar`}
+            width={32}
+            height={32}
+            className="h-8 w-8 rounded-full object-cover shadow-neu-raised-sm"
+          />
+        ) : (
+          <div className="h-8 w-8 rounded-full shadow-neu-raised-sm bg-bg-elevated" />
+        )}
         <p className="text-xs text-content-secondary">
           {author}
         </p>

--- a/src/components/docs/DocsLayoutShell.tsx
+++ b/src/components/docs/DocsLayoutShell.tsx
@@ -7,12 +7,11 @@ import {
   Menu, X, ChevronRight, Home
 } from "lucide-react";
 
-import { cn } from "@/lib/cn";
 import type { Heading, SidebarSection } from "@/lib/mdx";
 import { DocsSidebar } from "@/components/docs/DocsSidebar";
 import { TableOfContents } from "@/components/docs/TableOfContents";
 import { Navbar } from "@/components/layout/Navbar";
-import { FileCode2, FileJson, FileText, Github } from "lucide-react";
+import { FileCode2, FileText, Github } from "lucide-react";
 
 // Use production URL for AI assistant links
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://offer-hub.tech";
@@ -184,8 +183,7 @@ export function DocsLayoutShell({ nav, children }: DocsLayoutShellProps) {
             onClick={() => setIsDrawerOpen(false)}
           />
           <aside
-            className="relative h-full w-80 max-w-[85vw] p-8 bg-bg-base shadow-neu-raised"
-            style={{ borderTopRightRadius: "30px", borderBottomRightRadius: "30px" }}
+            className="relative h-full w-80 max-w-[85vw] p-8 bg-bg-base shadow-neu-raised rounded-r-[30px]"
           >
             <div className="mb-8 flex items-center justify-between pb-4 border-b border-theme-border/40">
               <p className="text-sm font-bold uppercase tracking-widest text-[#149A9B]">
@@ -213,7 +211,6 @@ export function DocsLayoutShell({ nav, children }: DocsLayoutShellProps) {
 import { ExportJSON } from "@/components/docs/ExportJSON";
 
 function DocActionsMenu({ slug }: { slug: string }) {
-  const [isOpen, setIsOpen] = useState(false);
   const [isExportingPdf, setIsExportingPdf] = useState(false);
   const [copyStatus, setCopyStatus] = useState<string | null>(null);
 
@@ -255,47 +252,6 @@ function DocActionsMenu({ slug }: { slug: string }) {
       console.error("Copy failed", err);
       setCopyStatus("Failed to copy");
       setTimeout(() => setCopyStatus(null), 2000);
-    }
-  };
-
-  const handleViewPlainText = () => {
-    const { markdown, title } = getPageContent();
-    const fullContent = `# ${title}\n\nSource: ${SITE_URL}/docs/${slug}\n\n${markdown}`;
-
-    // Create a new window with proper styling
-    const win = window.open("", "_blank");
-    if (win) {
-      win.document.write(`
-        <!DOCTYPE html>
-        <html>
-        <head>
-          <title>${title} - Plain Text</title>
-          <style>
-            body {
-              font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
-              padding: 2rem;
-              max-width: 800px;
-              margin: 0 auto;
-              line-height: 1.6;
-              background: #f8f9fa;
-              color: #1a1a1a;
-            }
-            pre {
-              white-space: pre-wrap;
-              word-wrap: break-word;
-              background: white;
-              padding: 1.5rem;
-              border-radius: 8px;
-              border: 1px solid #e1e4e8;
-            }
-          </style>
-        </head>
-        <body>
-          <pre>${fullContent.replace(/</g, "&lt;").replace(/>/g, "&gt;")}</pre>
-        </body>
-        </html>
-      `);
-      win.document.close();
     }
   };
 
@@ -341,90 +297,6 @@ function DocActionsMenu({ slug }: { slug: string }) {
       setIsExportingPdf(false);
     }
   };
-
-  const actions = [
-    {
-      label: copyStatus || "Copy as Markdown",
-      sublabel: copyStatus ? "Ready to paste!" : "Best for sharing with Claude/ChatGPT",
-      icon: (
-        <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2" className="w-4 h-4">
-          {copyStatus ? (
-            <path d="M20 6L9 17l-5-5" strokeLinecap="round" strokeLinejoin="round" />
-          ) : (
-            <>
-              <rect width="14" height="14" x="8" y="8" rx="2" ry="2" />
-              <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
-            </>
-          )}
-        </svg>
-      ),
-      onClick: handleCopyMarkdown
-    },
-    {
-      label: "View Plain Text",
-      sublabel: "See raw documentation content",
-      icon: (
-        <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2" className="w-4 h-4">
-          <path d="M4 22h14a2 2 0 0 0 2-2V7.5L14.5 2H6a2 2 0 0 0-2 2v4" />
-          <polyline points="14 2 14 8 20 8" />
-          <path d="m3 15 2 2 4-4" />
-        </svg>
-      ),
-      onClick: handleViewPlainText
-    },
-    {
-      type: "divider"
-    },
-    {
-      label: "Ask ChatGPT",
-      sublabel: "Discuss this page with OpenAI",
-      icon: (
-        <svg viewBox="0 0 24 24" fill="currentColor" className="w-4 h-4 text-[#10A37F]">
-          <path d="M22.28 9.82a5.39 5.39 0 0 0-1.07-3.79 5.48 5.48 0 0 0-3.92-2.22 5.41 5.41 0 0 0-4.39-.46 5.39 5.39 0 0 0-3.34-1.79 5.48 5.48 0 0 0-4.48 1.26 5.41 5.41 0 0 0-2.43 3.73 5.39 5.39 0 0 0-1.63 3.52 5.48 5.48 0 0 0 .54 4.54 5.41 5.41 0 0 0 3.73 2.43 5.39 5.39 0 0 0 1.79 3.34 5.48 5.48 0 0 0 4.54.54 5.41 5.41 0 0 0 2.43-3.73 5.39 5.39 0 0 0 3.52-1.63 5.48 5.48 0 0 0 1.26-4.48 5.41 5.41 0 0 0 3.19-4.28zm-10.43 8.33a3.3 3.3 0 0 1-2.1-.73 3.35 3.35 0 0 1-1.24-2.1c-.04-.26-.06-.52-.06-.79l-.01-5l2.25 1.3a.75.75 0 0 0 1.13-.65v-2.6L14 7.03l2.25 1.3c.2.11.43.17.66.17a1.32 1.32 0 0 0 .66-.17l2.25-1.3a3.3 3.3 0 0 1 .73 2.1 3.35 3.35 0 0 1-1.24 2.1l-2.25 1.3v2.6a.75.75 0 0 0 1.12.65l2.25-1.3c.1-.06.21-.11.31-.17a3.3 3.3 0 0 1-.73 2.1l-2.25 1.3a3.35 3.35 0 0 1-2.1 1.24 3.3 3.3 0 0 1-2.1-.01zm-5.75-5.07a3.3 3.3 0 0 1-.73-2.1l.01-2.6a.75.75 0 0 0-1.13-.65l-2.25 1.3a1.32 1.32 0 0 0-.31.17 3.35 3.35 0 0 1 .73-2.1 3.3 3.3 0 0 1 2.1-1.24 3.35 3.35 0 0 1 2.1.01 3.3 3.3 0 0 1 2.1.73l2.25 1.3v2.6a.75.75 0 0 0-1.12.65l-2.25-1.3-2.25-1.3a1.32 1.32 0 0 0-.66-.17c-.23 0-.46.06-.66.17l-2.25 1.3a3.35 3.35 0 0 1 1.24 2.1zm-1.83-9.1a3.3 3.3 0 0 1 2.1-.73l2.25 1.3v2.6a.75.75 0 0 0 1.12.65l2.25-1.3 2.25-1.3a1.32 1.32 0 0 0 .66-.17c.23 0 .46.06.66.17l2.25 1.3a3.35 3.35 0 0 1-1.24 2.1 3.3 3.3 0 0 1-2.1.73 3.35 3.35 0 0 1-2.1-.01l-2.25-1.3v-2.6a.75.75 0 0 0-1.13-.65l-2.25 1.3a3.3 3.3 0 0 1-.73-2.1zm12.33 3.42a3.35 3.35 0 0 1 .73 2.1v2.6a.75.75 0 0 0 1.12.65l2.25-1.3a1.32 1.32 0 0 0 .31-.17 3.35 3.35 0 0 1-.73 2.1 3.3 3.3 0 0 1-2.1 1.24 3.35 3.35 0 0 1-2.1-.01 3.3 3.3 0 0 1-2.1-.73l-2.25-1.3v-2.6a.75.75 0 0 0 1.13-.65l2.25 1.3 2.25 1.3a1.32 1.32 0 0 0 .66.17c.23 0 .46-.06.66-.17l2.25-1.3a3.35 3.35 0 0 1-1.24-2.1zm1.83 5.48a3.3 3.3 0 0 1-2.1.73l-2.25-1.3v-2.6a.75.75 0 0 0-1.12-.65l-2.25 1.3-2.25 1.3a1.32 1.32 0 0 0-.66.17c-.23 0-.46-.06-.66-.17l-2.25-1.3a3.35 3.35 0 0 1 1.24-2.1 3.3 3.3 0 0 1 2.1-.73 3.35 3.35 0 0 1 2.1.01l2.25 1.3v2.6a.75.75 0 0 0 1.13.65l2.25-1.3a3.3 3.3 0 0 1 .73 2.1z" />
-        </svg>
-      ),
-      external: true,
-      onClick: () => window.open(`https://chatgpt.com/?q=${encodeURIComponent("Please help me with this documentation page: " + SITE_URL + "/docs/" + slug)}`, "_blank")
-    },
-    {
-      label: "Ask Claude",
-      sublabel: "Discuss this page with Anthropic",
-      icon: (
-        <svg viewBox="0 0 24 24" fill="currentColor" className="w-4 h-4 text-[#D97706]">
-          <path d="M11.63 21.01a.34.34 0 0 1-.36-.08.33.33 0 0 1-.08-.36l4.08-11.41a.36.36 0 0 1 .33-.24h2.18c.24 0 .42.24.34.46l-4.08 11.4a.34.34 0 0 1-.3.23h-2.11zm-5.79 0a.34.34 0 0 1-.33-.24l-4.08-11.4a.34.34 0 0 1 .08-.34.33.33 0 0 1 .34-.08l2.11.23a.35.35 0 0 1 .23.36l4.08 11.4c.08.23-.08.47-.32.47H5.84zm6.65-17.15c.16 0 .31.1.37.26l1.3 3.65a.39.39 0 0 1-.37.52H1.38c-.24 0-.42-.25-.34-.47l1.3-3.65a.39.39 0 0 1 .37-.3h9.78z" />
-        </svg>
-      ),
-      external: true,
-      onClick: () => window.open(`https://claude.ai/new?q=${encodeURIComponent("Please help me with this documentation page: " + SITE_URL + "/docs/" + slug)}`, "_blank")
-    },
-    {
-      type: "divider"
-    },
-    {
-      label: "Copy MCP URL",
-      sublabel: "For Cursor, VSCode, or Windsurf",
-      icon: (
-        <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2" className="w-4 h-4 text-content-primary">
-          <rect x="4" y="4" width="16" height="16" rx="2" ry="2" />
-          <rect x="9" y="9" width="6" height="6" />
-          <path d="M9 1v3M15 1v3M9 20v3M15 20v3M20 9h3M20 15h3M1 9h3M1 15h3" />
-        </svg>
-      ),
-      onClick: () => navigator.clipboard.writeText(`${SITE_URL}/api/mcp`)
-    },
-    {
-      label: "Export PDF",
-      sublabel: isExportingPdf ? "Generating..." : "Download for offline reading",
-      icon: (
-        <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2" className="w-4 h-4 text-[#EF4444]">
-          <path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z" />
-          <polyline points="14 2 14 8 20 8" />
-          <path d="M12 18v-6M9 15l3 3 3-3" />
-        </svg>
-      ),
-      onClick: handleExportPdf
-    },
-  ];
 
   /* ─── Inline helpers ─── */
   async function handleExportMarkdown() {


### PR DESCRIPTION
Closes #1195
- fetch releases from GitHub API with ISR revalidation
- map release metadata/body to existing changelog entry shape
- add changelog loading skeleton and empty/error fallback states
- preserve existing neumorphic timeline card/badge UI
- remove static mock changelog entries
- clean related lint warnings in docs/community components

# 📝 Pull Request

## 🔧 Title:

- feat(changelog): replace hardcoded timeline with live GitHub Releases data

## 🛠️ Issue

- Closes #1195

## 📚 Description

- This PR replaces the static, fictitious changelog timeline with live data from the GitHub Releases API (`OFFER-HUB/offer-hub-monorepo`).
- The changelog page now maps real release metadata into the existing UI entry structure and parses release notes into description + change bullets.
- It also introduces robust UX states for loading and no-data/API-failure scenarios while preserving the existing neumorphic card/timeline design.

## ✅ Changes applied

- Replaced hardcoded `changelogEntries` in `src/app/changelog/page.tsx` with dynamic server fetch to:
  - `https://api.github.com/repos/OFFER-HUB/offer-hub-monorepo/releases`
- Added cache strategy using Next.js ISR:
  - `next: { revalidate: 3600 }`
- Implemented release-to-entry mapping for:
  - `version`, `date`, `title`, `badge`, `description`, `changes`
- Parsed GitHub release body content into:
  - Human-friendly description text
  - Bullet-based change list
- Added loading UI via route-level skeleton:
  - `src/app/changelog/loading.tsx`
- Added empty/error fallback UI when:
  - No releases are published
  - GitHub API is unavailable
- Removed all static mock changelog entries entirely.
- Preserved existing neumorphic timeline cards and badge styles.
- Cleaned related lint warnings in docs/community components and validated lint passes.

## 🔍 Evidence/Media (screenshots/videos)

- ✅ Lint check: `npm run lint` → no ESLint warnings or errors.
- ✅ Build check: `npm run build` completed successfully with `/changelog` generated and revalidation shown.
- 📸 Visual evidence: changelog now renders real GitHub releases and shows proper loading/empty states (add screenshots from local preview if needed).
