### PR TITLE
fix: add robots.txt and sitemap.xml for search engine crawling

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,12 @@
+# https://www.robotstxt.org/robotstxt.html
+User-agent: *
+Allow: /
+
+# Private API and admin paths
+Disallow: /api/
+Disallow: /admin/
+Disallow: /_next/
+Disallow: /private/
+
+# Sitemap
+Sitemap: https://offer-hub.tech/sitemap.xml

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,64 @@
+import { MetadataRoute } from "next";
+
+const BASE_URL = "https://offer-hub.tech";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const staticRoutes: MetadataRoute.Sitemap = [
+    {
+      url: BASE_URL,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 1.0,
+    },
+    {
+      url: `${BASE_URL}/use-cases`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.8,
+    },
+    {
+      url: `${BASE_URL}/blueprint`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.7,
+    },
+    {
+      url: `${BASE_URL}/pricing`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.8,
+    },
+    {
+      url: `${BASE_URL}/changelog`,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 0.6,
+    },
+    {
+      url: `${BASE_URL}/community`,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 0.7,
+    },
+    {
+      url: `${BASE_URL}/docs`,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 0.9,
+    },
+    {
+      url: `${BASE_URL}/terms`,
+      lastModified: new Date(),
+      changeFrequency: "yearly",
+      priority: 0.3,
+    },
+    {
+      url: `${BASE_URL}/privacy`,
+      lastModified: new Date(),
+      changeFrequency: "yearly",
+      priority: 0.3,
+    },
+  ];
+
+  return staticRoutes;
+}


### PR DESCRIPTION
## Summary

Closes #1205

Adds foundational SEO infrastructure: `robots.txt` for crawler guidance and a dynamic Next.js sitemap for search engine indexing.

## New Files

### `public/robots.txt`
- Allows all crawlers on public routes
- Disallows `/api/`, `/admin/`, `/_next/`, `/private/`
- References sitemap at `https://offer-hub.tech/sitemap.xml`

### `src/app/sitemap.ts`
Uses Next.js App Router's built-in `MetadataRoute.Sitemap` type for automatic sitemap generation.

| Route | Priority | Change Frequency |
|-------|----------|-----------------|
| `/` | 1.0 | weekly |
| `/docs` | 0.9 | weekly |
| `/pricing` | 0.8 | monthly |
| `/use-cases` | 0.8 | monthly |
| `/blueprint` | 0.7 | monthly |
| `/community` | 0.7 | weekly |
| `/changelog` | 0.6 | weekly |
| `/terms` | 0.3 | yearly |
| `/privacy` | 0.3 | yearly |

## Why Dynamic Sitemap

Using `src/app/sitemap.ts` instead of a static `public/sitemap.xml` because:
- Next.js handles it automatically at build time
- Easy to extend with dynamic doc routes from `docs-index.json`
- Type-safe with `MetadataRoute.Sitemap`

## Verification

After deployment, verify:
- `https://offer-hub.tech/robots.txt` returns the robots file
- `https://offer-hub.tech/sitemap.xml` returns valid XML sitemap