### PR TITLE
fix: remove NEXT_PUBLIC_ prefix from API key in code showcase

### DIFF
--- a/src/components/use-cases/ecommerce/CodeIntegrationShowcase.tsx
+++ b/src/components/use-cases/ecommerce/CodeIntegrationShowcase.tsx
@@ -57,9 +57,9 @@ await oh.escrows.fund(order.id, {
     docLabel: "SDK Guide",
     code: `import { OfferHub } from "@offerhub/sdk";
 
-// Client-side SDK (public key only, safe to expose in the browser)
+// Client-side SDK (publishable key only, safe to expose in the browser)
 const oh = new OfferHub({
-  apiKey: process.env.NEXT_PUBLIC_OFFERHUB_KEY,
+  apiKey: "oh_pub_xxxxxxxxxxxxxxxxxxxx",
 });
 
 // Buyer confirms delivery — triggers automatic fund release to the seller.


### PR DESCRIPTION
## Summary

Closes #1210

Replaces `process.env.NEXT_PUBLIC_OFFERHUB_KEY` with a clearly fake demo placeholder in the `CodeIntegrationShowcase` component.

## Context

`CodeIntegrationShowcase.tsx` is a **UI code demo component** that renders SDK examples in two tabs (server.ts / client.js). The client.js tab referenced `process.env.NEXT_PUBLIC_OFFERHUB_KEY` as an API key.

**Problem:** The `NEXT_PUBLIC_` prefix causes Next.js to embed the value directly into the client-side JavaScript bundle at build time. If a real API key were set in this variable, it would be publicly readable by anyone inspecting the page source.

**Fix:** Since this is a code showcase (not actual runtime code), the API key reference is replaced with a clearly fake demo string.

## Change

```diff
-// Client-side SDK (public key only, safe to expose in the browser)
+// Client-side SDK (publishable key only, safe to expose in the browser)
 const oh = new OfferHub({
-  apiKey: process.env.NEXT_PUBLIC_OFFERHUB_KEY,
+  apiKey: "oh_pub_xxxxxxxxxxxxxxxxxxxx",
 });
```

## Notes

- The `server.ts` tab correctly uses `process.env.OFFERHUB_API_KEY!` (no `NEXT_PUBLIC_` prefix) — this is fine as it represents server-side code
- The fake key uses `oh_pub_` prefix to indicate a publishable (not secret) key
- No other files in the codebase reference `NEXT_PUBLIC_OFFERHUB_KEY`