### PR TITLE
fix: add LoadingBar to pages where it is missing for navigation consistency

### DIFF
--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -5,6 +5,7 @@ import type { ComponentType } from "react";
 
 import { Footer } from "@/components/layout/Footer";
 import { Navbar } from "@/components/layout/Navbar";
+import LoadingBar from "@/components/ui/LoadingBar";
 
 export const metadata: Metadata = {
   title: "Pricing | OFFER-HUB",
@@ -81,6 +82,7 @@ export default function PricingPage() {
   return (
     <div className="min-h-screen flex flex-col bg-transparent">
       <Navbar />
+      <LoadingBar />
 
       <main className="flex-grow pt-28 pb-20">
         <section className="max-w-7xl mx-auto px-6 lg:px-8">

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -2,6 +2,7 @@
 
 import { Navbar } from "@/components/layout/Navbar";
 import { Footer } from "@/components/layout/Footer";
+import LoadingBar from "@/components/ui/LoadingBar";
 
 import {
   Mail,
@@ -41,6 +42,7 @@ export default function PrivacyPage() {
   return (
     <div className="min-h-screen flex flex-col">
       <Navbar />
+      <LoadingBar />
 
       <main className="flex-grow pt-24 sm:pt-28 md:pt-32 pb-16 sm:pb-20 px-4 sm:px-8 md:px-12 lg:px-24">
 

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -3,6 +3,7 @@
 import type { ReactNode } from "react";
 import { Navbar } from "@/components/layout/Navbar";
 import { Footer } from "@/components/layout/Footer";
+import LoadingBar from "@/components/ui/LoadingBar";
 import type { LucideIcon } from "lucide-react";
 import {
   AlertTriangle,
@@ -860,6 +861,7 @@ export default function TermsOfServicePage() {
   return (
     <div className="min-h-screen flex flex-col bg-bg-base text-content-primary">
       <Navbar />
+      <LoadingBar />
 
       <main className="flex-grow pt-32 pb-24 px-6 lg:px-8">
         <div className="max-w-4xl mx-auto">


### PR DESCRIPTION
## Summary

Closes #1218

Adds `<LoadingBar />` to the 3 pages that were missing it, ensuring consistent navigation feedback across all public routes.

## Changes

| Page | Status |
|------|--------|
| `/pricing` | ✅ Added |
| `/privacy` | ✅ Added |
| `/terms` | ✅ Added |
| `/blueprint` | Already had it |
| `/` (homepage) | Already had it |
| `/changelog` | Already had it |
| `/community` | Already had it |

## Pattern Used

Each file follows the same two-line pattern from `community/page.tsx`:

```tsx
import LoadingBar from "@/components/ui/LoadingBar";
// ...
<Navbar />
<LoadingBar />
```

## Testing

- The `LoadingBar` component shows a progress indicator during page transitions
- No props required — it auto-detects route changes via Next.js navigation events