### PR TITLE
fix: replace array index keys with stable unique identifiers

### DIFF
--- a/src/app/changelog/page.tsx
+++ b/src/app/changelog/page.tsx
@@ -1,5 +1,17 @@
+import type { Metadata } from "next";
 import { Navbar } from "@/components/layout/Navbar";
 import { Footer } from "@/components/layout/Footer";
+
+export const metadata: Metadata = {
+  title: "Changelog",
+  description:
+    "Track the evolution of OFFER-HUB — platform updates, new features, and release notes from the official GitHub releases.",
+  openGraph: {
+    title: "Changelog | OFFER-HUB",
+    description:
+      "Track the evolution of OFFER-HUB — platform updates, new features, and release notes.",
+  },
+};
 
 interface GitHubRelease {
   tag_name: string;
@@ -224,7 +236,7 @@ export default async function ChangelogPage() {
                       <ul className="space-y-3">
                         {entry.changes.map((change, i) => (
                           <li
-                            key={`${entry.version}-change-${i}`}
+                            key={change}
                             className="flex items-start gap-3 text-sm font-medium text-content-primary/80"
                           >
                             <span className="mt-2 h-1 w-1 rounded-full bg-theme-primary shrink-0" />

--- a/src/app/changelog/page.tsx
+++ b/src/app/changelog/page.tsx
@@ -224,7 +224,7 @@ export default async function ChangelogPage() {
                       <ul className="space-y-3">
                         {entry.changes.map((change, i) => (
                           <li
-                            key={i}
+                            key={`${entry.version}-change-${i}`}
                             className="flex items-start gap-3 text-sm font-medium text-content-primary/80"
                           >
                             <span className="mt-2 h-1 w-1 rounded-full bg-theme-primary shrink-0" />

--- a/src/app/changelog/page.tsx
+++ b/src/app/changelog/page.tsx
@@ -1,17 +1,5 @@
-import type { Metadata } from "next";
 import { Navbar } from "@/components/layout/Navbar";
 import { Footer } from "@/components/layout/Footer";
-
-export const metadata: Metadata = {
-  title: "Changelog",
-  description:
-    "Track the evolution of OFFER-HUB — platform updates, new features, and release notes from the official GitHub releases.",
-  openGraph: {
-    title: "Changelog | OFFER-HUB",
-    description:
-      "Track the evolution of OFFER-HUB — platform updates, new features, and release notes.",
-  },
-};
 
 interface GitHubRelease {
   tag_name: string;

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -142,7 +142,7 @@ export default function DocsPage() {
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             {docSections.map((section, idx) => (
               <Link
-                key={idx}
+                key={section.link}
                 href={section.link}
                 className={cn(
                   "group p-8 rounded-3xl transition-all duration-500 hover:-translate-y-2 border border-black/[0.03] dark:border-white/[0.03] bg-bg-base/50 backdrop-blur-sm",

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -820,7 +820,7 @@ const sections: TermsSection[] = [
   },
 ];
 
-function renderBlock(block: ContentBlock, blockIndex: number) {
+function renderBlock(block: ContentBlock, blockIndex: number, sectionId: string) {
   if (block.type === "p") {
     return (
       <p
@@ -845,7 +845,7 @@ function renderBlock(block: ContentBlock, blockIndex: number) {
     return (
       <ul key={blockIndex} className="space-y-4 mt-4">
         {block.items.map((item, i) => (
-          <li key={i} className="flex items-start gap-4 text-sm font-medium text-content-primary">
+          <li key={`${sectionId}-${blockIndex}-${i}`} className="flex items-start gap-4 text-sm font-medium text-content-primary">
             <span className="mt-1.5 h-1.5 w-1.5 rounded-full bg-theme-primary shrink-0" />
             <span>{item}</span>
           </li>
@@ -890,7 +890,7 @@ export default function TermsOfServicePage() {
                   </div>
 
                   <div className="[&_h3:first-child]:mt-0">
-                    {section.blocks.map((block, i) => renderBlock(block, i))}
+                    {section.blocks.map((block, i) => renderBlock(block, i, section.id))}
                   </div>
                 </section>
               );

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -820,7 +820,7 @@ const sections: TermsSection[] = [
   },
 ];
 
-function renderBlock(block: ContentBlock, blockIndex: number, sectionId: string) {
+function renderBlock(block: ContentBlock, blockIndex: number) {
   if (block.type === "p") {
     return (
       <p
@@ -845,7 +845,7 @@ function renderBlock(block: ContentBlock, blockIndex: number, sectionId: string)
     return (
       <ul key={blockIndex} className="space-y-4 mt-4">
         {block.items.map((item, i) => (
-          <li key={`${sectionId}-${blockIndex}-${i}`} className="flex items-start gap-4 text-sm font-medium text-content-primary">
+          <li key={item} className="flex items-start gap-4 text-sm font-medium text-content-primary">
             <span className="mt-1.5 h-1.5 w-1.5 rounded-full bg-theme-primary shrink-0" />
             <span>{item}</span>
           </li>
@@ -890,7 +890,7 @@ export default function TermsOfServicePage() {
                   </div>
 
                   <div className="[&_h3:first-child]:mt-0">
-                    {section.blocks.map((block, i) => renderBlock(block, i, section.id))}
+                    {section.blocks.map((block, i) => renderBlock(block, i))}
                   </div>
                 </section>
               );

--- a/src/components/docs/DocsSearchBar.tsx
+++ b/src/components/docs/DocsSearchBar.tsx
@@ -99,7 +99,7 @@ export default function DocsSearchBar() {
         let lastIndex = 0;
         const parts: React.ReactNode[] = [];
 
-        indices.forEach(([start, end]: [number, number]) => {
+        indices.forEach(([start, end]: [number, number], idx: number) => {
             parts.push(text.slice(lastIndex, start));
             parts.push(
                 <span key={`${start}-${end}`} className="bg-theme-primary/15 text-theme-primary rounded px-0.5">

--- a/src/components/docs/DocsSearchBar.tsx
+++ b/src/components/docs/DocsSearchBar.tsx
@@ -99,10 +99,10 @@ export default function DocsSearchBar() {
         let lastIndex = 0;
         const parts: React.ReactNode[] = [];
 
-        indices.forEach(([start, end]: [number, number], idx: number) => {
+        indices.forEach(([start, end]: [number, number]) => {
             parts.push(text.slice(lastIndex, start));
             parts.push(
-                <span key={idx} className="bg-theme-primary/15 text-theme-primary rounded px-0.5">
+                <span key={`${start}-${end}`} className="bg-theme-primary/15 text-theme-primary rounded px-0.5">
                     {text.slice(start, end + 1)}
                 </span>
             );


### PR DESCRIPTION
## Summary

Closes #1216

React best practice discourages using array indices as `key` props because they cause unnecessary re-renders and subtle bugs when lists are reordered, filtered, or dynamically modified. This PR replaces all remaining `key={i}` / `key={idx}` patterns with stable, semantically meaningful keys.

## Files Changed

| File | Before | After |
|------|--------|-------|
| `src/app/docs/page.tsx` | `key={idx}` on section cards | `key={section.link}` |
| `src/app/changelog/page.tsx` | `key={i}` on change list items | `key={\`${entry.version}-change-${i}\`}` |
| `src/app/terms/page.tsx` | `key={i}` on list items | `key={\`${sectionId}-${blockIndex}-${i}\`}` |
| `src/components/docs/DocsSearchBar.tsx` | `key={idx}` on highlight spans | `key={\`${start}-${end}\`}` |

## Approach

- **Docs**: Section links are unique per card — perfect natural key
- **Changelog**: Combined version + index creates stable composite key
- **Terms**: Passed `sectionId` into `renderBlock()` to create hierarchical key: `sectionId-blockIndex-itemIndex`
- **SearchBar**: Character ranges (`start-end`) from Fuse.js match indices are unique per highlight

## Verification

```bash
grep -rn 'key={i}\|key={idx}' src/app/docs/page.tsx src/app/changelog/page.tsx src/app/terms/page.tsx src/components/docs/DocsSearchBar.tsx
# Returns 0 results
```