### PR TITLE
feat: add loading.tsx skeletons for /pricing and /blueprint pages

### DIFF
--- a/src/app/blueprint/loading.tsx
+++ b/src/app/blueprint/loading.tsx
@@ -1,0 +1,78 @@
+import { Navbar } from "@/components/layout/Navbar";
+import { Footer } from "@/components/layout/Footer";
+
+function SectionSkeleton() {
+  return (
+    <div className="rounded-[2.5rem] p-8 md:p-12 bg-bg-elevated shadow-neu-raised animate-pulse">
+      {/* Section header */}
+      <div className="flex items-center gap-4 mb-8">
+        <div className="w-10 h-10 rounded-xl bg-bg-base shadow-neu-raised-sm" />
+        <div className="h-7 w-48 rounded bg-bg-base" />
+      </div>
+
+      {/* Content blocks */}
+      <div className="space-y-4">
+        <div className="h-4 w-full rounded bg-bg-base" />
+        <div className="h-4 w-5/6 rounded bg-bg-base" />
+        <div className="h-4 w-4/6 rounded bg-bg-base" />
+      </div>
+
+      {/* Sub-cards grid */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-8">
+        {[1, 2].map((item) => (
+          <div
+            key={item}
+            className="rounded-2xl p-6 bg-bg-base shadow-neu-raised-sm"
+          >
+            <div className="h-5 w-32 rounded bg-bg-elevated mb-3" />
+            <div className="space-y-2">
+              <div className="h-3 w-full rounded bg-bg-elevated" />
+              <div className="h-3 w-3/4 rounded bg-bg-elevated" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default function BlueprintLoading() {
+  return (
+    <div className="min-h-screen flex flex-col bg-transparent">
+      <Navbar />
+      <main className="flex-grow">
+        {/* Hero Skeleton */}
+        <div className="pt-32 pb-16 px-6 md:px-8">
+          <div className="max-w-4xl mx-auto text-center">
+            <div className="h-3 w-24 rounded mx-auto bg-bg-elevated shadow-neu-raised-sm mb-4 animate-pulse" />
+            <div className="h-12 md:h-16 w-2/3 mx-auto rounded bg-bg-elevated shadow-neu-raised mb-6 animate-pulse" />
+            <div className="h-5 w-5/6 md:w-2/3 mx-auto rounded bg-bg-elevated shadow-neu-raised-sm mb-2 animate-pulse" />
+            <div className="h-5 w-4/6 md:w-1/2 mx-auto rounded bg-bg-elevated shadow-neu-raised-sm animate-pulse" />
+          </div>
+        </div>
+
+        {/* Section Nav Skeleton */}
+        <div className="px-6 md:px-8 mb-16">
+          <div className="max-w-4xl mx-auto flex justify-center gap-4">
+            {[1, 2, 3, 4].map((item) => (
+              <div
+                key={item}
+                className="h-10 w-28 rounded-full bg-bg-elevated shadow-neu-raised-sm animate-pulse"
+              />
+            ))}
+          </div>
+        </div>
+
+        {/* Content Sections */}
+        <div className="px-6 md:px-8 pb-24">
+          <div className="max-w-5xl mx-auto space-y-12">
+            <SectionSkeleton />
+            <SectionSkeleton />
+            <SectionSkeleton />
+          </div>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/app/pricing/loading.tsx
+++ b/src/app/pricing/loading.tsx
@@ -1,0 +1,60 @@
+import { Navbar } from "@/components/layout/Navbar";
+import { Footer } from "@/components/layout/Footer";
+
+function PricingCardSkeleton() {
+  return (
+    <div className="rounded-[2.5rem] p-8 md:p-10 bg-bg-elevated shadow-neu-raised animate-pulse">
+      {/* Icon */}
+      <div className="w-12 h-12 rounded-xl bg-bg-base shadow-neu-raised-sm mb-6" />
+
+      {/* Name + Price */}
+      <div className="h-6 w-28 rounded bg-bg-base mb-2" />
+      <div className="h-10 w-36 rounded bg-bg-base mb-4" />
+
+      {/* Description */}
+      <div className="space-y-2 mb-8">
+        <div className="h-4 w-full rounded bg-bg-base" />
+        <div className="h-4 w-5/6 rounded bg-bg-base" />
+      </div>
+
+      {/* Features */}
+      <div className="space-y-3 mb-8">
+        {[1, 2, 3, 4].map((item) => (
+          <div key={item} className="flex items-center gap-3">
+            <div className="w-5 h-5 rounded-full bg-bg-base shrink-0" />
+            <div className="h-4 w-4/5 rounded bg-bg-base" />
+          </div>
+        ))}
+      </div>
+
+      {/* CTA Button */}
+      <div className="h-12 w-full rounded-xl bg-bg-base" />
+    </div>
+  );
+}
+
+export default function PricingLoading() {
+  return (
+    <div className="min-h-screen flex flex-col bg-transparent">
+      <Navbar />
+      <main className="flex-grow pt-32 pb-24 px-6 md:px-8">
+        <div className="max-w-6xl mx-auto">
+          {/* Header */}
+          <header className="text-center mb-20">
+            <div className="h-3 w-20 rounded mx-auto bg-bg-elevated shadow-neu-raised-sm mb-4 animate-pulse" />
+            <div className="h-12 md:h-14 w-1/2 mx-auto rounded bg-bg-elevated shadow-neu-raised mb-6 animate-pulse" />
+            <div className="h-5 w-3/4 md:w-1/2 mx-auto rounded bg-bg-elevated shadow-neu-raised-sm animate-pulse" />
+          </header>
+
+          {/* Pricing Cards Grid */}
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+            <PricingCardSkeleton />
+            <PricingCardSkeleton />
+            <PricingCardSkeleton />
+          </div>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Closes #1217

Adds neumorphic loading skeletons for the `/pricing` and `/blueprint` pages, matching the existing design language used in `/changelog/loading.tsx` and `/community/loading.tsx`.

## New Files

| File | Purpose |
|------|---------|
| `src/app/pricing/loading.tsx` | 3-card grid skeleton matching the pricing tier layout |
| `src/app/blueprint/loading.tsx` | Hero + nav pills + content sections skeleton |

## Design Decisions

- **Consistent Neumorphic Style**: Uses the same `shadow-neu-raised`, `bg-bg-elevated`, and `animate-pulse` patterns as existing skeletons
- **Layout Fidelity**: Skeleton shapes match the real page layout (card grid for pricing, hero + sections for blueprint)
- **Stable Keys**: Uses numeric identifiers (`key={1}`, `key={2}`) for static skeleton elements rather than array indices
- **Includes Navbar/Footer**: Both skeletons render the real Navbar and Footer for visual continuity during load

## Before → After

**Before**: White flash / blank page during route transition
**After**: Smooth neumorphic skeleton appears instantly while content loads