### PR TITLE
fix: respect prefers-reduced-motion in InteractiveDotGrid

### DIFF
--- a/src/components/ui/InteractiveDotGrid.tsx
+++ b/src/components/ui/InteractiveDotGrid.tsx
@@ -35,6 +35,9 @@ export function InteractiveDotGrid({
         const ctx = canvas.getContext("2d");
         if (!ctx) return;
 
+        // Respect prefers-reduced-motion: render static grid only
+        const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
         const effectRadius = 160;
         const maxRepulsion = 25;
         const baseRadius = 1.8;
@@ -186,17 +189,22 @@ export function InteractiveDotGrid({
         };
 
         window.addEventListener("resize", handleResize);
-        window.addEventListener("mousemove", handleMouseMove, { passive: true });
-        document.body.addEventListener("mouseleave", handleMouseLeave);
+
+        if (!prefersReducedMotion) {
+            window.addEventListener("mousemove", handleMouseMove, { passive: true });
+            document.body.addEventListener("mouseleave", handleMouseLeave);
+        }
 
         initGrid();
 
         return () => {
             clearTimeout(resizeTimer);
             window.removeEventListener("resize", handleResize);
-            window.removeEventListener("mousemove", handleMouseMove);
-            document.body.removeEventListener("mouseleave", handleMouseLeave);
-            cancelAnimationFrame(animationFrameRef.current);
+            if (!prefersReducedMotion) {
+                window.removeEventListener("mousemove", handleMouseMove);
+                document.body.removeEventListener("mouseleave", handleMouseLeave);
+                cancelAnimationFrame(animationFrameRef.current);
+            }
         };
     }, [dotColor, gridSize, opacity]);
 


### PR DESCRIPTION
## Summary

Closes #1211

The `InteractiveDotGrid` component uses canvas-based animation with `requestAnimationFrame` for mouse-tracking effects. This animation is NOT controlled by CSS, so the existing `@media (prefers-reduced-motion: reduce)` rule in `globals.css` has no effect on it.

## Problem

Users who enable **Reduce Motion** in their OS accessibility settings still see the interactive dot animation, which can cause discomfort for people with vestibular disorders.

## Solution

Added a runtime check at component initialization:

```ts
const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
```

When enabled:
- ✅ Static dot grid is rendered (looks identical to the first frame)
- ✅ Mouse interaction listeners are **not attached**
- ✅ No `requestAnimationFrame` calls
- ✅ Resize handler still works (re-renders static grid)
- ✅ No performance overhead from unused event listeners

## Accessibility Impact

| Feature | Before | After |
|---------|--------|-------|
| Dot grid visible | ✅ | ✅ |
| Mouse repulsion effect | Always on | Disabled when reduced-motion |
| Canvas animation loop | Always running | Static render only |
| Event listeners | Always attached | Conditionally attached |