### PR TITLE
feat: configure OpenGraph and Twitter Card metadata for social sharing

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -21,9 +21,61 @@ const jetbrainsMono = JetBrains_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "OFFER-HUB",
+  metadataBase: new URL("https://offer-hub.tech"),
+  title: {
+    default: "OFFER-HUB — Secure Non-Custodial Escrow for Marketplaces",
+    template: "%s | OFFER-HUB",
+  },
   description:
-    "OFFER-HUB empowers marketplaces to provide secure, non-custodial escrow payments without building complex payment infrastructure.",
+    "OFFER-HUB empowers marketplaces to provide secure, non-custodial escrow payments powered by Stellar smart contracts — without building complex payment infrastructure.",
+  keywords: [
+    "escrow",
+    "marketplace",
+    "Stellar",
+    "smart contracts",
+    "freelance",
+    "payments",
+    "blockchain",
+    "non-custodial",
+    "open source",
+  ],
+  authors: [{ name: "OFFER-HUB", url: "https://offer-hub.tech" }],
+  creator: "OFFER-HUB",
+  openGraph: {
+    type: "website",
+    locale: "en_US",
+    url: "https://offer-hub.tech",
+    siteName: "OFFER-HUB",
+    title: "OFFER-HUB — Secure Non-Custodial Escrow for Marketplaces",
+    description:
+      "Build trustless commerce with non-custodial escrow powered by Stellar smart contracts. Open-source, self-hostable, enterprise-ready.",
+    images: [
+      {
+        url: "/OFFER-HUB-logo.png",
+        width: 512,
+        height: 512,
+        alt: "OFFER-HUB Logo",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary",
+    title: "OFFER-HUB — Secure Non-Custodial Escrow for Marketplaces",
+    description:
+      "Build trustless commerce with non-custodial escrow powered by Stellar smart contracts.",
+    images: ["/OFFER-HUB-logo.png"],
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      "max-video-preview": -1,
+      "max-image-preview": "large",
+      "max-snippet": -1,
+    },
+  },
   icons: {
     icon: "/favicon.ico",
   },


### PR DESCRIPTION
## Summary

Closes #1204

Adds comprehensive social sharing metadata to the root layout, enabling proper link previews on Twitter, LinkedIn, Discord, Slack, and other platforms.

## Changes to `src/app/layout.tsx`

### Added
| Feature | Value |
|---------|-------|
| `metadataBase` | `https://offer-hub.tech` |
| `title.template` | `%s \| OFFER-HUB` |
| `title.default` | `OFFER-HUB — Secure Non-Custodial Escrow for Marketplaces` |
| `keywords` | escrow, marketplace, Stellar, smart contracts, etc. |
| `authors` | OFFER-HUB |
| `openGraph.type` | `website` |
| `openGraph.images` | `/OFFER-HUB-logo.png` (512×512) |
| `twitter.card` | `summary` |
| `robots.googleBot` | Full indexing with max previews |

### How Title Template Works

With the `%s | OFFER-HUB` template, pages that export their own metadata title will automatically get the brand suffix:

- Root: **OFFER-HUB — Secure Non-Custodial Escrow for Marketplaces**
- Pricing: **Pricing | OFFER-HUB**
- Docs: **Documentation | OFFER-HUB**

### OG Image

Uses the existing `/OFFER-HUB-logo.png` in `/public`. A dedicated 1200×630 OG banner image can be added as a follow-up.

## Verification

After merge, validate with:
- https://cards-dev.twitter.com/validator
- https://developers.facebook.com/tools/debug/
- https://www.opengraph.xyz/