### PR TITLE
feat: add robots.ts and sitemap.ts for search engine crawling

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,14 @@
+import type { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: ["/api/", "/_next/"],
+      },
+    ],
+    sitemap: "https://offer-hub.tech/sitemap.xml",
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,23 @@
+import type { MetadataRoute } from "next";
+
+const BASE_URL = "https://offer-hub.tech";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const staticPages = [
+    "",
+    "/pricing",
+    "/docs",
+    "/changelog",
+    "/community",
+    "/blueprint",
+    "/terms",
+    "/privacy",
+  ];
+
+  return staticPages.map((path) => ({
+    url: `${BASE_URL}${path}`,
+    lastModified: new Date(),
+    changeFrequency: path === "" ? "weekly" : "monthly",
+    priority: path === "" ? 1.0 : 0.7,
+  }));
+}


### PR DESCRIPTION
## Summary

Closes #1205

Adds `robots.ts` and `sitemap.ts` to `src/app/` using Next.js App Router's built-in MetadataRoute types.

## New Files

### `src/app/robots.ts`
- Allows all user agents on `/`
- Blocks crawling of `/api/` and `/_next/` internal routes
- Points to sitemap at `https://offer-hub.tech/sitemap.xml`

### `src/app/sitemap.ts`
- Generates XML sitemap for all 8 public pages
- Home page: `priority: 1.0`, `changeFrequency: weekly`
- Sub-pages: `priority: 0.7`, `changeFrequency: monthly`

## Pages Included in Sitemap

| Page | URL |
|------|-----|
| Home | `/` |
| Pricing | `/pricing` |
| Docs | `/docs` |
| Changelog | `/changelog` |
| Community | `/community` |
| Blueprint | `/blueprint` |
| Terms | `/terms` |
| Privacy | `/privacy` |

## Verification

After deploy, validate at:
- `https://offer-hub.tech/robots.txt`
- `https://offer-hub.tech/sitemap.xml`
- Submit to Google Search Console