### PR TITLE
feat: add error.tsx and global-error.tsx error boundaries

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useEffect } from "react";
+import { motion } from "framer-motion";
+import { AlertTriangle } from "lucide-react";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("[OFFER-HUB] Unhandled error:", error);
+  }, [error]);
+
+  return (
+    <main className="min-h-screen flex items-center justify-center bg-[var(--color-bg-base)] px-4">
+      <motion.div
+        initial={{ opacity: 0, scale: 0.95 }}
+        animate={{ opacity: 1, scale: 1 }}
+        transition={{ duration: 0.5, ease: "easeOut" }}
+        className="w-full max-w-md"
+      >
+        {/* Floating card */}
+        <motion.div
+          animate={{ y: [0, -12, 0] }}
+          transition={{
+            duration: 4,
+            ease: "easeInOut" as const,
+            repeat: Infinity,
+          }}
+          className="rounded-3xl p-10 flex flex-col items-center text-center"
+          style={{
+            background: "var(--color-bg-base)",
+            boxShadow:
+              "10px 10px 20px var(--shadow-dark), -10px -10px 20px var(--shadow-light)",
+          }}
+        >
+          {/* Sunken error badge */}
+          <div
+            className="w-36 h-36 rounded-2xl flex items-center justify-center mb-6"
+            style={{
+              background: "var(--color-bg-sunken)",
+              boxShadow:
+                "inset 10px 10px 20px var(--shadow-dark), inset -10px -10px 20px var(--shadow-light)",
+            }}
+          >
+            <AlertTriangle
+              size={56}
+              style={{ color: "var(--color-primary)" }}
+              strokeWidth={1.5}
+            />
+          </div>
+
+          {/* Headline */}
+          <h1
+            className="text-xl font-bold mb-3 leading-snug"
+            style={{ color: "var(--color-text-primary)" }}
+          >
+            Something went wrong
+          </h1>
+
+          {/* Subtext */}
+          <p
+            className="text-sm leading-relaxed mb-8"
+            style={{ color: "var(--color-text-secondary)" }}
+          >
+            An unexpected error occurred while processing your request.
+            {error.digest && (
+              <span className="block mt-2 font-mono text-xs opacity-60">
+                Error ID: {error.digest}
+              </span>
+            )}
+          </p>
+
+          {/* CTA Buttons */}
+          <div className="flex gap-4">
+            <button
+              onClick={reset}
+              className="btn-neumorphic-primary px-8 py-3 rounded-xl text-sm font-semibold"
+            >
+              Try Again
+            </button>
+            <a
+              href="/"
+              className="px-8 py-3 rounded-xl text-sm font-semibold"
+              style={{
+                color: "var(--color-text-secondary)",
+                background: "var(--color-bg-sunken)",
+                boxShadow:
+                  "inset 3px 3px 6px var(--shadow-dark), inset -3px -3px 6px var(--shadow-light)",
+              }}
+            >
+              Go Home
+            </a>
+          </div>
+        </motion.div>
+      </motion.div>
+    </main>
+  );
+}

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useEffect } from "react";
+
+/**
+ * Global error boundary — catches errors in the root layout itself.
+ * Must include its own <html> and <body> tags since the root layout
+ * may have failed to render.
+ */
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("[OFFER-HUB] Global error:", error);
+  }, [error]);
+
+  return (
+    <html lang="en">
+      <body
+        style={{
+          margin: 0,
+          fontFamily:
+            '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+          backgroundColor: "#1a1a2e",
+          color: "#e0e0e0",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          minHeight: "100vh",
+          padding: "1rem",
+        }}
+      >
+        <div
+          style={{
+            maxWidth: "28rem",
+            textAlign: "center",
+            padding: "2.5rem",
+            borderRadius: "1.5rem",
+            background: "#1a1a2e",
+            boxShadow:
+              "10px 10px 20px rgba(0,0,0,0.4), -10px -10px 20px rgba(50,50,80,0.15)",
+          }}
+        >
+          <div
+            style={{
+              width: "6rem",
+              height: "6rem",
+              borderRadius: "1rem",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              margin: "0 auto 1.5rem",
+              background: "#16162a",
+              boxShadow:
+                "inset 5px 5px 10px rgba(0,0,0,0.4), inset -5px -5px 10px rgba(50,50,80,0.15)",
+              fontSize: "2rem",
+            }}
+          >
+            ⚠️
+          </div>
+
+          <h1
+            style={{
+              fontSize: "1.25rem",
+              fontWeight: 700,
+              marginBottom: "0.75rem",
+            }}
+          >
+            Critical Error
+          </h1>
+
+          <p
+            style={{
+              fontSize: "0.875rem",
+              lineHeight: 1.6,
+              opacity: 0.7,
+              marginBottom: "2rem",
+            }}
+          >
+            The application encountered an unrecoverable error.
+            {error.digest && (
+              <span
+                style={{
+                  display: "block",
+                  marginTop: "0.5rem",
+                  fontFamily: "monospace",
+                  fontSize: "0.75rem",
+                  opacity: 0.5,
+                }}
+              >
+                Error ID: {error.digest}
+              </span>
+            )}
+          </p>
+
+          <button
+            onClick={reset}
+            style={{
+              padding: "0.75rem 2rem",
+              borderRadius: "0.75rem",
+              border: "none",
+              background: "linear-gradient(135deg, #6366f1, #818cf8)",
+              color: "white",
+              fontSize: "0.875rem",
+              fontWeight: 600,
+              cursor: "pointer",
+            }}
+          >
+            Reload Application
+          </button>
+        </div>
+      </body>
+    </html>
+  );
+}


### PR DESCRIPTION
## Summary

Closes #1212

Adds two error boundary files that Next.js App Router requires for graceful error handling.

## New Files

### `src/app/error.tsx`
Catches unhandled runtime errors within the app (below the root layout):
- Neumorphic design matching `not-found.tsx` visual style
- Uses framer-motion for entrance animation and floating card
- Displays error digest ID for debugging
- **Try Again** button (calls `reset()`) + **Go Home** link
- Logs errors to console with `[OFFER-HUB]` prefix

### `src/app/global-error.tsx`
Catches errors in the root layout itself (last resort):
- Uses **inline styles only** (no CSS variables/imports — the layout may have failed to render)
- Includes its own `<html>` and `<body>` tags (required by Next.js)
- Neumorphic dark theme with gradient CTA button
- **Reload Application** button

## Design Consistency

| Feature | not-found.tsx | error.tsx | global-error.tsx |
|---------|--------------|-----------|-----------------|
| Neumorphic cards | ✅ | ✅ | ✅ (inline) |
| Floating animation | ✅ | ✅ | ❌ (no deps) |
| framer-motion | ✅ | ✅ | ❌ (no imports) |
| CSS variables | ✅ | ✅ | ❌ (inline) |
| Error digest | N/A | ✅ | ✅ |