### PR TITLE
fix: replace hardcoded localhost URL in API Explorer with environment variable

### DIFF
--- a/src/components/api-explorer/EndpointPanel.tsx
+++ b/src/components/api-explorer/EndpointPanel.tsx
@@ -8,7 +8,8 @@ import { MethodBadge } from "./MethodBadge";
 import { ParameterInput } from "./ParameterInput";
 import { ResponseViewer } from "./ResponseViewer";
 
-const BASE_URL = "http://localhost:4000/api/v1";
+const BASE_URL =
+  process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:4000/api/v1";
 
 interface EndpointPanelProps {
   endpoint: ApiEndpoint;


### PR DESCRIPTION
## Summary

Closes #1209

The API Explorer's `EndpointPanel` component hardcodes `http://localhost:4000/api/v1` as the base URL. This means the "Try it" feature only works in local development and displays a localhost URL in production.

## Change

```diff
- const BASE_URL = "http://localhost:4000/api/v1";
+ const BASE_URL =
+   process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:4000/api/v1";
```

## Configuration

Set the environment variable in your deployment:

```bash
# .env.production
NEXT_PUBLIC_API_BASE_URL=https://api.offer-hub.tech/api/v1
```

Falls back to `localhost:4000` for local development (no change needed for devs).