### PR TITLE
fix: replace NEXT_PUBLIC_OFFERHUB_KEY with demo placeholder in code showcases

### DIFF
--- a/src/components/use-cases/dao-payroll/CodeIntegrationShowcase.tsx
+++ b/src/components/use-cases/dao-payroll/CodeIntegrationShowcase.tsx
@@ -71,7 +71,7 @@ await oh.escrows.fund(payroll.id, {
 
 // Governance dashboard SDK (public key only, safe in the browser)
 const oh = new OfferHub({
-  apiKey: process.env.NEXT_PUBLIC_OFFERHUB_KEY,
+  apiKey: "oh_demo_xxxxxxxxxxxx",  // Replace with your API key
 });
 
 // After governance vote passes, verify contributor milestone

--- a/src/components/use-cases/ecommerce/CodeIntegrationShowcase.tsx
+++ b/src/components/use-cases/ecommerce/CodeIntegrationShowcase.tsx
@@ -57,9 +57,9 @@ await oh.escrows.fund(order.id, {
     docLabel: "SDK Guide",
     code: `import { OfferHub } from "@offerhub/sdk";
 
-// Client-side SDK (public key only, safe to expose in the browser)
+// Initialize the OfferHub SDK with your API key
 const oh = new OfferHub({
-  apiKey: process.env.NEXT_PUBLIC_OFFERHUB_KEY,
+  apiKey: "oh_demo_xxxxxxxxxxxx",  // Replace with your API key
 });
 
 // Buyer confirms delivery — triggers automatic fund release to the seller.

--- a/src/components/use-cases/freelance/CodeIntegrationShowcase.tsx
+++ b/src/components/use-cases/freelance/CodeIntegrationShowcase.tsx
@@ -64,9 +64,9 @@ await oh.escrows.fund(order.id, {
     docLabel: "SDK Guide",
     code: `import { OfferHub } from "@offerhub/sdk";
 
-// Client-side SDK (public key only, safe to expose in the browser)
+// Initialize the OfferHub SDK with your API key
 const oh = new OfferHub({
-  apiKey: process.env.NEXT_PUBLIC_OFFERHUB_KEY,
+  apiKey: "oh_demo_xxxxxxxxxxxx",  // Replace with your API key
 });
 
 // Milestone Approval: release partial funds to the freelancer.

--- a/src/components/use-cases/real-estate/CodeIntegrationShowcase.tsx
+++ b/src/components/use-cases/real-estate/CodeIntegrationShowcase.tsx
@@ -68,9 +68,9 @@ await oh.escrows.fund(deposit.id, {
     docLabel: "SDK Guide",
     code: `import { OfferHub } from "@offerhub/sdk";
 
-// Client-side SDK (public key only, safe to expose in the browser)
+// Initialize the OfferHub SDK with your API key
 const oh = new OfferHub({
-  apiKey: process.env.NEXT_PUBLIC_OFFERHUB_KEY,
+  apiKey: "oh_demo_xxxxxxxxxxxx",  // Replace with your API key
 });
 
 // End-of-lease: verify inspection report and settle the deposit.


### PR DESCRIPTION
## Summary

Closes #1210

All 4 use-case code showcase components reference `process.env.NEXT_PUBLIC_OFFERHUB_KEY` in their displayed code snippets. The `NEXT_PUBLIC_` prefix causes Next.js to embed the variable into the client-side bundle, making it publicly readable.

Since these are **demo code snippets** (displayed to users as integration examples), they should use a clearly fake placeholder string instead of a real environment variable.

## Changes

| File | Before | After |
|------|--------|-------|
| ecommerce/CodeIntegrationShowcase.tsx | `process.env.NEXT_PUBLIC_OFFERHUB_KEY` | `"oh_demo_xxxxxxxxxxxx"` |
| dao-payroll/CodeIntegrationShowcase.tsx | `process.env.NEXT_PUBLIC_OFFERHUB_KEY` | `"oh_demo_xxxxxxxxxxxx"` |
| freelance/CodeIntegrationShowcase.tsx | `process.env.NEXT_PUBLIC_OFFERHUB_KEY` | `"oh_demo_xxxxxxxxxxxx"` |
| real-estate/CodeIntegrationShowcase.tsx | `process.env.NEXT_PUBLIC_OFFERHUB_KEY` | `"oh_demo_xxxxxxxxxxxx"` |

Also updated the misleading comment from _"public key only, safe to expose in the browser"_ to _"Initialize the OfferHub SDK with your API key"_.

## Note

The other `OFFERHUB_API_KEY` references (without `NEXT_PUBLIC_` prefix) in the same files are server-side code examples showing the correct pattern — those were intentionally left as-is.