### PR TITLE
fix: remove duplicate dark:invert class in SupportedBySection

### DIFF
--- a/src/components/SupportedBySection.tsx
+++ b/src/components/SupportedBySection.tsx
@@ -50,7 +50,7 @@ export default function SupportedBySection() {
                   alt={`${partner.name} logo`}
                   width={partner.width}
                   height={partner.height}
-                  className="object-contain dark:invert dark:brightness-0 dark:invert"
+                  className="object-contain dark:invert dark:brightness-0"
                   priority
                 />
               </Link>


### PR DESCRIPTION
## Summary

Closes #1215

```diff
- className="object-contain dark:invert dark:brightness-0 dark:invert"
+ className="object-contain dark:invert dark:brightness-0"
```

Removed the redundant second `dark:invert` class on line 53 of `SupportedBySection.tsx`. The first `dark:invert` already applies the filter; the duplicate is a no-op that adds markup noise.