### PR TITLE
feat: add docs-specific not-found.tsx for invalid slug routes

### DIFF
--- a/src/app/docs/[...slug]/not-found.tsx
+++ b/src/app/docs/[...slug]/not-found.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import Link from "next/link";
+import { motion } from "framer-motion";
+import { FileQuestion } from "lucide-react";
+
+export default function DocsNotFound() {
+  return (
+    <div className="flex-1 flex items-center justify-center py-24 px-4">
+      <motion.div
+        initial={{ opacity: 0, scale: 0.95 }}
+        animate={{ opacity: 1, scale: 1 }}
+        transition={{ duration: 0.5, ease: "easeOut" }}
+        className="w-full max-w-md"
+      >
+        <motion.div
+          animate={{ y: [0, -12, 0] }}
+          transition={{
+            duration: 4,
+            ease: "easeInOut" as const,
+            repeat: Infinity,
+          }}
+          className="rounded-3xl p-10 flex flex-col items-center text-center"
+          style={{
+            background: "var(--color-bg-base)",
+            boxShadow:
+              "10px 10px 20px var(--shadow-dark), -10px -10px 20px var(--shadow-light)",
+          }}
+        >
+          {/* Sunken 404 badge */}
+          <div
+            className="w-36 h-36 rounded-2xl flex items-center justify-center mb-6"
+            style={{
+              background: "var(--color-bg-sunken)",
+              boxShadow:
+                "inset 10px 10px 20px var(--shadow-dark), inset -10px -10px 20px var(--shadow-light)",
+            }}
+          >
+            <FileQuestion
+              size={56}
+              style={{ color: "var(--color-primary)" }}
+              strokeWidth={1.5}
+            />
+          </div>
+
+          {/* Headline */}
+          <h1
+            className="text-xl font-bold mb-3 leading-snug"
+            style={{ color: "var(--color-text-primary)" }}
+          >
+            Doc not found
+          </h1>
+
+          {/* Subtext */}
+          <p
+            className="text-sm leading-relaxed mb-8"
+            style={{ color: "var(--color-text-secondary)" }}
+          >
+            The documentation page you are looking for doesn&apos;t exist or has
+            been moved. Try searching for it or browse the docs hub.
+          </p>
+
+          {/* CTA Buttons */}
+          <div className="flex gap-4">
+            <Link
+              href="/docs"
+              className="btn-neumorphic-primary px-8 py-3 rounded-xl text-sm font-semibold"
+            >
+              Docs Hub
+            </Link>
+            <Link
+              href="/"
+              className="px-8 py-3 rounded-xl text-sm font-semibold"
+              style={{
+                color: "var(--color-text-secondary)",
+                background: "var(--color-bg-sunken)",
+                boxShadow:
+                  "inset 3px 3px 6px var(--shadow-dark), inset -3px -3px 6px var(--shadow-light)",
+              }}
+            >
+              Go Home
+            </Link>
+          </div>
+        </motion.div>
+      </motion.div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Closes #1213

When a user navigates to a non-existent docs page (e.g. `/docs/nonexistent/page`), the catch-all `[...slug]/page.tsx` calls `notFound()` which renders the closest `not-found.tsx`. Currently, this falls through to the root-level `not-found.tsx` which shows a generic "transaction path not found" message — confusing for docs users.

## New File

### `src/app/docs/[...slug]/not-found.tsx`

A docs-specific not-found page that:
- Shows **FileQuestion** icon (from lucide-react) instead of SearchX
- Says "Doc not found" with a helpful description
- Links to **Docs Hub** (`/docs`) as primary CTA
- Links to **Go Home** (`/`) as secondary action
- Renders within the docs layout (sidebar + nav visible)
- Matches the neumorphic design of the root `not-found.tsx`

## Visual Consistency

| Feature | Root not-found | Docs not-found |
|---------|----------------|----------------|
| Icon | SearchX | FileQuestion |
| Title | "transaction path not found" | "Doc not found" |
| Primary CTA | Return to Home | Docs Hub |
| Layout | Full page | Within docs layout |
| Animation | ✅ floating card | ✅ floating card |