### PR TITLE
fix(security): replace env var API key references with demo placeholders in code showcase

### DIFF
--- a/src/components/use-cases/ecommerce/CodeIntegrationShowcase.tsx
+++ b/src/components/use-cases/ecommerce/CodeIntegrationShowcase.tsx
@@ -30,7 +30,7 @@ const CODE_TABS: CodeTab[] = [
     code: `import { OfferHub } from "@offerhub/sdk";
 
 // Initialize SDK — The Orchestrator mirrors your backend state
-const oh = new OfferHub({ apiKey: process.env.OFFERHUB_API_KEY! });
+const oh = new OfferHub({ apiKey: "oh_live_xxxxxxxxxxxx" });
 
 // Order Creation: creates an escrow-safe purchase with a delivery window
 const order = await oh.orders.create({
@@ -59,7 +59,7 @@ await oh.escrows.fund(order.id, {
 
 // Client-side SDK (public key only, safe to expose in the browser)
 const oh = new OfferHub({
-  apiKey: process.env.NEXT_PUBLIC_OFFERHUB_KEY,
+  apiKey: "oh_pub_xxxxxxxxxxxx",
 });
 
 // Buyer confirms delivery — triggers automatic fund release to the seller.


### PR DESCRIPTION
## Summary

Closes #1210

The `CodeIntegrationShowcase.tsx` component displays SDK example code that references `process.env.NEXT_PUBLIC_OFFERHUB_KEY` and `process.env.OFFERHUB_API_KEY`. Since this is display-only demo code (rendered as syntax-highlighted text), using real env var references is:

1. **Misleading** — devs might think the component actually reads these vars
2. **A security anti-pattern** — `NEXT_PUBLIC_` prefix would expose the key in the client bundle

## Changes

### `src/components/use-cases/ecommerce/CodeIntegrationShowcase.tsx`

**Server tab:**
```diff
-const oh = new OfferHub({ apiKey: process.env.OFFERHUB_API_KEY! });
+const oh = new OfferHub({ apiKey: "oh_live_xxxxxxxxxxxx" });
```

**Client tab:**
```diff
-  apiKey: process.env.NEXT_PUBLIC_OFFERHUB_KEY,
+  apiKey: "oh_pub_xxxxxxxxxxxx",
```

## Rationale

- These code blocks are **string literals** rendered as syntax-highlighted text — they never execute
- Demo placeholders (`oh_live_xxxxxxxxxxxx`, `oh_pub_xxxxxxxxxxxx`) make the key format clear without referencing real env vars
- Follows SDK documentation best practices (e.g., Stripe uses `sk_test_xxxx` in their docs)