### PR TITLE
fix: replace fake fallback data with proper empty states in Community page

### DIFF
--- a/src/components/community/ContributorGrid.tsx
+++ b/src/components/community/ContributorGrid.tsx
@@ -1,3 +1,4 @@
+import { AlertCircle } from "lucide-react";
 import SectionHeading from "@/components/community/SectionHeading";
 
 interface Contributor {
@@ -11,17 +12,6 @@ interface ContributorGridProps {
   contributors?: Contributor[];
 }
 
-const mockContributors: Contributor[] = [
-  { name: "Ada M.", username: "ada-m", area: "Core Protocol", commits: 248 },
-  { name: "Dami O.", username: "dami-o", area: "Frontend", commits: 133 },
-  { name: "Hassan K.", username: "hassan-k", area: "DevRel", commits: 92 },
-  { name: "Lina S.", username: "lina-s", area: "Tooling", commits: 87 },
-  { name: "Marta P.", username: "marta-p", area: "QA", commits: 76 },
-  { name: "Tomi A.", username: "tomi-a", area: "Docs", commits: 70 },
-  { name: "Carlos R.", username: "carlos-r", area: "Backend", commits: 64 },
-  { name: "Femi B.", username: "femi-b", area: "Smart Contracts", commits: 58 },
-];
-
 function getInitials(name: string) {
   return name
     .split(" ")
@@ -32,7 +22,7 @@ function getInitials(name: string) {
 }
 
 export default function ContributorGrid({ contributors }: ContributorGridProps) {
-  const data = contributors ?? mockContributors;
+  const hasData = contributors && contributors.length > 0;
 
   return (
     <section id="contributor-grid" className="py-24">
@@ -43,29 +33,41 @@ export default function ContributorGrid({ contributors }: ContributorGridProps) 
           subtitle="The people building and shipping OFFER-HUB every day."
         />
 
-        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
-          {data.map((contributor) => (
-            <article
-              key={contributor.username}
-              className="rounded-2xl p-6 shadow-neu-raised bg-bg-elevated flex flex-col items-center text-center hover:shadow-neu-raised-hover transition-shadow duration-300"
-            >
-              <div
-                className="w-16 h-16 rounded-full shadow-neu-raised-sm flex items-center justify-center text-lg font-bold text-white bg-theme-primary"
+        {hasData ? (
+          <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+            {contributors.map((contributor) => (
+              <article
+                key={contributor.username}
+                className="rounded-2xl p-6 shadow-neu-raised bg-bg-elevated flex flex-col items-center text-center hover:shadow-neu-raised-hover transition-shadow duration-300"
               >
-                {getInitials(contributor.name)}
-              </div>
-              <h3 className="mt-4 text-base font-bold text-content-primary">
-                {contributor.name}
-              </h3>
-              <p className="mt-1 text-xs font-light text-content-secondary">
-                {contributor.area}
-              </p>
-              <p className="mt-3 text-sm font-medium text-theme-primary">
-                {contributor.commits} commits
-              </p>
-            </article>
-          ))}
-        </div>
+                <div
+                  className="w-16 h-16 rounded-full shadow-neu-raised-sm flex items-center justify-center text-lg font-bold text-white bg-theme-primary"
+                >
+                  {getInitials(contributor.name)}
+                </div>
+                <h3 className="mt-4 text-base font-bold text-content-primary">
+                  {contributor.name}
+                </h3>
+                <p className="mt-1 text-xs font-light text-content-secondary">
+                  {contributor.area}
+                </p>
+                <p className="mt-3 text-sm font-medium text-theme-primary">
+                  {contributor.commits} commits
+                </p>
+              </article>
+            ))}
+          </div>
+        ) : (
+          <div className="flex flex-col items-center justify-center p-12 rounded-2xl shadow-neu-raised bg-bg-elevated">
+            <AlertCircle size={24} className="text-content-muted" />
+            <p className="mt-3 text-sm font-semibold text-content-secondary">
+              Contributors temporarily unavailable
+            </p>
+            <p className="mt-1 text-xs text-content-muted">
+              We&apos;re fetching live contributor data from GitHub.
+            </p>
+          </div>
+        )}
 
         <div className="mt-12 text-center">
           <a

--- a/src/components/community/RepoStats.tsx
+++ b/src/components/community/RepoStats.tsx
@@ -7,18 +7,11 @@ interface RepoStatsProps {
      openIssues?: number;
 }
 
-const mockStats = {
-     stars: 2547,
-     forks: 380,
-     watchers: 145,
-     openIssues: 23,
-};
-
 export default function RepoStats({
-     stars = mockStats.stars,
-     forks = mockStats.forks,
-     watchers = mockStats.watchers,
-     openIssues = mockStats.openIssues,
+     stars,
+     forks,
+     watchers,
+     openIssues,
 }: RepoStatsProps) {
      const stats = [
           {
@@ -43,6 +36,22 @@ export default function RepoStats({
           },
      ];
 
+     const hasData = stats.some((s) => s.value != null);
+
+     if (!hasData) {
+          return (
+               <div className="flex flex-col items-center justify-center p-12 rounded-2xl shadow-raised" style={{ background: "#F1F3F7" }}>
+                    <AlertCircle size={24} style={{ color: "#6D758F" }} />
+                    <p className="mt-3 text-sm font-semibold" style={{ color: "#6D758F" }}>
+                         Stats temporarily unavailable
+                    </p>
+                    <p className="mt-1 text-xs" style={{ color: "#9CA3AF" }}>
+                         Check back soon — we&apos;re fetching live data from GitHub.
+                    </p>
+               </div>
+          );
+     }
+
      return (
           <div className="grid grid-cols-2 md:grid-cols-4 gap-6">
                {stats.map((stat) => {
@@ -58,7 +67,7 @@ export default function RepoStats({
                                    className="text-3xl font-black tracking-tight mt-3"
                                    style={{ color: "#149A9B" }}
                               >
-                                   {stat.value.toLocaleString()}
+                                   {(stat.value ?? 0).toLocaleString()}
                               </span>
                               <span
                                    className="text-sm uppercase tracking-widest mt-2"


### PR DESCRIPTION
## Summary

Closes #1207

Removes fabricated fallback data from `RepoStats.tsx` and `ContributorGrid.tsx` that displayed when the GitHub API was unavailable. Fake numbers (2,547 stars, 380 forks) and fictitious contributors ("Ada M.", "Dami O.") misled visitors and damaged trust.

## Changes

### `src/components/community/RepoStats.tsx`

- **Removed** `mockStats` object with invented numbers (2547 stars, 380 forks, 145 watchers, 23 open issues)
- **Added** empty state UI showing "Stats temporarily unavailable" with an explanatory message
- Props now default to `undefined` instead of mock values

### `src/components/community/ContributorGrid.tsx`

- **Removed** `mockContributors` array with 8 fictitious contributors
- **Added** empty state UI showing "Contributors temporarily unavailable" when no data is provided
- Component now renders contributor cards only when real data is available

## Before / After

| Scenario | Before | After |
|----------|--------|-------|
| API down | Shows fake "2,547 stars" | Shows "Stats temporarily unavailable" |
| No contributors | Shows 8 fake people | Shows "Contributors temporarily unavailable" |
| API working | Shows real data | Shows real data (no change) |