### PR TITLE
fix: remove duplicate dark:invert class in SupportedBySection

### DIFF
--- a/src/components/SupportedBySection.tsx
+++ b/src/components/SupportedBySection.tsx
@@ -50,7 +50,7 @@ export default function SupportedBySection() {
                   alt={`${partner.name} logo`}
                   width={partner.width}
                   height={partner.height}
-                  className="object-contain dark:invert dark:brightness-0 dark:invert"
+                  className="object-contain dark:invert dark:brightness-0"
                   priority
                 />
               </Link>


### PR DESCRIPTION
## Summary

Closes #1215

Removes the duplicated `dark:invert` class on the partner logo `<Image>` element in `SupportedBySection.tsx`.

## Changes

### `src/components/SupportedBySection.tsx`

```diff
-className="object-contain dark:invert dark:brightness-0 dark:invert"
+className="object-contain dark:invert dark:brightness-0"
```

## Impact

- **Zero visual change** — the second `dark:invert` was redundant (CSS applies the same rule once regardless of duplicates)
- Cleaner markup that won't cause confusion during future edits