### PR TITLE
Add global error boundaries for unhandled runtime errors 

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import Link from "next/link";
+import { motion } from "framer-motion";
+import { AlertTriangle } from "lucide-react";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <main className="min-h-screen flex items-center justify-center bg-[var(--color-bg-base)] px-4">
+      <motion.div
+        initial={{ opacity: 0, scale: 0.95 }}
+        animate={{ opacity: 1, scale: 1 }}
+        transition={{ duration: 0.5, ease: "easeOut" }}
+        className="w-full max-w-md"
+      >
+        {/* Floating card */}
+        <motion.div
+          animate={{ y: [0, -12, 0] }}
+          transition={{
+            duration: 4,
+            ease: "easeInOut" as const,
+            repeat: Infinity,
+          }}
+          className="rounded-3xl p-10 flex flex-col items-center text-center"
+          style={{
+            background: "var(--color-bg-base)",
+            boxShadow:
+              "10px 10px 20px var(--shadow-dark), -10px -10px 20px var(--shadow-light)",
+          }}
+        >
+          {/* Sunken error badge */}
+          <div
+            className="w-36 h-36 rounded-2xl flex items-center justify-center mb-6"
+            style={{
+              background: "var(--color-bg-sunken)",
+              boxShadow:
+                "inset 10px 10px 20px var(--shadow-dark), inset -10px -10px 20px var(--shadow-light)",
+            }}
+          >
+            <AlertTriangle
+              size={48}
+              strokeWidth={1.5}
+              style={{ color: "var(--color-primary)" }}
+            />
+          </div>
+
+          {/* Headline */}
+          <h1
+            className="text-xl font-bold mb-3 leading-snug"
+            style={{ color: "var(--color-text-primary)" }}
+          >
+            Something went wrong
+          </h1>
+
+          {/* Error message */}
+          <p
+            className="text-sm leading-relaxed mb-8"
+            style={{ color: "var(--color-text-secondary)" }}
+          >
+            {process.env.NODE_ENV === "development"
+              ? error.message
+              : "An unexpected error occurred. Please try again."}
+          </p>
+
+          {/* Action buttons */}
+          <div className="flex gap-3">
+            <button
+              onClick={reset}
+              className="btn-neumorphic-primary px-8 py-3 rounded-xl text-sm font-semibold"
+            >
+              Try again
+            </button>
+            <Link
+              href="/"
+              className="btn-neumorphic-primary px-8 py-3 rounded-xl text-sm font-semibold"
+            >
+              Return to Home
+            </Link>
+          </div>
+        </motion.div>
+      </motion.div>
+    </main>
+  );
+}

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import Link from "next/link";
+import { motion } from "framer-motion";
+import { AlertTriangle } from "lucide-react";
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <html lang="en">
+      <body className="min-h-screen flex items-center justify-center bg-[var(--color-bg-base)] px-4 antialiased">
+        <motion.div
+          initial={{ opacity: 0, scale: 0.95 }}
+          animate={{ opacity: 1, scale: 1 }}
+          transition={{ duration: 0.5, ease: "easeOut" }}
+          className="w-full max-w-md"
+        >
+          {/* Floating card */}
+          <motion.div
+            animate={{ y: [0, -12, 0] }}
+            transition={{
+              duration: 4,
+              ease: "easeInOut" as const,
+              repeat: Infinity,
+            }}
+            className="rounded-3xl p-10 flex flex-col items-center text-center"
+            style={{
+              background: "var(--color-bg-base)",
+              boxShadow:
+                "10px 10px 20px var(--shadow-dark), -10px -10px 20px var(--shadow-light)",
+            }}
+          >
+            {/* Sunken error badge */}
+            <div
+              className="w-36 h-36 rounded-2xl flex items-center justify-center mb-6"
+              style={{
+                background: "var(--color-bg-sunken)",
+                boxShadow:
+                  "inset 10px 10px 20px var(--shadow-dark), inset -10px -10px 20px var(--shadow-light)",
+              }}
+            >
+              <AlertTriangle
+                size={48}
+                strokeWidth={1.5}
+                style={{ color: "var(--color-primary)" }}
+              />
+            </div>
+
+            {/* Headline */}
+            <h1
+              className="text-xl font-bold mb-3 leading-snug"
+              style={{ color: "var(--color-text-primary)" }}
+            >
+              Something went wrong
+            </h1>
+
+            {/* Error message */}
+            <p
+              className="text-sm leading-relaxed mb-8"
+              style={{ color: "var(--color-text-secondary)" }}
+            >
+              {process.env.NODE_ENV === "development"
+                ? error.message
+                : "An unexpected error occurred. Please try again."}
+            </p>
+
+            {/* Action buttons */}
+            <div className="flex gap-3">
+              <button
+                onClick={reset}
+                className="btn-neumorphic-primary px-8 py-3 rounded-xl text-sm font-semibold"
+              >
+                Try again
+              </button>
+              <Link
+                href="/"
+                className="btn-neumorphic-primary px-8 py-3 rounded-xl text-sm font-semibold"
+              >
+                Return to Home
+              </Link>
+            </div>
+          </motion.div>
+        </motion.div>
+      </body>
+    </html>
+  );
+}


### PR DESCRIPTION
Closes #1212

Description:                                                               
                                                                             
  ## Summary                                                                 
  - Created `src/app/error.tsx` to catch runtime errors in page components   
  - Created `src/app/global-error.tsx` to catch errors in the root layout    
                                                                             
  ## Features                                                                
  - Error icon (`AlertTriangle`) in sunken neumorphic badge                  
  - Clear error headline with dev/prod message differentiation               
  - "Try again" button calling Next.js `reset()` function                    
  - "Return to Home" link for navigation recovery                            
  - Framer Motion entrance + floating animations                             
  - Proper `html`/`body` tags in `global-error.tsx`                          
                                                                             
  ## Testing                                                                 
  - Lint passes with no errors                                               
  - TypeScript compilation successful                                        
  - Build compiles without errors (pre-existing mermaid type issue unrelated