### PR TITLE
Add LoadingBar to pricing, privacy, and terms pages for consistent na…

### DIFF
--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -5,6 +5,7 @@ import type { ComponentType } from "react";
 
 import { Footer } from "@/components/layout/Footer";
 import { Navbar } from "@/components/layout/Navbar";
+import LoadingBar from "@/components/ui/LoadingBar";
 
 export const metadata: Metadata = {
   title: "Pricing | OFFER-HUB",
@@ -80,6 +81,7 @@ const tiers: PricingTier[] = [
 export default function PricingPage() {
   return (
     <div className="min-h-screen flex flex-col bg-transparent">
+      <LoadingBar />
       <Navbar />
 
       <main className="flex-grow pt-28 pb-20">

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -2,6 +2,7 @@
 
 import { Navbar } from "@/components/layout/Navbar";
 import { Footer } from "@/components/layout/Footer";
+import LoadingBar from "@/components/ui/LoadingBar";
 
 import {
   Mail,
@@ -40,6 +41,7 @@ const features = [
 export default function PrivacyPage() {
   return (
     <div className="min-h-screen flex flex-col">
+      <LoadingBar />
       <Navbar />
 
       <main className="flex-grow pt-24 sm:pt-28 md:pt-32 pb-16 sm:pb-20 px-4 sm:px-8 md:px-12 lg:px-24">

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -3,6 +3,7 @@
 import type { ReactNode } from "react";
 import { Navbar } from "@/components/layout/Navbar";
 import { Footer } from "@/components/layout/Footer";
+import LoadingBar from "@/components/ui/LoadingBar";
 import type { LucideIcon } from "lucide-react";
 import {
   AlertTriangle,
@@ -859,6 +860,7 @@ function renderBlock(block: ContentBlock, blockIndex: number) {
 export default function TermsOfServicePage() {
   return (
     <div className="min-h-screen flex flex-col bg-bg-base text-content-primary">
+      <LoadingBar />
       <Navbar />
 
       <main className="flex-grow pt-32 pb-24 px-6 lg:px-8">


### PR DESCRIPTION
## 📝 Pull Request 

Closes #1218 

## 🔧 Title: 

- Add LoadingBar to missing pages for consistent navigation transitions

## 🛠️ Issue

- Closes #issue-ID

## 📚 Description

- This PR adds `LoadingBar` to pages that were missing it (`/pricing`, `/privacy`, `/terms`) so navigation feedback is consistent with existing pages like `/`, `/community`, `/blueprint`, and `/changelog`.

## ✅ Changes applied

- Added `import LoadingBar from "@/components/ui/LoadingBar";` in:
  - `src/app/pricing/page.tsx`
  - `src/app/privacy/page.tsx`
  - `src/app/terms/page.tsx`
- Rendered `<LoadingBar />` at the top of each page layout (above `<Navbar />`) to match the existing implementation pattern.
- Verified `src/app/blueprint/page.tsx` already had `LoadingBar` and required no changes.
- Build/lint validation passed for affected pages.

## 🔍 Evidence/Media (screenshots/videos)


https://github.com/user-attachments/assets/8f0f937d-251c-47f1-a4b6-39e53a8d4624

