### PR TITLE
fix: respect prefers-reduced-motion in all animated components (#1211)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -455,6 +455,9 @@ body::before {
 }
 
 @media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto !important;
+  }
 
   *,
   *::before,
@@ -462,6 +465,7 @@ body::before {
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
   }
 }
 

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,21 +1,23 @@
 "use client";
 
 import Link from "next/link";
-import { motion } from "framer-motion";
+import { motion, useReducedMotion } from "framer-motion";
 import { SearchX } from "lucide-react";
 
 export default function NotFound() {
+  const shouldReduceMotion = useReducedMotion();
+
   return (
     <main className="min-h-screen flex items-center justify-center bg-[var(--color-bg-base)] px-4">
       <motion.div
         initial={{ opacity: 0, scale: 0.95 }}
         animate={{ opacity: 1, scale: 1 }}
-        transition={{ duration: 0.5, ease: "easeOut" }}
+        transition={{ duration: shouldReduceMotion ? 0 : 0.5, ease: "easeOut" }}
         className="w-full max-w-md"
       >
         {/* Floating card */}
         <motion.div
-          animate={{ y: [0, -12, 0] }}
+          animate={shouldReduceMotion ? {} : { y: [0, -12, 0] }}
           transition={{
             duration: 4,
             ease: "easeInOut" as const,

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -16,12 +16,29 @@ export default function HeroSection() {
     const el = headingRef.current;
     if (!el) return;
 
+    // Detect prefers-reduced-motion
+    const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+    let shouldReduceMotion = mediaQuery.matches;
+
+    const handleMediaChange = (e: MediaQueryListEvent) => {
+      shouldReduceMotion = e.matches;
+      if (shouldReduceMotion) {
+        cancelAnimationFrame(frame);
+        // Set a static beautiful gradient if motion is reduced
+        el.style.backgroundImage = "linear-gradient(135deg, #1bc8ca 0%, #149A9B 100%)";
+      } else {
+        frame = requestAnimationFrame(animate);
+      }
+    };
+
+    mediaQuery.addEventListener("change", handleMediaChange);
+
     let frame: number;
     let t = 0;
     let paused = false;
 
     const animate = () => {
-      if (paused) return;
+      if (paused || shouldReduceMotion) return;
       t += 0.022;
 
       const b1x = 50 + 28 * Math.sin(t * 0.70);
@@ -59,16 +76,24 @@ export default function HeroSection() {
         cancelAnimationFrame(frame);
       } else {
         paused = false;
-        frame = requestAnimationFrame(animate);
+        if (!shouldReduceMotion) {
+          frame = requestAnimationFrame(animate);
+        }
       }
     };
 
     document.addEventListener("visibilitychange", onVisibility);
-    frame = requestAnimationFrame(animate);
+
+    if (shouldReduceMotion) {
+      el.style.backgroundImage = "linear-gradient(135deg, #1bc8ca 0%, #149A9B 100%)";
+    } else {
+      frame = requestAnimationFrame(animate);
+    }
 
     return () => {
       cancelAnimationFrame(frame);
       document.removeEventListener("visibilitychange", onVisibility);
+      mediaQuery.removeEventListener("change", handleMediaChange);
     };
   }, []);
 

--- a/src/components/providers/ThemeProvider.tsx
+++ b/src/components/providers/ThemeProvider.tsx
@@ -2,6 +2,7 @@
 
 import { createContext, useContext, useEffect, useState, useCallback } from "react";
 import { flushSync } from "react-dom";
+import { MotionConfig } from "framer-motion";
 
 type Theme = "light" | "dark" | "system";
 type ResolvedTheme = "light" | "dark";
@@ -114,7 +115,9 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
   // Provider MUST always be rendered to avoid context errors
   return (
     <ThemeContext.Provider value={{ theme, setTheme, resolvedTheme, toggleTheme }}>
-      {children}
+      <MotionConfig reducedMotion="user">
+        {children}
+      </MotionConfig>
     </ThemeContext.Provider>
   );
 }


### PR DESCRIPTION
# fix: respect prefers-reduced-motion in all animated components

Closes https://github.com/OFFER-HUB/offer-hub-monorepo/issues/1211

## Summary
This PR implements comprehensive support for the `prefers-reduced-motion` media feature across the platform, improving accessibility (A11y) for users with vestibular disorders or photosensitivity.

## Changes
- **Global CSS Safety Rule**: Enhanced `src/app/globals.css` with a robust media query that forces all CSS animations and transitions to near-zero duration and disables smooth scrolling when reduced motion is preferred.
- **Global Framer Motion Config**: Integrated `<MotionConfig reducedMotion="user">` in `ThemeProvider.tsx` to automatically handle all `motion.*` components across the entire monorepo.
- **JS-Driven Animation Control**: Updated `HeroSection.tsx` to detect the system preference and stop the "Liquid Text" `requestAnimationFrame` loop, replacing it with a static premium gradient.
- **Component Specific Fixes**: Refactored `not-found.tsx` to use the `useReducedMotion` hook, ensuring the floating 404 card remains static when necessary.

## Evidence / Video
https://github.com/user-attachments/assets/0064e5b9-047e-4f93-be1c-881d8968c2db

## Verification
- [x] Verified that CSS animations stop when `prefers-reduced-motion: reduce` is active.
- [x] Verified that the Hero "Liquid Text" animation stops and shows a static background.
- [x] Verified that Framer Motion components respect the global config.
