### PR TITLE
fix(community): replace fabricated GitHub fallback data with empty st…

### DIFF
--- a/src/app/community/page.tsx
+++ b/src/app/community/page.tsx
@@ -17,6 +17,13 @@ interface RepoStats {
   openIssues: string;
 }
 
+interface CommunityData {
+  stats: RepoStats | null;
+  contributors: ContributorData[];
+  pullRequests: PullRequestData[];
+  issues: IssueData[];
+}
+
 interface Contributor {
   login: string;
   avatar_url: string;
@@ -104,7 +111,7 @@ let githubCache: { data: ReturnType<typeof processGitHubData> | null; timestamp:
 };
 const CACHE_TTL = 10 * 60 * 1000; // 10 minutes
 
-function processGitHubData(validData: NonNullable<Awaited<ReturnType<typeof fetchRepoData>>>[]) {
+function processGitHubData(validData: NonNullable<Awaited<ReturnType<typeof fetchRepoData>>>[]): CommunityData {
   const totalStars = validData.reduce((acc, d) => acc + d.repo.stargazers_count, 0);
   const totalForks = validData.reduce((acc, d) => acc + d.repo.forks_count, 0);
   const totalOpenIssues = validData.reduce((acc, d) => acc + d.repo.open_issues_count, 0);
@@ -205,33 +212,11 @@ async function fetchGitHubData() {
   } catch (error) {
     console.error('Error fetching GitHub data:', error);
     return {
-      stats: {
-        stars: "8.2k",
-        forks: "1.4k",
-        contributors: "168",
-        openIssues: "128",
-      },
-      contributors: [
-        { name: "Ada M.", username: "ada-m", avatar: "", commits: 248, profileUrl: "" },
-        { name: "Dami O.", username: "dami-o", avatar: "", commits: 133, profileUrl: "" },
-        { name: "Hassan K.", username: "hassan-k", avatar: "", commits: 92, profileUrl: "" },
-        { name: "Lina S.", username: "lina-s", avatar: "", commits: 87, profileUrl: "" },
-        { name: "Marta P.", username: "marta-p", avatar: "", commits: 76, profileUrl: "" },
-        { name: "Tomi A.", username: "tomi-a", avatar: "", commits: 70, profileUrl: "" },
-      ],
-      pullRequests: [
-        { number: 1042, title: "feat: add account-level escrow analytics", author: "contributor1", timestamp: "2 days ago", url: "", status: "Merged" },
-        { number: 1039, title: "refactor: simplify wallet sync flow", author: "contributor2", timestamp: "3 days ago", url: "", status: "Merged" },
-        { number: 1036, title: "fix: resolve pagination edge case in jobs feed", author: "contributor3", timestamp: "5 days ago", url: "", status: "Merged" },
-        { number: 1033, title: "docs: add validator onboarding guide", author: "contributor4", timestamp: "1 week ago", url: "", status: "Merged" },
-      ],
-      issues: [
-        { number: 1055, title: "Improve CI cache invalidation strategy", priority: "Medium", url: "", labels: [] },
-        { number: 1051, title: "Add e2e tests for payout cancellation", priority: "High", url: "", labels: [] },
-        { number: 1048, title: "Expose webhook replay in dashboard", priority: "Low", url: "", labels: [] },
-        { number: 1046, title: "Polish mobile nav focus styles", priority: "Low", url: "", labels: [] },
-      ],
-    } as { stats: RepoStats; contributors: ContributorData[]; pullRequests: PullRequestData[]; issues: IssueData[] };
+      stats: null,
+      contributors: [],
+      pullRequests: [],
+      issues: [],
+    } as CommunityData;
   }
 }
 

--- a/src/components/community/ContributorGrid.tsx
+++ b/src/components/community/ContributorGrid.tsx
@@ -11,17 +11,6 @@ interface ContributorGridProps {
   contributors?: Contributor[];
 }
 
-const mockContributors: Contributor[] = [
-  { name: "Ada M.", username: "ada-m", area: "Core Protocol", commits: 248 },
-  { name: "Dami O.", username: "dami-o", area: "Frontend", commits: 133 },
-  { name: "Hassan K.", username: "hassan-k", area: "DevRel", commits: 92 },
-  { name: "Lina S.", username: "lina-s", area: "Tooling", commits: 87 },
-  { name: "Marta P.", username: "marta-p", area: "QA", commits: 76 },
-  { name: "Tomi A.", username: "tomi-a", area: "Docs", commits: 70 },
-  { name: "Carlos R.", username: "carlos-r", area: "Backend", commits: 64 },
-  { name: "Femi B.", username: "femi-b", area: "Smart Contracts", commits: 58 },
-];
-
 function getInitials(name: string) {
   return name
     .split(" ")
@@ -32,7 +21,7 @@ function getInitials(name: string) {
 }
 
 export default function ContributorGrid({ contributors }: ContributorGridProps) {
-  const data = contributors ?? mockContributors;
+  const data = contributors ?? [];
 
   return (
     <section id="contributor-grid" className="py-24">
@@ -43,29 +32,40 @@ export default function ContributorGrid({ contributors }: ContributorGridProps) 
           subtitle="The people building and shipping OFFER-HUB every day."
         />
 
-        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
-          {data.map((contributor) => (
-            <article
-              key={contributor.username}
-              className="rounded-2xl p-6 shadow-neu-raised bg-bg-elevated flex flex-col items-center text-center hover:shadow-neu-raised-hover transition-shadow duration-300"
-            >
-              <div
-                className="w-16 h-16 rounded-full shadow-neu-raised-sm flex items-center justify-center text-lg font-bold text-white bg-theme-primary"
+        {data.length > 0 ? (
+          <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+            {data.map((contributor) => (
+              <article
+                key={contributor.username}
+                className="rounded-2xl p-6 shadow-neu-raised bg-bg-elevated flex flex-col items-center text-center hover:shadow-neu-raised-hover transition-shadow duration-300"
               >
-                {getInitials(contributor.name)}
-              </div>
-              <h3 className="mt-4 text-base font-bold text-content-primary">
-                {contributor.name}
-              </h3>
-              <p className="mt-1 text-xs font-light text-content-secondary">
-                {contributor.area}
-              </p>
-              <p className="mt-3 text-sm font-medium text-theme-primary">
-                {contributor.commits} commits
-              </p>
-            </article>
-          ))}
-        </div>
+                <div
+                  className="w-16 h-16 rounded-full shadow-neu-raised-sm flex items-center justify-center text-lg font-bold text-white bg-theme-primary"
+                >
+                  {getInitials(contributor.name)}
+                </div>
+                <h3 className="mt-4 text-base font-bold text-content-primary">
+                  {contributor.name}
+                </h3>
+                <p className="mt-1 text-xs font-light text-content-secondary">
+                  {contributor.area}
+                </p>
+                <p className="mt-3 text-sm font-medium text-theme-primary">
+                  {contributor.commits} commits
+                </p>
+              </article>
+            ))}
+          </div>
+        ) : (
+          <div className="rounded-2xl p-6 shadow-neu-raised bg-bg-elevated text-center">
+            <p className="text-base font-bold text-content-primary">
+              Contributors temporarily unavailable
+            </p>
+            <p className="mt-2 text-sm text-content-secondary">
+              Live contributor activity could not be loaded from GitHub.
+            </p>
+          </div>
+        )}
 
         <div className="mt-12 text-center">
           <a

--- a/src/components/community/ContributorsSection.tsx
+++ b/src/components/community/ContributorsSection.tsx
@@ -84,14 +84,29 @@ const ContributorsSection = ({ contributors }: ContributorsSectionProps) => {
         <SectionHeading
           eyebrow="Contributors"
           title="Meet the people shipping OFFER-HUB"
-          subtitle={`Meet the developers shipping OFFER-HUB every day. A growing community of ${totalContributors} contributors.`}
+          subtitle={
+            totalContributors > 0
+              ? `Meet the developers shipping OFFER-HUB every day. A growing community of ${totalContributors} contributors.`
+              : "Contributor data is temporarily unavailable while we reconnect to GitHub."
+          }
         />
 
-        <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4 mt-12">
-          {visibleContributors.map((person) => (
-            <ContributorCard key={person.username} person={person} />
-          ))}
-        </div>
+        {totalContributors > 0 ? (
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4 mt-12">
+            {visibleContributors.map((person) => (
+              <ContributorCard key={person.username} person={person} />
+            ))}
+          </div>
+        ) : (
+          <div className="mt-12 rounded-3xl bg-bg-base p-8 shadow-neu-raised">
+            <p className="text-sm font-black uppercase tracking-widest text-content-primary">
+              Contributors temporarily unavailable
+            </p>
+            <p className="mt-3 text-sm text-content-secondary">
+              We could not load live contributor activity right now. Please try again shortly.
+            </p>
+          </div>
+        )}
 
         {hasMore && (
           <div className="mt-16 text-center">

--- a/src/components/community/HeroRepoStatsSection.tsx
+++ b/src/components/community/HeroRepoStatsSection.tsx
@@ -8,15 +8,17 @@ interface RepoStats {
 }
 
 interface HeroRepoStatsSectionProps {
-  stats: RepoStats;
+  stats: RepoStats | null;
 }
 
 const HeroRepoStatsSection = ({ stats }: HeroRepoStatsSectionProps) => {
+  const statsUnavailable = stats === null;
+
   const repoStats = [
-    { label: "Stars", value: stats.stars, icon: Star, color: "text-[#149A9B]" },
-    { label: "Forks", value: stats.forks, icon: GitFork, color: "text-[#19213D]" },
-    { label: "Contributors", value: stats.contributors, icon: Users, color: "text-[#149A9B]" },
-    { label: "Open Issues", value: stats.openIssues, icon: AlertCircle, color: "text-[#19213D]" },
+    { label: "Stars", value: stats?.stars ?? "N/A", icon: Star, color: "text-[#149A9B]" },
+    { label: "Forks", value: stats?.forks ?? "N/A", icon: GitFork, color: "text-[#19213D]" },
+    { label: "Contributors", value: stats?.contributors ?? "N/A", icon: Users, color: "text-[#149A9B]" },
+    { label: "Open Issues", value: stats?.openIssues ?? "N/A", icon: AlertCircle, color: "text-[#19213D]" },
   ];
 
   return (
@@ -31,8 +33,9 @@ const HeroRepoStatsSection = ({ stats }: HeroRepoStatsSectionProps) => {
               Building the Future <br />of <span className="text-theme-primary">Payments</span>
             </h1>
             <p className="mt-8 max-w-xl text-lg font-medium leading-relaxed text-content-secondary">
-              A global decentralized community of {stats.contributors} contributors
-              shipping modular infrastructure every day.
+              {statsUnavailable
+                ? "GitHub stats are temporarily unavailable. Live repository metrics will return shortly."
+                : `A global decentralized community of ${stats.contributors} contributors shipping modular infrastructure every day.`}
             </p>
 
             <div className="mt-10 flex flex-wrap gap-4">
@@ -48,27 +51,43 @@ const HeroRepoStatsSection = ({ stats }: HeroRepoStatsSectionProps) => {
           </div>
 
           <div className="lg:col-span-5 relative">
-            <div className="grid grid-cols-2 gap-6">
-              {repoStats.map((stat) => (
-                <div
-                  key={stat.label}
-                  className="group rounded-3xl bg-bg-elevated shadow-neu-raised p-6 transition-all duration-500 hover:scale-[1.02]"
-                >
-                  <div className="flex items-center justify-between mb-4">
-                    <div className="p-2.5 rounded-xl bg-bg-sunken shadow-neu-sunken-subtle">
-                      <stat.icon size={18} className={`${stat.color} transition-transform group-hover:scale-110`} />
-                    </div>
-                    <div className="h-1 w-4 rounded-full bg-theme-primary/20" />
+            {statsUnavailable ? (
+              <div className="rounded-3xl bg-bg-elevated shadow-neu-raised p-8">
+                <div className="flex items-center gap-3">
+                  <div className="p-2.5 rounded-xl bg-bg-sunken shadow-neu-sunken-subtle">
+                    <AlertCircle size={18} className="text-theme-primary" />
                   </div>
-                  <p className="text-[10px] font-bold uppercase tracking-widest text-content-secondary">
-                    {stat.label}
-                  </p>
-                  <p className="mt-1 text-3xl font-black text-content-primary tracking-tight">
-                    {stats[stat.label.toLowerCase().replace(" ", "") as keyof typeof stats] || stat.value}
+                  <p className="text-sm font-black uppercase tracking-widest text-content-primary">
+                    Stats temporarily unavailable
                   </p>
                 </div>
-              ))}
-            </div>
+                <p className="mt-4 text-sm font-medium text-content-secondary">
+                  We could not load live GitHub repository metrics right now. Please check again in a few minutes.
+                </p>
+              </div>
+            ) : (
+              <div className="grid grid-cols-2 gap-6">
+                {repoStats.map((stat) => (
+                  <div
+                    key={stat.label}
+                    className="group rounded-3xl bg-bg-elevated shadow-neu-raised p-6 transition-all duration-500 hover:scale-[1.02]"
+                  >
+                    <div className="flex items-center justify-between mb-4">
+                      <div className="p-2.5 rounded-xl bg-bg-sunken shadow-neu-sunken-subtle">
+                        <stat.icon size={18} className={`${stat.color} transition-transform group-hover:scale-110`} />
+                      </div>
+                      <div className="h-1 w-4 rounded-full bg-theme-primary/20" />
+                    </div>
+                    <p className="text-[10px] font-bold uppercase tracking-widest text-content-secondary">
+                      {stat.label}
+                    </p>
+                    <p className="mt-1 text-3xl font-black text-content-primary tracking-tight">
+                      {stat.value}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/src/components/community/RepoStats.tsx
+++ b/src/components/community/RepoStats.tsx
@@ -7,38 +7,50 @@ interface RepoStatsProps {
      openIssues?: number;
 }
 
-const mockStats = {
-     stars: 2547,
-     forks: 380,
-     watchers: 145,
-     openIssues: 23,
-};
-
 export default function RepoStats({
-     stars = mockStats.stars,
-     forks = mockStats.forks,
-     watchers = mockStats.watchers,
-     openIssues = mockStats.openIssues,
+     stars,
+     forks,
+     watchers,
+     openIssues,
 }: RepoStatsProps) {
+     const isUnavailable =
+          [stars, forks, watchers, openIssues].some((value) => value === undefined);
+
+     if (isUnavailable) {
+          return (
+               <div
+                    className="rounded-2xl p-6 shadow-raised"
+                    style={{ background: "#F1F3F7" }}
+               >
+                    <p className="text-sm font-semibold" style={{ color: "#19213D" }}>
+                         Stats temporarily unavailable
+                    </p>
+                    <p className="mt-2 text-xs" style={{ color: "#6D758F" }}>
+                         Live GitHub repository metrics could not be loaded right now.
+                    </p>
+               </div>
+          );
+     }
+
      const stats = [
           {
                icon: Star,
-               value: stars,
+               value: stars!,
                label: "Stars",
           },
           {
                icon: GitFork,
-               value: forks,
+               value: forks!,
                label: "Forks",
           },
           {
                icon: Eye,
-               value: watchers,
+               value: watchers!,
                label: "Watchers",
           },
           {
                icon: AlertCircle,
-               value: openIssues,
+               value: openIssues!,
                label: "Open Issues",
           },
      ];


### PR DESCRIPTION
## Summary
- Removed fabricated fallback repo stats and contributor data shown when GitHub API is unavailable
- Replaced fake values with explicit, user-facing unavailable states
- Kept existing loading skeleton behavior intact during fetch
- Updated community data fallback to return null/empty data instead of invented content

## Issue
- Closes #1207

## Files changed
- src/components/community/RepoStats.tsx
- src/components/community/ContributorGrid.tsx
- src/components/community/HeroRepoStatsSection.tsx
- src/components/community/ContributorsSection.tsx
- src/app/community/page.tsx

