### PR TITLE
fix(docs): replace broken Help Center link on docs hub

### DIFF
--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -175,7 +175,7 @@ export default function DocsPage() {
             Can&apos;t find what you&apos;re looking for?
           </p>
           <div className="flex justify-center items-center gap-8">
-            <Link href="/help" className="text-theme-primary font-black uppercase tracking-widest text-xs hover:tracking-[0.2em] transition-all">Help Center</Link>
+            <Link href="/community" className="text-theme-primary font-black uppercase tracking-widest text-xs hover:tracking-[0.2em] transition-all">Help Center</Link>
             <span className="w-1.5 h-1.5 rounded-full bg-theme-border/40" />
             <Link href="https://github.com/OFFER-HUB/offer-hub-monorepo/issues" className="text-theme-primary font-black uppercase tracking-widest text-xs hover:tracking-[0.2em] transition-all">GitHub Issues</Link>
           </div>


### PR DESCRIPTION
## Summary
- replace the broken `/help` docs support CTA with `/community` in the docs hub page
- keep the CTA label as "Help Center" while routing users to a valid support-adjacent page
- resolves the assigned dead-link bug in docs navigation

## Test plan
- [x] Open the Docs hub page
- [x] Click **Help Center** and confirm it resolves to `/community` (not 404)
- [x] Verify no lint issues in `src/app/docs/page.tsx`

Close #1208

