### PR TITLE
fix: Add robots.txt and sitemap.xml for search engine crawling

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,6 @@
+User-agent: *
+Allow: /
+Disallow: /api/
+Disallow: /admin/
+
+Sitemap: https://offer-hub.tech/sitemap.xml

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,50 @@
+import { MetadataRoute } from 'next';
+import docsIndex from '@/data/docs-index.json';
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const baseUrl = 'https://offer-hub.tech';
+
+  const staticRoutes = [
+    '',
+    '/use-cases',
+    '/blueprint',
+    '/pricing',
+    '/changelog',
+    '/community',
+    '/docs',
+    '/terms',
+    '/privacy',
+  ];
+
+  const sitemapEntries: MetadataRoute.Sitemap = staticRoutes.map((route) => ({
+    url: `${baseUrl}${route}`,
+    lastModified: new Date(),
+    changeFrequency: 'weekly',
+    priority: route === '' ? 1 : 0.8,
+  }));
+
+  const docPaths = new Set<string>();
+
+  if (Array.isArray(docsIndex)) {
+    docsIndex.forEach((entry) => {
+      if (entry.link) {
+        // Strip out the hash fragment from the link to get the page URL
+        const basePath = entry.link.split('#')[0];
+        if (basePath && basePath.startsWith('/docs/')) {
+          docPaths.add(basePath);
+        }
+      }
+    });
+  }
+
+  docPaths.forEach((docPath) => {
+    sitemapEntries.push({
+      url: `${baseUrl}${docPath}`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.6,
+    });
+  });
+
+  return sitemapEntries;
+}


### PR DESCRIPTION
# 📝 Pull Request 

## 🔧 Title: 

- fix: Add robots.txt and sitemap.xml for search engine crawling

## 🛠️ Issue

- Closes #1205

## 📚 Description

- This PR adds the foundational SEO infrastructure necessary for proper search engine indexing of the platform. It introduces a `robots.txt` file to safely manage crawler access and a dynamic `sitemap.xml` that automatically updates as documentation pages change, fulfilling all acceptance criteria.

## ✅ Changes applied

- Added `public/robots.txt` to allow all crawlers on public routes while explicitly disallowing private API (`/api/`) and admin (`/admin/`) paths, and properly referenced the sitemap.
- Created a dynamic `src/app/sitemap.ts` file leveraging Next.js App Router's `MetadataRoute.Sitemap` feature.
- Implemented static route configurations including `url`, `lastModified`, `changeFrequency`, and `priority` for standard platform pages (`/`, `/use-cases`, `/blueprint`, etc.).
- Integrated the build-time `docs-index.json` to dynamically generate individual sitemap entries for every unique `/docs/[...slug]` page dynamically.

## 🔍 Evidence/Media (screenshots/videos)

- N/A (Backend / Build-time SEO infrastructure). The sitemap validates via Next.js types and successfully compiles `/sitemap.xml`.
