### PR TITLE
fix: add Next.js metadata exports to all public pages for SEO

### DIFF
--- a/src/app/blueprint/page.tsx
+++ b/src/app/blueprint/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { Navbar } from "@/components/layout/Navbar";
 import { Footer } from "@/components/layout/Footer";
 import LoadingBar from "@/components/ui/LoadingBar";
@@ -7,6 +8,21 @@ import BlueprintSectionNav from "@/components/blueprint/BlueprintSectionNav";
 import OrchestratorShowcase from "@/components/blueprint/OrchestratorShowcase";
 import MarketplaceTemplate from "@/components/blueprint/MarketplaceTemplate";
 import EvolutionTimeline from "@/components/blueprint/EvolutionTimeline";
+
+export const metadata: Metadata = {
+  title: "Blueprint",
+  description:
+    "Explore the OFFER-HUB technical blueprint: orchestrator architecture, marketplace templates, and the evolution roadmap for trustless payment infrastructure.",
+  keywords: [
+    "blueprint",
+    "architecture",
+    "orchestrator",
+    "marketplace",
+    "roadmap",
+    "OFFER-HUB",
+    "payment infrastructure",
+  ],
+};
 
 export default function BlueprintPage() {
   return (

--- a/src/app/changelog/page.tsx
+++ b/src/app/changelog/page.tsx
@@ -1,5 +1,19 @@
+import type { Metadata } from "next";
 import { Navbar } from "@/components/layout/Navbar";
 import { Footer } from "@/components/layout/Footer";
+
+export const metadata: Metadata = {
+  title: "Changelog",
+  description:
+    "Track every release and update to the OFFER-HUB platform — new features, improvements, and fixes across the ecosystem.",
+  keywords: [
+    "changelog",
+    "releases",
+    "updates",
+    "OFFER-HUB",
+    "version history",
+  ],
+};
 
 interface GitHubRelease {
   tag_name: string;

--- a/src/app/community/page.tsx
+++ b/src/app/community/page.tsx
@@ -1,5 +1,15 @@
 import type { Metadata } from "next";
 import HeroRepoStatsSection from "@/components/community/HeroRepoStatsSection";
+import ContributorsSection from "@/components/community/ContributorsSection";
+import HowToContribute from "@/components/community/HowToContribute";
+import RecentPRsSection, { PullRequestData } from "@/components/community/RecentPRsSection";
+import OpenIssuesSection from "@/components/community/OpenIssuesSection";
+import RepoLinksSection from "@/components/community/RepoLinksSection";
+import CommunityChannelsSection from "@/components/community/CommunityChannelsSection";
+import RegistrationForm from "@/components/community/RegistrationForm";
+import LoadingBar from "@/components/ui/LoadingBar";
+import { Footer } from "@/components/layout/Footer";
+import { Navbar } from "@/components/layout/Navbar";
 
 export const metadata: Metadata = {
   title: "Community",
@@ -14,16 +24,6 @@ export const metadata: Metadata = {
     "contribute",
   ],
 };
-import ContributorsSection from "@/components/community/ContributorsSection";
-import HowToContribute from "@/components/community/HowToContribute";
-import RecentPRsSection, { PullRequestData } from "@/components/community/RecentPRsSection";
-import OpenIssuesSection from "@/components/community/OpenIssuesSection";
-import RepoLinksSection from "@/components/community/RepoLinksSection";
-import CommunityChannelsSection from "@/components/community/CommunityChannelsSection";
-import RegistrationForm from "@/components/community/RegistrationForm";
-import LoadingBar from "@/components/ui/LoadingBar";
-import { Footer } from "@/components/layout/Footer";
-import { Navbar } from "@/components/layout/Navbar";
 
 interface RepoStats {
   stars: string;

--- a/src/app/community/page.tsx
+++ b/src/app/community/page.tsx
@@ -1,4 +1,19 @@
+import type { Metadata } from "next";
 import HeroRepoStatsSection from "@/components/community/HeroRepoStatsSection";
+
+export const metadata: Metadata = {
+  title: "Community",
+  description:
+    "Join the OFFER-HUB open-source community. Explore contributors, open issues, recent pull requests, and learn how to get involved.",
+  keywords: [
+    "community",
+    "open source",
+    "contributors",
+    "GitHub",
+    "OFFER-HUB",
+    "contribute",
+  ],
+};
 import ContributorsSection from "@/components/community/ContributorsSection";
 import HowToContribute from "@/components/community/HowToContribute";
 import RecentPRsSection, { PullRequestData } from "@/components/community/RecentPRsSection";

--- a/src/app/docs/layout.tsx
+++ b/src/app/docs/layout.tsx
@@ -1,5 +1,21 @@
+import type { Metadata } from "next";
 import { getSidebarNav } from "@/lib/mdx";
 import { DocsLayoutShell } from "@/components/docs/DocsLayoutShell";
+
+export const metadata: Metadata = {
+  title: "Documentation",
+  description:
+    "Explore OFFER-HUB documentation: getting started guides, API reference, TypeScript SDK, escrow workflows, and self-hosting instructions.",
+  keywords: [
+    "documentation",
+    "API reference",
+    "SDK",
+    "escrow",
+    "getting started",
+    "OFFER-HUB",
+    "self-hosting",
+  ],
+};
 
 export default function DocsLayout({ children }: { children: React.ReactNode }) {
   const nav = getSidebarNav();

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,21 @@
+import type { Metadata } from "next";
 import { Navbar } from "@/components/layout/Navbar";
+
+export const metadata: Metadata = {
+  title: "OFFER-HUB — Trustless Payments Orchestrator for Marketplaces",
+  description:
+    "OFFER-HUB empowers marketplaces to provide secure, non-custodial escrow payments without building complex payment infrastructure from scratch.",
+  keywords: [
+    "escrow",
+    "marketplace payments",
+    "non-custodial",
+    "Stellar",
+    "Trustless Work",
+    "Airtm",
+    "payment orchestration",
+    "USDC",
+  ],
+};
 import { Footer } from "@/components/layout/Footer";
 import HeroSection from "@/components/HeroSection";
 import StatsSection from "@/components/StatsSection";

--- a/src/app/use-cases/layout.tsx
+++ b/src/app/use-cases/layout.tsx
@@ -3,6 +3,16 @@ import type { Metadata } from "next";
 export const metadata: Metadata = {
     title: "Industry Use Cases — OFFER HUB",
     description: "Explore how OFFER HUB's non-custodial escrow orchestrates payment workflows across Freelance, eCommerce, DAOs, and Real Estate.",
+    keywords: [
+        "use cases",
+        "freelance",
+        "ecommerce",
+        "DAO payroll",
+        "real estate",
+        "escrow",
+        "OFFER-HUB",
+        "marketplace",
+    ],
 };
 
 export default function UseCasesLayout({


### PR DESCRIPTION
## 🔧 Title: 
- fix: add Next.js metadata exports to all public pages for SEO

## 🛠️ Issue
- Closes #1203

## 📚 Description
- Public pages had no title, description, or keywords metadata, hurting SEO and social sharing previews. Added `export const metadata` to each public-facing page and layout using the Next.js Metadata API.

## ✅ Changes applied
- `src/app/page.tsx` — homepage metadata
- `src/app/blueprint/page.tsx` — blueprint metadata
- `src/app/changelog/page.tsx` — changelog metadata
- `src/app/community/page.tsx` — community metadata + fixed import order
- `src/app/docs/layout.tsx` — docs metadata (lives in layout since page is a client component)
- `src/app/use-cases/layout.tsx` — added keywords to existing metadata

## 🔍 Evidence/Media (screenshots/videos)
- N/A (no visual changes)
