### PR TITLE
fix: Add not-found.tsx for invalid /docs/[...slug] routes

### DIFF
--- a/src/app/docs/[...slug]/not-found.tsx
+++ b/src/app/docs/[...slug]/not-found.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import Link from "next/link";
+import { motion, useReducedMotion } from "framer-motion";
+import { FileQuestion, Home, BookOpen, Search } from "lucide-react";
+
+export default function DocsNotFound() {
+  const shouldReduceMotion = useReducedMotion();
+
+  return (
+    <div className="min-h-[70vh] flex items-center justify-center px-4 py-12">
+      <motion.div
+        initial={{ opacity: 0, scale: 0.95 }}
+        animate={{ opacity: 1, scale: 1 }}
+        transition={{ duration: shouldReduceMotion ? 0 : 0.5, ease: "easeOut" }}
+        className="w-full max-w-2xl"
+      >
+        {/* Floating card */}
+        <motion.div
+          animate={shouldReduceMotion ? {} : { y: [0, -8, 0] }}
+          transition={{
+            duration: 4,
+            ease: "easeInOut" as const,
+            repeat: Infinity,
+          }}
+          className="rounded-3xl p-10 flex flex-col items-center text-center"
+          style={{
+            background: "var(--color-bg-base)",
+            boxShadow:
+              "10px 10px 20px var(--shadow-dark), -10px -10px 20px var(--shadow-light)",
+          }}
+        >
+          {/* Sunken 404 badge */}
+          <div
+            className="w-32 h-32 rounded-2xl flex items-center justify-center mb-6"
+            style={{
+              background: "var(--color-bg-sunken)",
+              boxShadow:
+                "inset 8px 8px 16px var(--shadow-dark), inset -8px -8px 16px var(--shadow-light)",
+            }}
+          >
+            <FileQuestion
+              size={56}
+              style={{ color: "var(--color-primary)" }}
+              strokeWidth={1.5}
+            />
+          </div>
+
+          {/* Headline */}
+          <h1
+            className="text-2xl font-bold mb-3 leading-snug"
+            style={{ color: "var(--color-text-primary)" }}
+          >
+            Documentation Page Not Found
+          </h1>
+
+          {/* Subtext */}
+          <p
+            className="text-base leading-relaxed mb-8 max-w-md"
+            style={{ color: "var(--color-text-secondary)" }}
+          >
+            The documentation page you're looking for doesn't exist or may have been moved.
+            Try exploring the docs from the beginning or search for what you need.
+          </p>
+
+          {/* Action buttons */}
+          <div className="flex flex-col sm:flex-row gap-4 w-full sm:w-auto">
+            <Link
+              href="/docs"
+              className="btn-neumorphic-primary px-6 py-3 rounded-xl text-sm font-semibold inline-flex items-center justify-center gap-2"
+            >
+              <BookOpen size={18} strokeWidth={2} />
+              Browse Docs
+            </Link>
+            
+            <Link
+              href="/"
+              className="btn-neumorphic-secondary px-6 py-3 rounded-xl text-sm font-semibold inline-flex items-center justify-center gap-2"
+            >
+              <Home size={18} strokeWidth={2} />
+              Go Home
+            </Link>
+          </div>
+
+          {/* Helpful links section */}
+          <div className="mt-10 pt-8 border-t w-full" style={{ borderColor: "var(--color-border)" }}>
+            <p
+              className="text-sm font-medium mb-4"
+              style={{ color: "var(--color-text-secondary)" }}
+            >
+              Popular Documentation Sections
+            </p>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 text-left">
+              <Link
+                href="/docs/getting-started"
+                className="px-4 py-3 rounded-xl text-sm transition-all duration-300"
+                style={{
+                  background: "var(--color-bg-base)",
+                  boxShadow: "4px 4px 8px var(--shadow-dark), -4px -4px 8px var(--shadow-light)",
+                  color: "var(--color-text-primary)",
+                }}
+              >
+                <span className="font-medium">Getting Started</span>
+                <p className="text-xs mt-1" style={{ color: "var(--color-text-secondary)" }}>
+                  Quick start guide
+                </p>
+              </Link>
+
+              <Link
+                href="/docs/api"
+                className="px-4 py-3 rounded-xl text-sm transition-all duration-300"
+                style={{
+                  background: "var(--color-bg-base)",
+                  boxShadow: "4px 4px 8px var(--shadow-dark), -4px -4px 8px var(--shadow-light)",
+                  color: "var(--color-text-primary)",
+                }}
+              >
+                <span className="font-medium">API Reference</span>
+                <p className="text-xs mt-1" style={{ color: "var(--color-text-secondary)" }}>
+                  Complete API docs
+                </p>
+              </Link>
+
+              <Link
+                href="/docs/architecture"
+                className="px-4 py-3 rounded-xl text-sm transition-all duration-300"
+                style={{
+                  background: "var(--color-bg-base)",
+                  boxShadow: "4px 4px 8px var(--shadow-dark), -4px -4px 8px var(--shadow-light)",
+                  color: "var(--color-text-primary)",
+                }}
+              >
+                <span className="font-medium">Architecture</span>
+                <p className="text-xs mt-1" style={{ color: "var(--color-text-secondary)" }}>
+                  System design
+                </p>
+              </Link>
+
+              <Link
+                href="/docs/guides"
+                className="px-4 py-3 rounded-xl text-sm transition-all duration-300"
+                style={{
+                  background: "var(--color-bg-base)",
+                  boxShadow: "4px 4px 8px var(--shadow-dark), -4px -4px 8px var(--shadow-light)",
+                  color: "var(--color-text-primary)",
+                }}
+              >
+                <span className="font-medium">Guides</span>
+                <p className="text-xs mt-1" style={{ color: "var(--color-text-secondary)" }}>
+                  Step-by-step tutorials
+                </p>
+              </Link>
+            </div>
+          </div>
+        </motion.div>
+      </motion.div>
+    </div>
+  );
+}


### PR DESCRIPTION
This closes issue #1213 

## 📘 Description

This PR adds a documentation-specific 404 page that displays when users navigate to non-existent documentation paths (e.g., `/docs/invalid-page`). Previously, users would see the generic root 404 page with no context about being in the docs section or how to find the content they need.

## 🔧 Changes

### Created `src/app/docs/[...slug]/not-found.tsx`
A styled, docs-specific not-found page that:
- **Provides clear context**: Users know they're in the docs section and the page doesn't exist
- **Offers recovery paths**: Links to browse docs (`/docs`) and return home (`/`)
- **Suggests popular sections**: Quick links to Getting Started, API Reference, Architecture, and Guides
- **Follows design system**: Uses neumorphic design with raised card, sunken badge, and smooth animations
- **Maintains consistency**: Matches the visual language of the root `not-found.tsx`

### Key Features
- **Neumorphic card design** with dual shadows (light/dark)
- **Sunken 404 badge** with `FileQuestion` icon
- **Two primary CTAs**: "Browse Docs" and "Go Home"
- **Popular sections grid**: 4 quick-access links to common doc areas
- **Smooth animations**: Framer Motion with reduced motion support
- **Responsive layout**: Mobile-first design with flexbox/grid

### Existing Integration
The `src/app/docs/[...slug]/page.tsx` already calls `notFound()` when a slug doesn't match any entry:
```tsx
if (!doc) notFound();
```

This means the new not-found page will automatically display for invalid doc routes.

## ✅ Acceptance Criteria

- [x] Created `src/app/docs/[...slug]/not-found.tsx` as docs-specific 404 page
- [x] Clear message that the doc page was not found
- [x] Link back to `/docs` (Browse Docs button)
- [x] Link to home page (`/` - Go Home button)
- [x] Display popular documentation sections (Getting Started, API, Architecture, Guides)
- [x] Design follows neumorphic design system from `docs/design/neumorphism.md`
- [x] Consistent with root `not-found.tsx` visual language
- [x] `notFound()` already called in `page.tsx` when slug doesn't match

## 🎨 Design Details

### Neumorphic Elements
- **Raised card**: `10px 10px 20px` dark shadow, `-10px -10px 20px` light highlight
- **Sunken badge**: `inset 8px 8px 16px` dark shadow, `inset -8px -8px 16px` light highlight
- **Quick links**: `4px 4px 8px` raised shadows for each section card
- **Border radius**: `rounded-3xl` (24px) for main card, `rounded-2xl` (16px) for badge, `rounded-xl` (12px) for links

### Color Palette
- **Primary**: `var(--color-primary)` (#149A9B teal)
- **Text Primary**: `var(--color-text-primary)` (#19213D)
- **Text Secondary**: `var(--color-text-secondary)` (#6D758F)
- **Background**: `var(--color-bg-base)` (#F1F3F7)
- **Shadows**: `var(--shadow-dark)` and `var(--shadow-light)`

### Animation
- **Floating effect**: Gentle Y-axis animation (0 → -8px → 0) over 4 seconds
- **Entrance**: Fade in + scale (0.95 → 1) over 0.5s
- **Reduced motion**: Respects `prefers-reduced-motion` user preference

## 🧪 Testing

### Manual Testing Steps
1. Navigate to a valid doc page (e.g., `/docs/getting-started`)
2. Navigate to an invalid doc path (e.g., `/docs/this-does-not-exist`)
3. Verify the docs-specific 404 page displays (not the root 404)
4. Click "Browse Docs" → should navigate to `/docs`
5. Click "Go Home" → should navigate to `/`
6. Click any popular section link → should navigate to that doc section
7. Test on mobile and desktop viewports
8. Verify animations are smooth (or disabled if reduced motion is preferred)

### Expected Behavior
- ✅ Docs-specific 404 displays for invalid `/docs/*` routes
- ✅ Root 404 still displays for other invalid routes (e.g., `/invalid-page`)
- ✅ All links navigate correctly
- ✅ Design matches neumorphic system
- ✅ Responsive on all screen sizes

## 📸 Visual Preview

The page features:
- **Top**: Sunken badge with `FileQuestion` icon and teal accent
- **Center**: Clear headline and helpful description
- **CTAs**: Two primary buttons (Browse Docs, Go Home)
- **Bottom**: Grid of 4 popular doc section cards
- **Overall**: Floating card with gentle animation

## 📋 Context

Referenced documentation:
- `src/app/not-found.tsx` – Visual reference for design consistency
- `docs/design/neumorphism.md` – Shadow physics and elevation states
- `docs/design/visual-dna.md` – Color palette and design tokens

## 🚀 Impact

This change improves the user experience when navigating documentation:
- **Better context**: Users know they're still in the docs section
- **Faster recovery**: Quick links help users find what they need
- **Professional polish**: Maintains design consistency throughout the app
- **Reduced frustration**: Clear guidance instead of generic 404

## 🔗 Related

- Root 404 page: `src/app/not-found.tsx` (unchanged)
- Docs page handler: `src/app/docs/[...slug]/page.tsx` (already calls `notFound()`)
- Docs layout: `src/app/docs/layout.tsx` (provides consistent shell)
