### PR TITLE
fix: Clarify escrow auto-release conditions in Terms of Service

### DIFF
--- a/docs/terms-and-conditions.md
+++ b/docs/terms-and-conditions.md
@@ -107,8 +107,18 @@ Violation of these prohibitions may result in immediate account termination, wit
 OFFER-HUB integrates with **Trustless Work** smart contracts on the **Stellar blockchain** to provide non-custodial escrow for transactions. When a Client engages a Freelancer:
 
 - The Client deposits funds into a smart contract escrow prior to work commencement.
-- Funds are released to the Freelancer upon Client approval of deliverables, or automatically under conditions defined in the smart contract.
+- Funds are released to the Freelancer upon Client approval of deliverables.
 - OFFER-HUB does not directly hold, control, or take custody of escrowed funds. The smart contract governs fund release.
+
+### 6.1.1 Auto-Release Conditions
+
+Escrowed funds may be released automatically under the following conditions:
+
+- **Deadline Passed:** If the project deadline passes without the Client raising a dispute or approving the deliverables, funds will auto-release to the Freelancer after a **default review period of 72 hours** from the delivery date. This timeout period may be configured differently per project and will be clearly stated in the project terms before funding.
+- **Milestone Approval:** For milestone-based projects, each milestone payment auto-releases when the Client approves that specific milestone, or when the milestone review period expires without dispute.
+- **Dispute Prevention:** If a dispute is raised before the auto-release window closes, the automatic release is suspended pending dispute resolution. Funds remain locked in escrow until the dispute is formally resolved by the platform.
+
+Users should carefully review the specific timeout periods and auto-release terms for each transaction before funding escrow. These terms are binding once funds are deposited into the smart contract.
 
 ### 6.2 Platform Fees
 

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -300,9 +300,34 @@ const sections: TermsSection[] = [
         type: "ul",
         items: [
           "The Client deposits funds into a smart contract escrow prior to work commencement.",
-          "Funds are released to the Freelancer upon Client approval of deliverables, or automatically under conditions defined in the smart contract.",
+          "Funds are released to the Freelancer upon Client approval of deliverables.",
           "OFFER-HUB does not directly hold, control, or take custody of escrowed funds. The smart contract governs fund release.",
         ],
+      },
+      { type: "h3", children: "6.1.1 Auto-Release Conditions" },
+      {
+        type: "p",
+        children: (
+          <>
+            Escrowed funds may be released automatically under the following conditions:
+          </>
+        ),
+      },
+      {
+        type: "ul",
+        items: [
+          <><strong>Deadline Passed:</strong> If the project deadline passes without the Client raising a dispute or approving the deliverables, funds will auto-release to the Freelancer after a <strong>default review period of 72 hours</strong> from the delivery date. This timeout period may be configured differently per project and will be clearly stated in the project terms before funding.</>,
+          <><strong>Milestone Approval:</strong> For milestone-based projects, each milestone payment auto-releases when the Client approves that specific milestone, or when the milestone review period expires without dispute.</>,
+          <><strong>Dispute Prevention:</strong> If a dispute is raised before the auto-release window closes, the automatic release is suspended pending dispute resolution. Funds remain locked in escrow until the dispute is formally resolved by the platform.</>,
+        ],
+      },
+      {
+        type: "p",
+        children: (
+          <>
+            Users should carefully review the specific timeout periods and auto-release terms for each transaction before funding escrow. These terms are binding once funds are deposited into the smart contract.
+          </>
+        ),
       },
       { type: "h3", children: "6.2 Platform Fees" },
       {


### PR DESCRIPTION
Updated src/app/terms/page.tsx and docs/terms-and-conditions.md to replace a vague auto-release statement with explicit conditions covering deadline-based release after a default 72-hour review period, milestone approval triggers, and dispute suspension of auto-release. A new Section 6.1.1 "Auto-Release Conditions" was added to both files with identical language to ensure legal consistency between the web page and documentation. Users are also informed that project-specific terms may override the default timeout. This addresses issue #1291 by giving users transparent, specific information about when and how escrow funds auto-release before they commit to funding.
Closed #1291 