### PR TITLE
#1286 fix: Set safe CORS default instead of wildcard fallback in next…

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,25 @@
 import type { NextConfig } from "next";
 
+// Validate CORS configuration at build time
+const getCorsOrigin = () => {
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL;
+
+  // In production, NEXT_PUBLIC_SITE_URL is required
+  if (process.env.NODE_ENV === "production") {
+    if (!siteUrl) {
+      throw new Error(
+        "NEXT_PUBLIC_SITE_URL is required in production environment. " +
+          "Please set it in your environment variables. " +
+          "Example: https://offer-hub.tech",
+      );
+    }
+    return siteUrl;
+  }
+
+  // In development, use localhost:3000 as default
+  return siteUrl || "http://localhost:3000";
+};
+
 const nextConfig: NextConfig = {
   async headers() {
     return [
@@ -9,7 +29,7 @@ const nextConfig: NextConfig = {
           { key: "Access-Control-Allow-Credentials", value: "true" },
           {
             key: "Access-Control-Allow-Origin",
-            value: process.env.NEXT_PUBLIC_SITE_URL || "*",
+            value: getCorsOrigin(),
           },
           {
             key: "Access-Control-Allow-Methods",


### PR DESCRIPTION
[#1286] Set safe CORS default instead of wildcard fallback in next.config.ts

🔒 Security Fix

Problem
The CORS configuration was using `process.env.NEXT_PUBLIC_SITE_URL || "*"` as a fallback. If the environment variable wasn't defined at deploy time, the server would accept cross-origin requests from **any domain**, creating a security vulnerability that allows unauthorized third-party sites to make credentialed requests to the API.

 Solution
- Removed the unsafe wildcard (`*`) fallback
- Added build-time validation that throws an error in production if `NEXT_PUBLIC_SITE_URL` is missing
- Implemented environment-aware defaults (localhost:3000 for development)

---

 📝 Changes

next.config.ts
- Added getCorsOrigin() function with proper validation logic
- Production: Throws build error if `NEXT_PUBLIC_SITE_URL` is not set
- Development: Falls back to `http://localhost:3000`
- CORS origin is now securely configured and incompatible with wildcard fallbacks

---

 ✅ Verification

| Scenario | Behavior | Status |
|----------|----------|--------|
| Dev (no env var) | Uses `http://localhost:3000` | ✅ Pass |
| Prod (no env var) | Build fails with clear error | ✅ Pass |
| Prod (with env var) | Uses configured origin | ✅ Pass |
| Custom origin | Respects `.env` value | ✅ Pass |

---

🚀 Impact
- Security: Eliminates cross-origin request vulnerability
- Build Safety: Production deployments fail fast without proper configuration
- Compatibility: Now compatible with `Access-Control-Allow-Credentials: true`

---

 📦 Pre-merge Checklist
- [x] Remove wildcard CORS fallback
- [x] Add build-time validation
- [x] Environment-specific defaults
- [x] `.env.example` has `NEXT_PUBLIC_SITE_URL` documented
- [x] All tests verified

Closes #1286 