### PR TITLE
fix: Update links in terms page to use relative paths

### DIFF
--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -806,12 +806,12 @@ const sections: TermsSection[] = [
           </>,
           <>
             <strong>Website:</strong>{" "}
-            <a
+            <Link
               href="/"
               className="font-bold text-theme-primary hover:text-content-primary"
             >
               https://offer-hub.tech
-            </a>
+            </Link>
           </>,
         ],
       },

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -466,7 +466,7 @@ const sections: TermsSection[] = [
           <>
             Your use of the Platform is also governed by our{" "}
             <Link
-              href="https://offer-hub.tech/privacy"
+              href="/privacy"
               className="font-bold text-theme-primary hover:text-content-primary underline underline-offset-2"
             >
               Privacy Policy
@@ -807,9 +807,7 @@ const sections: TermsSection[] = [
           <>
             <strong>Website:</strong>{" "}
             <a
-              href="https://offer-hub.tech"
-              target="_blank"
-              rel="noopener noreferrer"
+              href="/"
               className="font-bold text-theme-primary hover:text-content-primary"
             >
               https://offer-hub.tech


### PR DESCRIPTION
# 📝 Pull Request

## 🔧 Title:

- fix: Replace hardcoded absolute URLs with relative paths in Terms of Service page

## 🛠️ Issue

- Closes #1206

## 📚 Description

- This quick fix removes internal hardcoded absolute URLs from the Terms of Service page and replaces them with relative paths so links work correctly across production, staging, and local environments.

## ✅ Changes applied

- Updated `src/app/terms/page.tsx`:
  - Replaced `https://offer-hub.tech/privacy` with `/privacy`
  - Replaced `https://offer-hub.tech` with `/`
  - Removed `target="_blank"` and `rel="noopener noreferrer"` from the internal home link
- Searched `src/` for other `https://offer-hub.tech` references in anchor tags and confirmed no additional internal anchor links required conversion
- Kept external third-party links (GitHub, Telegram, docs, etc.) as absolute URLs
- Verified internal links in Terms and Privacy pages:
  - Terms now uses `/privacy` and `/`
  - Privacy page contains only `mailto:` links (no internal absolute URL anchors)

## 🔍 Evidence/Media (screenshots/videos)
- N/A (content-only legal page link update; no UI/design changes)
