### PR TITLE
docs: add CHANGELOG.md and update CONTRIBUTING.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+
+---
+
+## [0.1.0] - 2025-01-01
+
+### Added
+- Initial monorepo structure with npm Workspaces (`apps/api`, `apps/worker`, `packages/shared`, `packages/database`, `packages/sdk`)
+- NestJS API server with modular architecture (port 4000)
+- BullMQ async worker for background task processing
+- Prisma ORM with PostgreSQL — schema, migrations, and generated client
+- Internal user balance management (available and reserved balances)
+- Top-up flow via Airtm integration
+- Non-custodial escrow checkout via Trustless Work on the Stellar network
+- Withdrawal flow to Airtm accounts
+- Idempotency keys on all mutating endpoints
+- Audit log infrastructure
+- Redis-backed queue and cache layer
+- Docker Compose setup for local PostgreSQL and Redis
+- Next.js frontend with `/changelog` page that fetches releases dynamically from GitHub Releases API
+- Comprehensive documentation under `/docs` (architecture, API design, coding standards, contributing guide)
+
+[Unreleased]: https://github.com/OFFER-HUB/offer-hub-monorepo/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/OFFER-HUB/offer-hub-monorepo/releases/tag/v0.1.0

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -87,8 +87,9 @@ Before submitting a change, ensure you:
 1. Create a branch from `main`.
 2. Make your changes and use atomic commits.
 3. Ensure the project builds correctly (`npm run build`).
-4. Open a PR using our Pull Request template.
-5. Wait for a maintainer's review.
+4. **If your PR introduces a user-facing change** (new feature, bug fix, deprecation, breaking change, or security patch), add an entry to the `[Unreleased]` section of [`CHANGELOG.md`](../CHANGELOG.md) at the repository root. Follow the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format and place the change under the appropriate category: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, or `Security`.
+5. Open a PR using our Pull Request template.
+6. Wait for a maintainer's review.
 
 ## Roadmap & Tasks
 


### PR DESCRIPTION
Add static CHANGELOG.md and update contributing guide
  
  The project lacked a static CHANGELOG.md, making it harder for developers and
  open-source contributors to evaluate project maturity at a glance.
  
  Changes:
  
  - Added CHANGELOG.md at the repo root following the Keep a Changelog
  (https://keepachangelog.com/en/1.1.0/) convention with an [Unreleased] section
  and a backfilled [0.1.0] entry covering the initial release
  - Updated docs/CONTRIBUTING.md to instruct contributors to update [Unreleased]
   in CHANGELOG.md as part of any PR that introduces a user-facing change
  
  Notes:
  
  - The static CHANGELOG.md targets developers/contributors; the dynamic
  /changelog page remains unchanged for end users
  - Version numbers follow Semantic Versioning (https://semver.org/)
   closes #1295