### PR TITLE
- fix: Add focus trap and Escape key support to mobile navigation menu

### DIFF
--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
@@ -22,6 +22,66 @@ export function Navbar() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isScrolled, setIsScrolled] = useState(false);
   const pathname = usePathname();
+
+  const menuRef = useRef<HTMLDivElement>(null);
+  const toggleRef = useRef<HTMLButtonElement>(null);
+  const wasMenuOpen = useRef(false);
+
+  useEffect(() => {
+    if (isMenuOpen) {
+      wasMenuOpen.current = true;
+      const menuEl = menuRef.current;
+      if (!menuEl) return;
+
+      // Find all focusable elements within the mobile menu
+      const focusableSelectors = 'a[href], button:not([disabled]), [tabIndex]:not([tabIndex="-1"])';
+      const focusableElements = Array.from(
+        menuEl.querySelectorAll<HTMLElement>(focusableSelectors)
+      );
+
+      if (focusableElements.length > 0) {
+        // Focus the first element automatically
+        focusableElements[0].focus();
+      }
+
+      const handleKeyDown = (e: KeyboardEvent) => {
+        if (e.key === "Escape") {
+          setIsMenuOpen(false);
+          return;
+        }
+
+        if (e.key === "Tab") {
+          const firstEl = focusableElements[0];
+          const lastEl = focusableElements[focusableElements.length - 1];
+
+          if (!firstEl || !lastEl) return;
+
+          if (e.shiftKey) {
+            // Shift + Tab: wrap from first to last
+            if (document.activeElement === firstEl) {
+              lastEl.focus();
+              e.preventDefault();
+            }
+          } else {
+            // Tab: wrap from last to first
+            if (document.activeElement === lastEl) {
+              firstEl.focus();
+              e.preventDefault();
+            }
+          }
+        }
+      };
+
+      document.addEventListener("keydown", handleKeyDown);
+      return () => {
+        document.removeEventListener("keydown", handleKeyDown);
+      };
+    } else if (wasMenuOpen.current) {
+      // Only return focus if the menu was open and is now closing
+      toggleRef.current?.focus();
+      wasMenuOpen.current = false;
+    }
+  }, [isMenuOpen]);
 
   useEffect(() => {
     let ticking = false;
@@ -136,6 +196,7 @@ export function Navbar() {
 
             {/* ── Mobile hamburger ── */}
             <button
+              ref={toggleRef}
               onClick={() => setIsMenuOpen(!isMenuOpen)}
               className="lg:hidden p-2 rounded-full transition-all duration-300 ease-out bg-bg-base text-content-secondary shadow-neu-raised hover:shadow-neu-sunken-subtle"
               aria-label="Toggle menu"
@@ -150,13 +211,16 @@ export function Navbar() {
       {isMenuOpen && (
         <>
           {/* Backdrop */}
-          <div
-            className="lg:hidden fixed inset-0 z-[499] bg-black/20 dark:bg-black/40 backdrop-blur-sm animate-fadeIn"
+          <button
+            className="lg:hidden fixed inset-0 z-[499] bg-black/20 dark:bg-black/40 backdrop-blur-sm animate-fadeIn w-full h-full border-none p-0 cursor-default outline-none"
             onClick={() => setIsMenuOpen(false)}
+            aria-label="Close menu"
+            tabIndex={-1}
           />
 
           {/* Menu panel */}
           <div
+            ref={menuRef}
             className="lg:hidden fixed top-24 left-4 right-4 z-[501] p-6 rounded-3xl bg-bg-base shadow-neu-raised-scrolled animate-fadeInUp"
           >
             <div className="flex flex-col gap-2">


### PR DESCRIPTION
# 📝 Pull Request 

## 🔧 Title: 

- fix: Add focus trap and Escape key support to mobile navigation menu

## 🛠️ Issue

- Closes #1282

## 📚 Description

- This PR resolves keyboard accessibility issues (WCAG 2.1 - Success Criterion 2.1.1) in the mobile navigation menu within `Navbar.tsx`. Previously, keyboard users could tab out of the open mobile menu into hidden background content, there was no `Escape` key listener to close the menu overlay, and the backdrop was a non-interactive `div`.

## ✅ Changes applied

- **Focus Trap Implementation:** Added references (`useRef`) and document listeners to restrict keyboard tab navigation strictly within the mobile menu when it is open.
- **Smart Focus Management:**
  - Automatically shifts focus to the first interactive element ("Home") as soon as the menu opens.
  - Safely returns focus to the hamburger toggle button when the menu is closed, ensuring keyboard users never lose their position.
- **Escape Key Support:** Implemented a global keydown event listener to close the mobile menu overlay immediately upon pressing the `Escape` key.
- **Accessible Backdrop:** Replaced the non-semantic backdrop `div` with a semantic `<button>` containing `aria-label="Close menu"` and `tabIndex={-1}` to ensure native click/tap response without interrupting the keyboard tab flow.

## 🔍 Evidence/Media (screenshots/videos)


https://github.com/user-attachments/assets/ed4ad629-a0c6-4f3a-888b-fb647c321dbb


