### PR TITLE
Docs create security best practices

### DIFF
--- a/content/docs/guide/security.mdx
+++ b/content/docs/guide/security.mdx
@@ -1,0 +1,348 @@
+---
+title: Security Best Practices
+description: Concrete guidance for platform integrators on API key management, webhook validation, wallet security, escrow verification, and blockchain-specific attack mitigations.
+order: 9
+section: Guides
+---
+
+Integrating OFFER-HUB into your marketplace means handling real USDC transactions on a public blockchain. A misconfiguration can expose user funds or allow spoofed payment events to reach your system. This guide gives you concrete, OFFER-HUB-specific security practices — not generic web security advice.
+
+<Callout type="warning">
+  This guide focuses on threats specific to payment orchestration and blockchain escrow. Read it before going to production.
+</Callout>
+
+## API Key Management
+
+OFFER-HUB API keys follow the format `ohk_live_xxx` (production) and `ohk_test_xxx` (sandbox). A leaked live key gives full control over all payment operations — including releasing escrow funds and initiating withdrawals.
+
+### Store Keys in Environment Variables
+
+<Callout type="tip">
+  API keys must **never** appear in source code, client-side bundles, or version control. Use environment variables, and load them server-side only.
+</Callout>
+
+```bash
+# .env — never commit this file
+OFFER_HUB_API_KEY=ohk_live_abc123...
+OFFER_HUB_WEBHOOK_SECRET=whsec_xyz789...
+```
+
+```typescript
+// ✅ Read from the environment at runtime — server-side only
+const apiKey = process.env.OFFER_HUB_API_KEY;
+if (!apiKey) throw new Error('OFFER_HUB_API_KEY is not set');
+```
+
+```typescript
+// ❌ Never hardcode keys in source code
+const apiKey = 'ohk_live_abc123...'; // Will end up in git history
+
+// ❌ Never embed keys in client-side bundles
+const response = await fetch('/api/orders', {
+  headers: { Authorization: `Bearer ohk_live_abc123...` },
+});
+```
+
+### API Key Transport
+
+API keys must **only** travel server-to-server. Your marketplace backend calls OFFER-HUB; your frontend never does.
+
+```
+❌ Browser → OFFER-HUB API  (exposes key via DevTools)
+✅ Browser → Your Backend → OFFER-HUB API
+```
+
+### Rotation
+
+Rotate your API key:
+
+- **Immediately** if a team member with access leaves
+- **Immediately** if you suspect exposure (public repos, logs, error messages)
+- **Every 90 days** as routine practice in production
+
+### Scopes
+
+Use the minimum scope each service needs:
+
+| Service | Required Scope |
+|---------|----------------|
+| Read-only dashboard | `read` |
+| Order creation service | `write` |
+| Dispute resolution admin | `support` |
+
+---
+
+## Webhook Signature Validation
+
+OFFER-HUB signs every webhook payload with an HMAC-SHA256 signature. **Always validate this signature.** Without validation, any actor who knows your webhook URL can send spoofed events — such as a fake `escrow.released` — and trick your system into delivering services without payment.
+
+### Validation Implementation
+
+Each webhook request carries:
+
+```
+X-OfferHub-Signature: sha256=<hex_digest>
+```
+
+```typescript
+import { createHmac, timingSafeEqual } from 'crypto';
+
+function verifyWebhookSignature(
+  rawBody: Buffer,
+  signatureHeader: string,
+  secret: string,
+): boolean {
+  const expected = `sha256=${createHmac('sha256', secret)
+    .update(rawBody)
+    .digest('hex')}`;
+
+  try {
+    // Use timingSafeEqual to prevent timing attacks
+    return timingSafeEqual(Buffer.from(signatureHeader), Buffer.from(expected));
+  } catch {
+    return false; // Different lengths — always invalid
+  }
+}
+
+// Express example — use raw body parser
+app.post('/webhooks/offerhub', express.raw({ type: 'application/json' }), (req, res) => {
+  const sig = req.headers['x-offerhub-signature'] as string;
+
+  if (!verifyWebhookSignature(req.body, sig, process.env.OFFER_HUB_WEBHOOK_SECRET!)) {
+    return res.status(401).json({ error: 'Invalid signature' });
+  }
+
+  const event = JSON.parse(req.body.toString());
+  // Safe to process
+});
+```
+
+<Callout type="warning">
+  Parse the **raw body** before JSON.parse — the signature covers the raw bytes, not the parsed object. Using `express.json()` instead of `express.raw()` will always fail validation.
+</Callout>
+
+### Replay Attack Prevention
+
+A valid signature doesn't mean the event is fresh. Store processed event IDs in Redis to prevent duplicate processing:
+
+```typescript
+const FIVE_MINUTES_MS = 5 * 60 * 1000;
+
+async function processWebhook(event: any) {
+  // Check timestamp freshness
+  const age = Math.abs(Date.now() - new Date(event.timestamp).getTime());
+  if (age > FIVE_MINUTES_MS) throw new Error('Stale event rejected');
+
+  // Deduplicate using event ID
+  const key = `webhook:processed:${event.id}`;
+  const alreadyProcessed = await redis.exists(key);
+  if (alreadyProcessed) return { status: 'duplicate' };
+
+  await redis.setex(key, 3600, '1');
+  // Process the event
+}
+```
+
+---
+
+## Wallet Private Key Management
+
+OFFER-HUB manages Stellar invisible wallets for your users. Private keys are encrypted with AES-256-GCM at rest. As an integrator, you call the Orchestrator API — **you should never handle raw private keys directly.**
+
+### What the Orchestrator Handles
+
+- Generating Stellar keypairs per user
+- Encrypting and storing private keys (never in plaintext)
+- Decrypting keys **in memory only** during transaction signing
+- Zeroing the in-memory key immediately after signing
+
+### Rules You Must Follow
+
+```typescript
+// ❌ Never log objects that may contain key fields
+console.log('Wallet:', wallet); // Strip sensitive fields first
+
+// ❌ Never send private keys to clients
+res.json({ secretKey: wallet.secretKey }); // Never
+
+// ❌ Never store unencrypted keys
+await db.users.update({ stellarSecretKey: rawKey }); // Must be encrypted
+```
+
+### If You Self-Host the Orchestrator
+
+The encryption key protecting all wallet private keys must be treated as your most sensitive secret:
+
+```bash
+# Generate with high entropy — never a human-readable string
+WALLET_ENCRYPTION_KEY=$(openssl rand -hex 32)
+```
+
+- Store it in an HSM or managed secrets service (AWS Secrets Manager, HashiCorp Vault)
+- **Never** store it in your codebase, `.env` files in version control, or database
+- Back it up securely — losing this key means losing access to all user wallets permanently
+
+<Callout type="note">
+  The platform wallet (used to sign dispute resolutions) is the most sensitive key in the system. Consider an HSM like AWS CloudHSM or Azure Dedicated HSM for production deployments.
+</Callout>
+
+---
+
+## Escrow Integration Security
+
+The escrow flow is the highest-risk operation in OFFER-HUB. A bug here can result in funds being released to the wrong party or funds being permanently locked.
+
+### Verify State Before Releasing Funds
+
+Always verify order and escrow state from the API before triggering a resolution. Never rely solely on a webhook event.
+
+```typescript
+async function releaseEscrow(orderId: string, requestedBy: string) {
+  const order = await offerHubClient.orders.get(orderId);
+
+  if (order.status !== 'IN_PROGRESS') {
+    throw new Error(`Cannot release order in state: ${order.status}`);
+  }
+  if (order.buyerId !== requestedBy) {
+    throw new Error('Only the buyer can release escrow funds');
+  }
+  if (!order.escrow || order.escrow.status !== 'FUNDED') {
+    throw new Error('Escrow is not in FUNDED state');
+  }
+
+  return offerHubClient.orders.release(orderId, { requestedBy });
+}
+```
+
+### Verification Checklist
+
+Before calling `POST /orders/:id/resolution/release`:
+
+| Check | Why |
+|-------|-----|
+| Order status is `IN_PROGRESS` | Prevents double-release |
+| Requester is the buyer | Only the buyer approves delivery |
+| Escrow status is `FUNDED` | Prevents acting on unfunded escrow |
+| Work delivery evidence exists | App-level check: ensure work was submitted |
+| No open dispute exists | Cannot release during active dispute |
+
+### Use Idempotency Keys
+
+Protect against double-releases caused by network retries:
+
+```typescript
+// Key must be deterministic per operation — not random per retry
+const idempotencyKey = `release:${orderId}:${buyerId}`;
+
+await offerHubClient.orders.release(orderId, {
+  requestedBy: buyerId,
+  idempotencyKey,
+});
+```
+
+---
+
+## Security Headers and CSP
+
+Configure HTTP security headers to protect your users from XSS attacks that could intercept payment flows.
+
+### Next.js Configuration
+
+```javascript
+// next.config.js
+const securityHeaders = [
+  { key: 'Strict-Transport-Security', value: 'max-age=63072000; includeSubDomains; preload' },
+  { key: 'X-Frame-Options', value: 'SAMEORIGIN' },
+  { key: 'X-Content-Type-Options', value: 'nosniff' },
+  { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+  { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
+];
+
+module.exports = {
+  async headers() {
+    return [{ source: '/(.*)', headers: securityHeaders }];
+  },
+};
+```
+
+### Content Security Policy
+
+A strict CSP prevents injected scripts from stealing session tokens or intercepting payment data:
+
+```
+Content-Security-Policy:
+  default-src 'self';
+  script-src 'self' 'nonce-{NONCE}';
+  connect-src 'self' https://your-orchestrator.example.com;
+  frame-ancestors 'none';
+  upgrade-insecure-requests;
+```
+
+<Callout type="warning">
+  Never use `script-src 'unsafe-inline'` or `connect-src *` in a payment context. Restrict `connect-src` to your Orchestrator's exact domain only.
+</Callout>
+
+---
+
+## Blockchain-Specific Attack Vectors
+
+### Replay Attacks
+
+**Risk:** A signed Stellar transaction is resubmitted to process the same payment twice.
+
+**Mitigation by OFFER-HUB:** Stellar transactions include a sequence number — each transaction can only be processed once. Replaying it returns `tx_bad_seq`.
+
+**Your responsibility:** Use idempotency keys on all API calls. If a release succeeds but the network drops before you receive the response, retry with the same idempotency key to get the cached result instead of a second release.
+
+### Front-Running
+
+**Risk:** An attacker submits a competing transaction before yours to manipulate fund flow.
+
+**Relevance:** Stellar uses a FIFO queue within each ledger cycle, not fee-priority auctions like Ethereum. Traditional front-running does not apply.
+
+**Residual risk:** Enforce strict RBAC on your Orchestrator deployment and enable database audit logging to prevent internal actors from triggering unauthorized releases.
+
+### Balance Desynchronization
+
+**Risk:** OFFER-HUB's off-chain balance (PostgreSQL) diverges from the on-chain USDC balance (Stellar ledger).
+
+**How to detect it:**
+
+```typescript
+async function reconcileBalance(userId: string) {
+  const offChain = await offerHubClient.balances.get(userId);
+  const account = await stellarServer.loadAccount(wallet.publicKey);
+  const usdcBalance = account.balances.find(b => b.asset_code === 'USDC');
+
+  const delta = Math.abs(
+    parseFloat(usdcBalance?.balance ?? '0') - parseFloat(offChain.available)
+  );
+
+  if (delta > 0.001) {
+    // Alert: investigate before processing further transactions
+    alertOpsTeam({ userId, offChain: offChain.available, onChain: usdcBalance?.balance });
+  }
+}
+```
+
+### Phishing via Fake Deposit Addresses
+
+**Risk:** An attacker substitutes a legitimate deposit address with their own Stellar address.
+
+```typescript
+// ✅ Always fetch deposit addresses from the API — never from user-supplied input
+const { data } = await offerHubClient.wallet.getDepositAddress(userId);
+displayAddress(data.address);
+
+// ❌ Never trust an address from the request body
+const depositAddress = req.body.depositAddress; // Attacker-controlled
+```
+
+---
+
+## Next Steps
+
+- [Escrow Guide](/docs/guide/escrow) — Smart contract escrow mechanics
+- [Webhooks Reference](/docs/api-reference/webhooks) — Payload formats and headers
+- [Self-Hosting Guide](/docs/guide/self-hosting) — Secure production deployment
+- [API Reference](/docs/api-reference/overview) — Authentication and rate limiting

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,6 +46,7 @@ OFFER-HUB documentation is organized in two locations:
 - [Events Reference](./guides/events-reference.md) - SSE and webhook events
 - [Errors & Troubleshooting](./guides/errors-troubleshooting.md) - Error codes and solutions
 - [Marketplace Integration](./guides/marketplace-integration.md) - Integration patterns
+- [Security Best Practices](./guides/security.md) - API keys, webhooks, wallet security, and blockchain-specific threats
 - [Deployment](./guides/deployment.md) - Production deployment
 - [Scaling & Customization](./guides/scaling-customization.md) - Advanced configuration
 - [AirTM Integration](./guides/airtm.md) - AirTM payment provider

--- a/docs/guides/security.md
+++ b/docs/guides/security.md
@@ -1,0 +1,518 @@
+# Security Best Practices for Platform Integrators
+
+> Concrete guidance for developers integrating OFFER-HUB into their own marketplaces — covering API key management, webhook validation, wallet security, escrow verification, and blockchain-specific attack mitigations.
+
+---
+
+## Table of Contents
+
+- [API Key Management](#api-key-management)
+- [Webhook Signature Validation](#webhook-signature-validation)
+- [Wallet Private Key Management](#wallet-private-key-management)
+- [Escrow Integration Security](#escrow-integration-security)
+- [Security Headers and CSP](#security-headers-and-csp)
+- [Blockchain-Specific Attack Vectors](#blockchain-specific-attack-vectors)
+
+---
+
+## API Key Management
+
+OFFER-HUB API keys follow the format `ohk_live_xxx` (production) and `ohk_test_xxx` (sandbox). A leaked live key gives full control over all payment operations, including releasing escrow funds and initiating withdrawals.
+
+### Storage
+
+✅ **DO:**
+
+```bash
+# Store keys in environment variables — never hardcoded
+OFFER_HUB_API_KEY=ohk_live_abc123...
+```
+
+```typescript
+// Read from the environment at runtime
+const apiKey = process.env.OFFER_HUB_API_KEY;
+if (!apiKey) throw new Error('OFFER_HUB_API_KEY is not set');
+```
+
+❌ **DON'T:**
+
+```typescript
+// Never hardcode keys in source code
+const apiKey = 'ohk_live_abc123...'; // ❌ Will end up in git history
+
+// Never embed keys in client-side bundles
+const response = await fetch('/api/orders', {
+  headers: { Authorization: `Bearer ohk_live_abc123...` }, // ❌
+});
+```
+
+```json
+// Never commit keys to version control
+// .env.example — show structure only, no real values
+{
+  "OFFER_HUB_API_KEY": "ohk_live_REPLACE_ME"
+}
+```
+
+### Key Rotation
+
+API keys should be rotated:
+
+- Immediately if any team member with access leaves
+- Immediately if you suspect a key has been exposed (logs, error messages, public repos)
+- Every 90 days as a routine practice in production
+
+**Rotation procedure:**
+
+1. Generate a new key in the Orchestrator admin
+2. Deploy the new key to all services using secret manager tooling (e.g., AWS Secrets Manager, HashiCorp Vault)
+3. Verify all services are using the new key
+4. Revoke the old key
+
+### Scopes
+
+Use the minimum scope necessary for each integration point:
+
+| Service | Required Scope |
+|---------|----------------|
+| Read-only dashboard | `read` |
+| Order creation service | `write` |
+| Dispute resolution admin | `support` |
+
+Never use a `write` or `support` scoped key from a context that only needs `read`.
+
+### API Key Transport
+
+API keys must **only** travel server-to-server. Your marketplace backend calls OFFER-HUB; your frontend never does.
+
+```
+❌ Browser → OFFER-HUB API (exposes key to any user with DevTools)
+✅ Browser → Your Backend → OFFER-HUB API
+```
+
+---
+
+## Webhook Signature Validation
+
+OFFER-HUB signs every webhook payload with an HMAC-SHA256 signature using a secret you configure. **Always validate this signature.** Without validation, any actor who knows your webhook URL can send spoofed events — such as a fake `escrow.released` event — and trick your system into delivering services without payment.
+
+### How Signatures Work
+
+Each webhook request includes the header:
+
+```
+X-OfferHub-Signature: sha256=<hex_digest>
+```
+
+The digest is computed as:
+
+```
+HMAC-SHA256(secret, raw_request_body)
+```
+
+### Validation Implementation
+
+```typescript
+import { createHmac, timingSafeEqual } from 'crypto';
+
+function verifyWebhookSignature(
+  rawBody: Buffer,
+  signatureHeader: string,
+  secret: string,
+): boolean {
+  const expected = createHmac('sha256', secret)
+    .update(rawBody)
+    .digest('hex');
+
+  const expectedHeader = `sha256=${expected}`;
+
+  // Use timingSafeEqual to prevent timing attacks
+  try {
+    return timingSafeEqual(
+      Buffer.from(signatureHeader),
+      Buffer.from(expectedHeader),
+    );
+  } catch {
+    // Buffers of different lengths throw — treat as invalid
+    return false;
+  }
+}
+
+// Express middleware example
+app.post('/webhooks/offerhub', express.raw({ type: 'application/json' }), (req, res) => {
+  const signature = req.headers['x-offerhub-signature'] as string;
+
+  if (!verifyWebhookSignature(req.body, signature, process.env.WEBHOOK_SECRET!)) {
+    return res.status(401).json({ error: 'Invalid signature' });
+  }
+
+  const event = JSON.parse(req.body.toString());
+  // Safe to process
+});
+```
+
+### Critical Rules
+
+✅ **DO:**
+
+- Parse the raw body **before** JSON.parse — the signature is over the raw bytes
+- Use `timingSafeEqual` — standard `===` is vulnerable to timing attacks
+- Return `401` immediately on invalid signatures — do not log the payload
+- Rotate the webhook secret if it may have been exposed
+
+❌ **DON'T:**
+
+```typescript
+// Don't validate the parsed JSON body — the signature is over raw bytes
+const parsedBody = JSON.parse(req.body); // ❌ Sign the raw body, not this
+```
+
+```typescript
+// Don't trust the event type without validating the signature first
+if (event.type === 'escrow.released') {
+  releaseOrder(event.data.orderId); // ❌ Validate signature first
+}
+```
+
+```typescript
+// Don't use string equality — vulnerable to timing attacks
+if (signature === expected) { ... } // ❌ Use timingSafeEqual
+```
+
+### Replay Attack Prevention
+
+A valid signature doesn't mean the event is fresh. Add a timestamp check:
+
+```typescript
+const FIVE_MINUTES_MS = 5 * 60 * 1000;
+
+function isTimestampFresh(event: any): boolean {
+  const eventTime = new Date(event.timestamp).getTime();
+  return Math.abs(Date.now() - eventTime) < FIVE_MINUTES_MS;
+}
+```
+
+Track processed event IDs in Redis to prevent duplicate processing:
+
+```typescript
+const alreadyProcessed = await redis.exists(`webhook:processed:${event.id}`);
+if (alreadyProcessed) return res.status(200).json({ status: 'duplicate' });
+
+await redis.setex(`webhook:processed:${event.id}`, 3600, '1');
+```
+
+---
+
+## Wallet Private Key Management
+
+OFFER-HUB manages Stellar invisible wallets for your users. Private keys are encrypted at rest with AES-256-GCM. As a platform integrator, you interact with the Orchestrator's API — you should **never** handle raw private keys directly.
+
+### What the Orchestrator Handles
+
+- Generating Stellar keypairs for each user
+- Encrypting and storing private keys (never in plaintext)
+- Decrypting keys **in memory only** during transaction signing
+- Immediately zeroing the in-memory key after signing
+
+### What You Must Never Do
+
+❌ **Never log private keys or mnemonic phrases:**
+
+```typescript
+// ❌ Never do this — private keys in logs are catastrophic
+console.log('User wallet:', { secretKey: user.stellarSecretKey });
+logger.info({ user }); // ❌ If user object contains key fields, strip them first
+```
+
+❌ **Never transmit private keys:**
+
+```typescript
+// ❌ Never send private keys to clients, even over HTTPS
+res.json({ wallet: { address: wallet.publicKey, secretKey: wallet.secretKey } });
+```
+
+❌ **Never store unencrypted keys:**
+
+```typescript
+// ❌ Never store raw secret keys in your database
+await db.users.update({ stellarSecretKey: rawKey }); // Must be encrypted
+```
+
+### If You Deploy Your Own Orchestrator Instance
+
+If you self-host OFFER-HUB, you are responsible for the encryption key used to protect wallet private keys:
+
+```bash
+# Must be a high-entropy random value — never a human-readable string
+WALLET_ENCRYPTION_KEY=$(openssl rand -hex 32)
+```
+
+- Store this key in a hardware security module (HSM) or secrets manager — never in your codebase or version control
+- Rotating the encryption key requires re-encrypting all stored wallets — plan migrations carefully
+- Back up the key securely — if lost, all user wallets are permanently inaccessible
+
+### Hardware Wallet Recommendations
+
+For the Orchestrator's platform wallet (used to sign dispute resolutions), consider using a hardware wallet integration:
+
+- The platform wallet signs dispute resolution transactions — it is the most sensitive key in the system
+- Use a hardware security module (HSM) like AWS CloudHSM or Azure Dedicated HSM for production
+- At minimum, store the platform private key in a managed secrets service with audit logging
+
+---
+
+## Escrow Integration Security
+
+The escrow flow is the highest-risk operation in OFFER-HUB. A bug here can result in funds being released to the wrong party or funds being permanently locked.
+
+### Verify State Before Acting
+
+Always verify the escrow and order state via the API before triggering a resolution. Never rely solely on a webhook event to determine whether a release is safe.
+
+```typescript
+// ✅ Always double-check state before releasing
+async function releaseEscrow(orderId: string, requestedBy: string) {
+  const order = await offerHubClient.orders.get(orderId);
+
+  // Verify the order is in a releasable state
+  if (order.status !== 'IN_PROGRESS') {
+    throw new Error(`Cannot release order in state: ${order.status}`);
+  }
+
+  // Verify the requester is the buyer
+  if (order.buyerId !== requestedBy) {
+    throw new Error('Only the buyer can release escrow funds');
+  }
+
+  // Verify escrow is funded on-chain before releasing
+  if (!order.escrow || order.escrow.status !== 'FUNDED') {
+    throw new Error('Escrow is not in FUNDED state');
+  }
+
+  return offerHubClient.orders.release(orderId, { requestedBy });
+}
+```
+
+### What to Verify Before Releasing Funds
+
+Before calling `POST /orders/:id/resolution/release`, confirm:
+
+| Check | Why |
+|-------|-----|
+| Order status is `IN_PROGRESS` | Prevents releasing an already-released or refunded order |
+| Requester is the buyer | Only the buyer can approve work delivery |
+| Escrow status is `FUNDED` | Prevents releasing unfunded escrow (would fail on-chain anyway) |
+| Delivery evidence exists | Application-level check: ensure work was actually submitted |
+| No open dispute exists | Prevents releasing while a dispute is active |
+
+### Idempotency Keys
+
+All state-changing operations must use idempotency keys to prevent double-releases caused by network retries:
+
+```typescript
+const idempotencyKey = `release-${orderId}-${requestedBy}-${Date.now()}`;
+
+await offerHubClient.orders.release(orderId, {
+  requestedBy,
+  idempotencyKey,
+});
+```
+
+Store the idempotency key and its result so retries return the cached response rather than executing twice.
+
+### Cross-Checking with the Stellar Ledger
+
+For high-value orders, cross-check the escrow contract state directly on the Stellar blockchain before releasing:
+
+```typescript
+import { Horizon } from '@stellar/stellar-sdk';
+
+const server = new Horizon.Server('https://horizon.stellar.org');
+
+// Verify the contract holds the expected amount before releasing
+async function verifyEscrowOnChain(contractId: string, expectedAmount: string) {
+  // Query the Trustless Work contract state
+  // Compare against OFFER-HUB's reported escrow amount
+  // Alert if there is a mismatch — indicates possible data inconsistency
+}
+```
+
+---
+
+## Security Headers and CSP
+
+If you are building a web frontend on top of OFFER-HUB, configure security headers to protect your users.
+
+### Recommended HTTP Security Headers
+
+```typescript
+// Next.js — next.config.js
+const securityHeaders = [
+  {
+    key: 'X-DNS-Prefetch-Control',
+    value: 'on',
+  },
+  {
+    key: 'Strict-Transport-Security',
+    value: 'max-age=63072000; includeSubDomains; preload',
+  },
+  {
+    key: 'X-Frame-Options',
+    value: 'SAMEORIGIN',
+  },
+  {
+    key: 'X-Content-Type-Options',
+    value: 'nosniff',
+  },
+  {
+    key: 'Referrer-Policy',
+    value: 'strict-origin-when-cross-origin',
+  },
+  {
+    key: 'Permissions-Policy',
+    value: 'camera=(), microphone=(), geolocation=()',
+  },
+];
+
+module.exports = {
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: securityHeaders,
+      },
+    ];
+  },
+};
+```
+
+### Content Security Policy
+
+A strict CSP prevents XSS attacks from injecting malicious scripts that could steal API keys from localStorage or intercept payment flows.
+
+```typescript
+const cspHeader = `
+  default-src 'self';
+  script-src 'self' 'nonce-{NONCE}';
+  style-src 'self' 'nonce-{NONCE}';
+  img-src 'self' data: https:;
+  connect-src 'self' https://your-orchestrator.example.com;
+  font-src 'self';
+  object-src 'none';
+  base-uri 'self';
+  form-action 'self';
+  frame-ancestors 'none';
+  upgrade-insecure-requests;
+`.replace(/\s{2,}/g, ' ').trim();
+```
+
+✅ **DO:**
+
+- Use nonces instead of `'unsafe-inline'` for inline scripts
+- Restrict `connect-src` to only your Orchestrator's domain — not `*`
+- Set `frame-ancestors 'none'` to prevent clickjacking on payment flows
+- Enable `upgrade-insecure-requests` to force HTTPS
+
+❌ **DON'T:**
+
+```
+// Never use these in production
+Content-Security-Policy: script-src 'unsafe-inline' 'unsafe-eval' *
+```
+
+### CORS on Your Proxy Backend
+
+Your marketplace backend proxies calls to OFFER-HUB. Configure CORS restrictively:
+
+```typescript
+// Only allow requests from your own frontend domain
+app.use(cors({
+  origin: ['https://your-marketplace.com'],
+  methods: ['GET', 'POST', 'PUT'],
+  allowedHeaders: ['Content-Type', 'Authorization'],
+  credentials: true,
+}));
+```
+
+---
+
+## Blockchain-Specific Attack Vectors
+
+OFFER-HUB operates on the Stellar blockchain and uses Soroban smart contracts for escrow. Understand these attack vectors specific to blockchain payment orchestration.
+
+### Replay Attacks
+
+**What it is:** A signed Stellar transaction is intercepted and resubmitted to process the same payment twice.
+
+**How OFFER-HUB mitigates it:** Stellar transactions include a sequence number tied to the source account. A transaction can only be processed once — replaying it will fail with `tx_bad_seq`.
+
+**What you must do:** Use idempotency keys on all OFFER-HUB API calls. If a release call succeeds but your network connection drops before you receive the response, retrying with the same idempotency key returns the original result instead of triggering a second release.
+
+```typescript
+// Idempotency key must be deterministic per operation — not random per retry
+const key = `release:${orderId}:${buyerId}`;
+```
+
+### Front-Running
+
+**What it is:** An attacker monitors a pending transaction and submits a competing transaction with a higher fee to be processed first.
+
+**Relevance to OFFER-HUB:** Stellar uses a FIFO queue within each ledger cycle, not a fee-priority auction like Ethereum. Front-running in the Ethereum sense is not applicable.
+
+**Residual risk:** A malicious actor with Orchestrator database access could attempt to trigger a release before the buyer approves. Mitigation: enforce strict role-based access control on your Orchestrator deployment and enable database audit logging.
+
+### Reentrancy (Soroban Contracts)
+
+**What it is:** A contract function calls an external contract, which calls back into the original function before it finishes — leading to double-spending.
+
+**Relevance to OFFER-HUB:** Trustless Work's Soroban contracts are designed to prevent reentrancy. The Orchestrator never calls back into itself during a transaction signing sequence.
+
+**What you must do:** Do not build custom Soroban contract logic that interacts with the OFFER-HUB escrow contracts unless you have conducted a formal security audit of the reentrancy surface.
+
+### Balance Desynchronization
+
+**What it is:** OFFER-HUB's off-chain balance (PostgreSQL) diverges from the on-chain USDC balance (Stellar ledger). This can happen if a blockchain transaction is submitted but the database update fails, or vice versa.
+
+**How to detect it:**
+
+```typescript
+// Periodically reconcile your critical accounts
+async function reconcileBalance(userId: string) {
+  const offChainBalance = await offerHubClient.balances.get(userId);
+  const onChainBalance = await stellarHorizon.loadAccount(wallet.publicKey);
+
+  const usdc = onChainBalance.balances.find(b => b.asset_code === 'USDC');
+
+  if (Math.abs(parseFloat(usdc?.balance ?? '0') - parseFloat(offChainBalance.available)) > 0.001) {
+    // Alert: balance mismatch — investigate before processing further transactions
+    alertOpsTeam({ userId, offChain: offChainBalance.available, onChain: usdc?.balance });
+  }
+}
+```
+
+### Phishing via Fake Deposit Addresses
+
+**What it is:** An attacker substitutes a legitimate deposit address with their own Stellar address, redirecting user deposits to themselves.
+
+**Mitigation:** Always fetch the deposit address fresh from the Orchestrator API. Never cache it in a place users can influence.
+
+```typescript
+// ✅ Always fetch from the API — never from user-supplied input
+const { data } = await offerHubClient.wallet.getDepositAddress(userId);
+showToUser(data.address);
+```
+
+```typescript
+// ❌ Never trust a deposit address from the request body
+const depositAddress = req.body.depositAddress; // ❌ Attacker-controlled
+```
+
+---
+
+## Related Documentation
+
+- [API Contract](../standards/api-contract.md) — API response structure and error codes
+- [Escrow Guide](./escrow.md) — Smart contract escrow mechanics
+- [Wallets Guide](./wallets.md) — Invisible Stellar wallet system
+- [Events Reference](./events-reference.md) — Webhook events and SSE
+- [Errors & Troubleshooting](./errors-troubleshooting.md) — Error codes and debugging

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -2,7 +2,7 @@
 
 import { useRef, useEffect } from "react";
 import DocsSearchBar from "@/components/docs/DocsSearchBar";
-import { Book, Code, Shield, LifeBuoy, Terminal, Zap, ChevronRight } from "lucide-react";
+import { Book, Code, Shield, LifeBuoy, Terminal, Zap, ChevronRight, Lock } from "lucide-react";
 import Link from "next/link";
 import { cn } from "@/lib/cn";
 
@@ -55,6 +55,13 @@ const docSections = [
     description: "Deploy OFFER-HUB on your own infrastructure with Docker and configure it.",
     link: "/docs/guide/self-hosting",
     count: "2 articles"
+  },
+  {
+    icon: <Lock />,
+    title: "Security Best Practices",
+    description: "API key management, webhook validation, wallet key security, and blockchain-specific attack mitigations.",
+    link: "/docs/guide/security",
+    count: "1 guide"
   }
 ];
 


### PR DESCRIPTION
## Related Issue

Closes #1293

---

## 🔖 Title

docs: Create security best practices guide for platform integrators

---

## 📝 Description

The `/docs` folder had no security guide. Developers integrating OFFER-HUB into their own marketplaces had no documented guidance on how to handle API keys, validate webhooks, protect wallet private keys, or securely implement the escrow flow.

This PR adds a comprehensive, OFFER-HUB-specific security guide focused on threats relevant to payment orchestration and blockchain escrow — not generic web security advice.

---

## 🔄 Changes Made

- **`docs/guides/security.md`** — New internal security guide for platform integrators covering:
  - API key storage, transport, rotation, and scopes
  - Webhook signature validation with `timingSafeEqual` and replay attack prevention
  - Wallet private key management rules and HSM recommendations
  - Escrow integration security checklist and state verification before releasing funds
  - Security headers and Content Security Policy (CSP) for apps built on OFFER-HUB
  - Blockchain-specific attack vectors: replay attacks, front-running, balance desynchronization, and phishing via fake deposit addresses

- **`content/docs/guide/security.mdx`** — Public-facing MDX version of the guide rendered at `/docs/guide/security`, with proper frontmatter (`title`, `description`, `order: 9`, `section: Guides`) and MDX `<Callout>` components for warnings and tips

- **`docs/README.md`** — Added link to the new security guide under the **Guides (Internal)** section

- **`src/app/docs/page.tsx`** — Added a **Security Best Practices** card with a `Lock` icon to the docs hub page, linking to `/docs/guide/security`

---

## 📈 Testing

### 📈 Test Output

- Verified `content/docs/guide/security.mdx` frontmatter is valid and follows the same structure as existing guides (e.g., `order`, `section`, `title`, `description`)
- Verified the new guide appears in the sidebar navigation (driven by `getSidebarNav()` in `src/lib/mdx.ts` which reads all `.mdx` files under `content/docs/`)
- Verified the Security card appears on the `/docs` hub page alongside existing cards
- Verified all internal links in `docs/guides/security.md` resolve to existing files
- Verified the `Lock` icon import from `lucide-react` is available in the existing version used by the project

### Coverage Output

This PR adds only documentation and a UI link — no business logic, no new API routes, no database changes. No unit tests are required.

---

## 📸 Video

 Run the dev server with `npm run dev` and navigate to:
 - http://localhost:3000/docs         → Security Best Practices card visible in hub
 - http://localhost:3000/docs/guide/security → Full security guide rendered


https://github.com/user-attachments/assets/11e85d4c-6597-40f3-8ab4-94fa0c5c409e

