### PR TITLE
Fix add http security headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 
+- Add HTTP security headers (CSP, HSTS, X-Frame-Options, and related) via `next.config.ts` for all routes
+
 ---
 
 ## [0.1.0] - 2025-01-01

--- a/config/security-headers.ts
+++ b/config/security-headers.ts
@@ -1,0 +1,81 @@
+type Header = { key: string; value: string };
+
+const isProduction = process.env.NODE_ENV === "production";
+
+function parseOrigin(value: string | undefined): string | null {
+  if (!value?.trim()) return null;
+  try {
+    return new URL(value.trim()).origin;
+  } catch {
+    return null;
+  }
+}
+
+function uniqueOrigins(origins: (string | null | undefined)[]): string[] {
+  return [...new Set(origins.filter((o): o is string => Boolean(o)))];
+}
+
+/**
+ * Builds a pragmatic CSP for Next.js App Router:
+ * - Blocks third-party scripts (script-src 'self')
+ * - Allows inline scripts/styles required by Next.js hydration and React
+ */
+export function buildContentSecurityPolicy(): string {
+  const connectOrigins = uniqueOrigins([
+    parseOrigin(process.env.NEXT_PUBLIC_SUPABASE_URL),
+    parseOrigin(process.env.NEXT_PUBLIC_API_BASE_URL),
+    parseOrigin(process.env.NEXT_PUBLIC_API_URL),
+    parseOrigin(process.env.NEXT_PUBLIC_SITE_URL),
+    "https://*.supabase.co",
+    "https://ipapi.co",
+    "https://api.github.com",
+  ]);
+
+  const directives = [
+    "default-src 'self'",
+    `script-src 'self' 'unsafe-inline'${isProduction ? "" : " 'unsafe-eval'"}`,
+    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+    "img-src 'self' data: blob: https://avatars.githubusercontent.com",
+    "font-src 'self' https://fonts.gstatic.com",
+    `connect-src 'self' ${connectOrigins.join(" ")}`.trim(),
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'self'",
+  ];
+
+  if (isProduction) {
+    directives.push("upgrade-insecure-requests");
+  }
+
+  return directives.join("; ");
+}
+
+export function getSecurityHeaders(): Header[] {
+  const cspHeaderName = isProduction
+    ? "Content-Security-Policy"
+    : "Content-Security-Policy-Report-Only";
+
+  const headers: Header[] = [
+    { key: "X-Frame-Options", value: "SAMEORIGIN" },
+    { key: "X-Content-Type-Options", value: "nosniff" },
+    {
+      key: "Referrer-Policy",
+      value: "strict-origin-when-cross-origin",
+    },
+    {
+      key: "Permissions-Policy",
+      value: "camera=(), microphone=(), geolocation=()",
+    },
+    { key: cspHeaderName, value: buildContentSecurityPolicy() },
+  ];
+
+  if (isProduction) {
+    headers.push({
+      key: "Strict-Transport-Security",
+      value: "max-age=63072000; includeSubDomains; preload",
+    });
+  }
+
+  return headers;
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,26 +1,35 @@
 import type { NextConfig } from "next";
+import { getSecurityHeaders } from "./config/security-headers";
+
+const corsHeaders = [
+  { key: "Access-Control-Allow-Credentials", value: "true" },
+  {
+    key: "Access-Control-Allow-Origin",
+    value: process.env.NEXT_PUBLIC_SITE_URL || "*",
+  },
+  {
+    key: "Access-Control-Allow-Methods",
+    value: "GET,DELETE,PATCH,POST,PUT,OPTIONS",
+  },
+  {
+    key: "Access-Control-Allow-Headers",
+    value:
+      "X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version, Authorization",
+  },
+];
 
 const nextConfig: NextConfig = {
   async headers() {
+    const securityHeaders = getSecurityHeaders();
+
     return [
       {
+        source: "/(.*)",
+        headers: securityHeaders,
+      },
+      {
         source: "/api/:path*",
-        headers: [
-          { key: "Access-Control-Allow-Credentials", value: "true" },
-          {
-            key: "Access-Control-Allow-Origin",
-            value: process.env.NEXT_PUBLIC_SITE_URL || "*",
-          },
-          {
-            key: "Access-Control-Allow-Methods",
-            value: "GET,DELETE,PATCH,POST,PUT,OPTIONS",
-          },
-          {
-            key: "Access-Control-Allow-Headers",
-            value:
-              "X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version, Authorization",
-          },
-        ],
+        headers: [...securityHeaders, ...corsHeaders],
       },
     ];
   },


### PR DESCRIPTION
# 📝 Pull Request

## 🔧 Title:

fix: Add HTTP security headers to next.config.ts

## 🛠️ Issue

- Closes #1285

## 📚 Description

Adds baseline HTTP security headers to all Next.js routes via `headers()` in `next.config.ts`. A shared module (`config/security-headers.ts`) centralizes header values and builds a pragmatic Content-Security-Policy that blocks third-party scripts while allowing inline scripts/styles required by Next.js and React.

In development, CSP is emitted as `Content-Security-Policy-Report-Only` so violations are logged without breaking the app. In production, CSP is enforced and HSTS is included.

## ✅ Changes applied

- Added `config/security-headers.ts` with `getSecurityHeaders()` and `buildContentSecurityPolicy()`
- Applied security headers globally on `/(.*)` and on `/api/:path*` (alongside existing CORS headers)
- CSP `connect-src` includes origins from env (`NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_API_BASE_URL`, etc.) plus `*.supabase.co`, `ipapi.co`, and `api.github.com`
- `style-src` / `font-src` allow `fonts.googleapis.com` and `fonts.gstatic.com`
- Updated `CHANGELOG.md` under `Security`

## Acceptance criteria (#1285)

| Criterion | Status | Notes |
|-----------|--------|-------|
| `X-Frame-Options: SAMEORIGIN` | ✅ | Present on `/`, `/community`, `/api/*` |
| `X-Content-Type-Options: nosniff` | ✅ | Present |
| `Referrer-Policy: strict-origin-when-cross-origin` | ✅ | Present |
| `Permissions-Policy` (camera, microphone, geolocation) | ✅ | `camera=(), microphone=(), geolocation=()` |
| `Strict-Transport-Security` with required max-age | ✅ | Production only (`NODE_ENV=production`) |
| `Content-Security-Policy` with known third-party origins | ✅ | Supabase, ipapi.co, GitHub API, Google Fonts |
| Headers via `headers()` in `next.config.ts` | ✅ | |
| CSP Report-Only in development | ✅ | Verified via module output below |
| Verify headers in production responses | ✅ | `curl -I` against `next start` (see console output) |
| Block unknown **external** scripts | ✅ | `script-src 'self'` (+ `'unsafe-inline'` for Next.js) |
| Block unknown **inline** scripts (strict) | ⚠️ Partial | Requires nonce middleware; pragmatic `'unsafe-inline'` was chosen |

**Post-deploy:** Run [securityheaders.com](https://securityheaders.com) against the production domain for an external grade.

## 🔍 Evidence / validation (console output)

### `npm run build` (exit 0)

```
=== BUILD VERIFICATION ===
├ ○ /pricing                               910 B         131 kB
├ ○ /privacy                             5.24 kB         135 kB
├ ○ /sitemap.xml                           147 B         107 kB
├ ○ /terms                                 11 kB         141 kB
└ ○ /use-cases                           23.9 kB         203 kB
+ First Load JS shared by all             107 kB
  ├ chunks/1255-ad409e5887c155b0.js      45.7 kB
  ├ chunks/4bd1b696-100b9d70ed4e49c1.js  54.2 kB
  └ other shared chunks (total)          7.01 kB


○  (Static)   prerendered as static content
●  (SSG)      prerendered as static HTML (uses generateStaticParams)
ƒ  (Dynamic)  server-rendered on demand
```

### Development mode (`NODE_ENV=development`, module check)

```
=== MODULE CHECK (development NODE_ENV) ===
CSP header name: Content-Security-Policy-Report-Only
CSP value: default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob: https://avatars.githubusercontent.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://*.supabase.co https://ipapi.co https://api.github.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'
All headers:
X-Frame-Options: SAMEORIGIN
X-Content-Type-Options: nosniff
Referrer-Policy: strict-origin-when-cross-origin
Permissions-Policy: camera=(), microphone=(), geolocation=()
Content-Security-Policy-Report-Only: default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob: https://avatars.githubusercontent.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://*.supabase.co https://ipapi.co https://api.github.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'
```

### Production mode (`npm run start -p 3001`, `curl -sI`)

```
=== PRODUCTION: GET / (HTML) ===
HTTP/1.1 200 OK
X-Frame-Options: SAMEORIGIN
X-Content-Type-Options: nosniff
Referrer-Policy: strict-origin-when-cross-origin
Permissions-Policy: camera=(), microphone=(), geolocation=()
Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob: https://avatars.githubusercontent.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://psxegcaowaerovfyyxfl.supabase.co http://localhost:4000 https://offer-hub.tech https://*.supabase.co https://ipapi.co https://api.github.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'; upgrade-insecure-requests
Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
Vary: rsc, next-router-state-tree, next-router-prefetch, next-router-segment-prefetch, Accept-Encoding
x-nextjs-cache: HIT
x-nextjs-prerender: 1
x-nextjs-prerender: 1
x-nextjs-stale-time: 300
X-Powered-By: Next.js
Cache-Control: s-maxage=31536000
ETag: "16xt7ducmcx1ilb"
Content-Type: text/html; charset=utf-8
Content-Length: 70772
Date: Thu, 28 May 2026 17:34:00 GMT
Connection: keep-alive
Keep-Alive: timeout=5


=== PRODUCTION: GET /community ===
HTTP/1.1 200 OK
X-Frame-Options: SAMEORIGIN
X-Content-Type-Options: nosniff
Referrer-Policy: strict-origin-when-cross-origin
Permissions-Policy: camera=(), microphone=(), geolocation=()
Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob: https://avatars.githubusercontent.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://psxegcaowaerovfyyxfl.supabase.co http://localhost:4000 https://offer-hub.tech https://*.supabase.co https://ipapi.co https://api.github.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'; upgrade-insecure-requests
Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
Vary: rsc, next-router-state-tree, next-router-prefetch, next-router-segment-prefetch, Accept-Encoding
x-nextjs-cache: HIT
x-nextjs-prerender: 1
x-nextjs-prerender: 1
x-nextjs-stale-time: 300
X-Powered-By: Next.js
Cache-Control: s-maxage=7200, stale-while-revalidate=31528800
ETag: "ojsqdwc9368lan"
Content-Type: text/html; charset=utf-8
Content-Length: 400865
Date: Thu, 28 May 2026 17:34:00 GMT
Connection: keep-alive
Keep-Alive: timeout=5


=== PRODUCTION: GET /api/privacy/export (OPTIONS) ===
HTTP/1.1 204 No Content
X-Frame-Options: SAMEORIGIN
X-Content-Type-Options: nosniff
Referrer-Policy: strict-origin-when-cross-origin
Permissions-Policy: camera=(), microphone=(), geolocation=()
Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob: https://avatars.githubusercontent.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://psxegcaowaerovfyyxfl.supabase.co http://localhost:4000 https://offer-hub.tech https://*.supabase.co https://ipapi.co https://api.github.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'; upgrade-insecure-requests
Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
Access-Control-Allow-Credentials: true
Access-Control-Allow-Origin: https://offer-hub.tech
Access-Control-Allow-Methods: GET,DELETE,PATCH,POST,PUT,OPTIONS
Access-Control-Allow-Headers: X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version, Authorization
vary: rsc, next-router-state-tree, next-router-prefetch, next-router-segment-prefetch
allow: OPTIONS, POST
Date: Thu, 28 May 2026 17:34:00 GMT
Connection: keep-alive
Keep-Alive: timeout=5
```

## Test plan

- [x] `npm run build` succeeds
- [x] Security headers present on `/` and `/community` (production `next start`)
- [x] Security headers + CORS preserved on `/api/privacy/export`
- [x] Development uses `Content-Security-Policy-Report-Only`
- [x] Production uses `Content-Security-Policy` + HSTS
- [ ] Manual smoke test in browser (home, docs, community, waitlist form)
- [ ] [securityheaders.com](https://securityheaders.com) scan on deployed production URL

## 🔍 Evidence/Media (screenshots/videos)

- Console validation output included above (no screenshots required for header checks)
