### PR TITLE
feat: add print stylesheet for technical documentation pages (#1325)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -503,3 +503,74 @@ body::before {
 ::view-transition-new(root) {
   z-index: 99999;
 }
+
+/* ══════════════════════════════════════════════════════════════════════════════
+   PRINT STYLESHEET - Technical Documentation Layout
+   ══════════════════════════════════════════════════════════════════════════════ */
+@media print {
+  @page {
+    margin: 2cm;
+  }
+
+  /* Force hidden for printing */
+  .print\:hidden {
+    display: none !important;
+  }
+
+  /* Reset layout constraints and backgrounds for printing */
+  body, 
+  .min-h-screen, 
+  main,
+  #doc-page-export-content {
+    background: transparent !important;
+    color: #000000 !important;
+  }
+
+  body::before {
+    display: none !important;
+  }
+
+  /* Reset spacings and paddings */
+  .pt-40 {
+    padding-top: 0 !important;
+  }
+
+  .pb-10 {
+    padding-bottom: 0 !important;
+  }
+
+  .mb-16 {
+    margin-bottom: 2rem !important;
+  }
+
+  /* Reset layout grid to span full-width single column */
+  .max-w-\[1800px\],
+  .max-w-6xl,
+  .xl\:max-w-7xl {
+    max-width: 100% !important;
+    width: 100% !important;
+    padding: 0 !important;
+    margin: 0 !important;
+  }
+
+  .grid {
+    display: block !important;
+    width: 100% !important;
+  }
+
+  main {
+    width: 100% !important;
+    max-width: 100% !important;
+    padding: 0 !important;
+    margin: 0 !important;
+  }
+
+  /* Avoid page-breaks inside crucial components */
+  pre, 
+  code, 
+  .mermaid, 
+  [class*="mermaid"] {
+    page-break-inside: avoid !important;
+    break-inside: avoid !important;
+  }
+}

--- a/src/components/docs/DocsLayoutShell.tsx
+++ b/src/components/docs/DocsLayoutShell.tsx
@@ -143,7 +143,7 @@ export function DocsLayoutShell({ nav, children }: DocsLayoutShellProps) {
 
             {/* Actions toolbar */}
             {!isHub && isKnownDocPage && (
-              <div className="flex items-center justify-start md:justify-end">
+              <div className="flex items-center justify-start md:justify-end print:hidden">
                 <DocActionsMenu slug={currentDocSlug} />
               </div>
             )}
@@ -153,7 +153,7 @@ export function DocsLayoutShell({ nav, children }: DocsLayoutShellProps) {
         {/* SECTION 2: DOCS CONTENT GRID (Wider width as before) */}
         <div className="max-w-[1800px] mx-auto px-6 lg:px-12">
           <div className="grid grid-cols-1 lg:grid-cols-[300px_minmax(0,1fr)] xl:grid-cols-[300px_minmax(0,1fr)_280px] gap-12 lg:gap-20 min-h-[calc(100vh-8rem)]">
-            <aside className="hidden lg:block">
+            <aside className="hidden lg:block print:hidden">
               <div className="sticky top-40 max-h-[calc(100vh-12rem)] flex flex-col">
                 <DocsSidebar nav={nav} className="overflow-y-auto" />
               </div>
@@ -166,14 +166,14 @@ export function DocsLayoutShell({ nav, children }: DocsLayoutShellProps) {
                 </div>
 
                 {headings.length > 0 && (
-                  <div className="xl:hidden mt-20 pt-10 border-t border-[#D1D5DB]/20">
+                  <div className="xl:hidden mt-20 pt-10 border-t border-[#D1D5DB]/20 print:hidden">
                     <TableOfContents headings={headings} />
                   </div>
                 )}
               </div>
             </main>
 
-            <aside className="hidden xl:block">
+            <aside className="hidden xl:block print:hidden">
               {headings.length > 0 && (
                 <div className="sticky top-40 max-h-[calc(100vh-12rem)] overflow-y-auto scrollbar-thin">
                   <TableOfContents headings={headings} />
@@ -185,15 +185,15 @@ export function DocsLayoutShell({ nav, children }: DocsLayoutShellProps) {
       </div>
 
       {isDrawerOpen && (
-        <div className="fixed inset-0 z-50 lg:hidden">
+        <div className="fixed inset-0 z-50 lg:hidden print:hidden">
           <button
             type="button"
-            className="absolute inset-0 bg-black/40 backdrop-blur-sm"
+            className="absolute inset-0 bg-black/40 backdrop-blur-sm print:hidden"
             aria-label="Close docs navigation overlay"
             onClick={() => setIsDrawerOpen(false)}
           />
           <aside
-            className="relative h-full w-80 max-w-[85vw] p-8 bg-bg-base shadow-neu-raised rounded-r-[30px]"
+            className="relative h-full w-80 max-w-[85vw] p-8 bg-bg-base shadow-neu-raised rounded-r-[30px] print:hidden"
           >
             <div className="mb-8 flex items-center justify-between pb-4 border-b border-theme-border/40">
               <p className="text-sm font-bold uppercase tracking-widest text-[#149A9B]">

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -63,7 +63,7 @@ export function Navbar() {
        */}
       <header
         className={cn(
-          "fixed top-4 left-4 right-4 md:left-1/2 md:-translate-x-1/2 md:max-w-6xl xl:max-w-7xl md:w-full z-[500] transition-all duration-300 ease-out rounded-full bg-bg-base",
+          "fixed top-4 left-4 right-4 md:left-1/2 md:-translate-x-1/2 md:max-w-6xl xl:max-w-7xl md:w-full z-[500] transition-all duration-300 ease-out rounded-full bg-bg-base print:hidden",
           isScrolled
             ? "shadow-neu-raised-scrolled py-1"
             : "shadow-neu-raised py-2"

--- a/src/components/ui/FloatingCTA.tsx
+++ b/src/components/ui/FloatingCTA.tsx
@@ -113,7 +113,7 @@ export function FloatingCTA() {
       <style>{rotatingBorderStyles}</style>
 
       <div
-        className={`fixed bottom-4 right-4 md:bottom-6 md:right-6 z-50 transition-all duration-300 ease-out ${isVisible
+        className={`fixed bottom-4 right-4 md:bottom-6 md:right-6 z-50 transition-all duration-300 ease-out print:hidden ${isVisible
           ? "opacity-100 translate-y-0 scale-100"
           : "opacity-0 translate-y-4 scale-95"
           }`}


### PR DESCRIPTION
# Title feat: add print stylesheet for technical documentation pages (#1325)

## Description
This Pull Request implements a dedicated print stylesheet (`@media print`) and utility classes (`print:hidden`) for the technical documentation pages. It guarantees a clean, single-column document layout optimized for printing or exporting to PDF.

### Key Changes:
- **Style Reset (`globals.css`)**: Removed gradients, background decorations, and set the page margins to a clean `2cm` via `@page`.
- **Single Column Layout**: Forced grid-based page containers to display as a standard block at `100%` width.
- **Clean Printing**: Added `print:hidden` classes to the primary Navbar (`Navbar.tsx`), the side navigation panels (sidebar and mobile drawer in `DocsLayoutShell.tsx`), the table of contents (`TableOfContents`), the actions toolbar (`DocActionsMenu`), and the floating Join Waitlist button (`FloatingCTA.tsx`).
- **Page Break Control**: Added rules preventing code blocks (`pre`/`code`) and Mermaid diagrams (`.mermaid`) from getting broken abruptly across page borders.

## Closes
Closes #1325

## Screenshots & Evidence
<img width="1842" height="986" alt="image" src="https://github.com/user-attachments/assets/2b421617-5142-4f60-8785-ccde8958d677" />
