### PR TITLE
fix: replace window.location.href with router.push in FloatingCTA

### DIFF
--- a/src/components/ui/FloatingCTA.tsx
+++ b/src/components/ui/FloatingCTA.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { X, ArrowRight } from "lucide-react";
 
 const STORAGE_KEY = "offer-hub-cta-dismissed";
@@ -50,6 +50,7 @@ const rotatingBorderStyles = `
 
 export function FloatingCTA() {
   const pathname = usePathname();
+  const router = useRouter();
   const [isVisible, setIsVisible] = useState(false);
   const [isAnimating, setIsAnimating] = useState(false);
 
@@ -101,8 +102,8 @@ export function FloatingCTA() {
   };
 
   const handleClick = () => {
-    // Navigate to home page waitlist section
-    window.location.href = "/#waitlist-form";
+    // Navigate to home page waitlist section using client-side navigation
+    router.push("/#waitlist-form");
   };
 
   if (!isAnimating) return null;


### PR DESCRIPTION
# PR Title

```
fix: replace window.location.href with router.push in FloatingCTA
```

# PR Description

> Copy everything below this line into the PR body.

---

## Description

The `FloatingCTA` component was navigating to the waitlist section using `window.location.href = "/#waitlist-form"` inside its `handleClick` handler. This approach triggers a full browser page reload on every click, which discards all in-memory React state, re-executes every layout effect across the component tree, and completely bypasses the client-side routing that Next.js App Router is designed to provide.

This pull request replaces that direct `window` assignment with `router.push("/#waitlist-form")` from the `useRouter` hook provided by `next/navigation`, ensuring navigation is handled entirely on the client side without a page reload.

## Changes

**File:** `src/components/ui/FloatingCTA.tsx`

1. **Added `useRouter`** to the existing `next/navigation` import alongside `usePathname`.
2. **Initialized the router instance** via `const router = useRouter()` at the top of the component body.
3. **Replaced `window.location.href`** with `router.push("/#waitlist-form")` inside the `handleClick` function, removing all direct `window` access from the click handler.

No other logic was modified. The dismiss flow, `localStorage` persistence, animation states, and excluded-page checks remain exactly as they were.

## Acceptance Criteria

- [x] Import `useRouter` from `next/navigation` and replace `window.location.href = "/#waitlist-form"` with `router.push("/#waitlist-form")`
- [x] Clicking the CTA while already on `/` still scrolls to `#waitlist-form` without a reload
- [x] Clicking the CTA from any other route (e.g. `/docs`, `/pricing`) navigates to `/#waitlist-form` using client-side navigation
- [x] No direct `window` access remains in the click handler — the function is safe to reference during SSR
- [x] Existing dismiss logic and `localStorage` behavior remain unchanged

## Related Issue

Closes #1315
