### PR TITLE
feat: Add breadcrumb navigation to documentation pages

### DIFF
--- a/src/components/docs/Breadcrumb.tsx
+++ b/src/components/docs/Breadcrumb.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useMemo } from "react";
+import { ChevronRight, Home } from "lucide-react";
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://offer-hub.tech";
+
+function formatSegment(segment: string): string {
+  return decodeURIComponent(segment)
+    .replace(/-/g, " ")
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+export function Breadcrumb() {
+  const pathname = usePathname();
+
+  const pathSegments = useMemo(() => {
+    const [, docs, ...rest] = pathname.split("/");
+    if (docs !== "docs") return [];
+    return rest.filter(Boolean);
+  }, [pathname]);
+
+  const isHub = pathname === "/docs" || pathname === "/docs/";
+
+  if (isHub || pathSegments.length === 0) return null;
+
+  const breadcrumbItems = [
+    { name: "Docs", href: "/docs" },
+    ...pathSegments.map((segment, index) => ({
+      name: formatSegment(segment),
+      href: `/docs/${pathSegments.slice(0, index + 1).join("/")}`,
+    })),
+  ];
+
+  const structuredData = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      { "@type": "ListItem", position: 1, name: "Home", item: SITE_URL },
+      ...breadcrumbItems.map((item, index) => ({
+        "@type": "ListItem",
+        position: index + 2,
+        name: item.name,
+        item: `${SITE_URL}${item.href}`,
+      })),
+    ],
+  };
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+      />
+      <div className="flex items-center gap-2 text-[14px] whitespace-nowrap overflow-x-auto no-scrollbar py-1">
+        <Link
+          href="/docs"
+          className="text-[#149A9B] hover:text-[#149A9B]/80 transition-colors font-medium flex items-center gap-1.5"
+        >
+          <Home size={15} />
+          Docs
+        </Link>
+        {pathSegments.map((segment, index) => {
+          const href = `/docs/${pathSegments.slice(0, index + 1).join("/")}`;
+          const isLast = index === pathSegments.length - 1;
+          return (
+            <span key={`${segment}-${index}`} className="flex items-center gap-2">
+              <ChevronRight size={14} className="text-content-secondary/30" />
+              {isLast ? (
+                <span className="text-content-primary font-medium">
+                  {formatSegment(segment)}
+                </span>
+              ) : (
+                <Link
+                  href={href}
+                  className="text-content-secondary hover:text-content-primary transition-colors font-medium"
+                >
+                  {formatSegment(segment)}
+                </Link>
+              )}
+            </span>
+          );
+        })}
+      </div>
+    </>
+  );
+}

--- a/src/components/docs/DocsLayoutShell.tsx
+++ b/src/components/docs/DocsLayoutShell.tsx
@@ -1,16 +1,14 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import Link from "next/link";
 import { usePathname } from "next/navigation";
-import {
-  Menu, X, ChevronRight, Home
-} from "lucide-react";
+import { Menu, X } from "lucide-react";
 
 import type { Heading, SidebarSection } from "@/lib/mdx";
 import { DocsSidebar } from "@/components/docs/DocsSidebar";
 import { TableOfContents } from "@/components/docs/TableOfContents";
 import { Navbar } from "@/components/layout/Navbar";
+import { Breadcrumb } from "@/components/docs/Breadcrumb";
 import { FileCode2, FileText, Github } from "lucide-react";
 
 // Use production URL for AI assistant links
@@ -19,12 +17,6 @@ const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://offer-hub.tech";
 interface DocsLayoutShellProps {
   nav: SidebarSection[];
   children: React.ReactNode;
-}
-
-function formatSegment(segment: string) {
-  return decodeURIComponent(segment)
-    .replace(/-/g, " ")
-    .replace(/\b\w/g, (char) => char.toUpperCase());
 }
 
 function collectHeadingsFromPage(): Heading[] {
@@ -97,7 +89,7 @@ export function DocsLayoutShell({ nav, children }: DocsLayoutShellProps) {
         <div className="max-w-6xl xl:max-w-7xl mx-auto px-6 lg:px-8 mb-16">
           <div className="relative z-40 flex flex-col md:flex-row md:items-center justify-between gap-6">
 
-            {/* Breadcrumb - Differentiated colors, no bold */}
+            {/* Breadcrumb navigation */}
             <nav aria-label="Breadcrumb" className="flex items-center gap-2 overflow-hidden flex-1">
               <button
                 type="button"
@@ -108,36 +100,11 @@ export function DocsLayoutShell({ nav, children }: DocsLayoutShellProps) {
                 <Menu size={20} />
               </button>
 
-              <div className="flex items-center gap-2 text-[14px] whitespace-nowrap overflow-x-auto no-scrollbar py-1">
-                {!isHub ? (
-                  <>
-                    <Link href="/docs" className="text-[#149A9B] hover:text-[#149A9B]/80 transition-colors font-medium flex items-center gap-1.5">
-                      <Home size={15} />
-                      Docs
-                    </Link>
-                    {pathSegments.map((segment, index) => {
-                      const href = `/docs/${pathSegments.slice(0, index + 1).join("/")}`;
-                      const isLast = index === pathSegments.length - 1;
-                      return (
-                        <span key={`${segment}-${index}`} className="flex items-center gap-2">
-                          <ChevronRight size={14} className="text-content-secondary/30" />
-                          {isLast ? (
-                            <span className="text-content-primary font-medium">
-                              {formatSegment(segment)}
-                            </span>
-                          ) : (
-                            <Link href={href} className="text-content-secondary hover:text-content-primary transition-colors font-medium">
-                              {formatSegment(segment)}
-                            </Link>
-                          )}
-                        </span>
-                      );
-                    })}
-                  </>
-                ) : (
-                  <span className="text-content-primary font-bold tracking-tight opacity-40 italic">Documentation Index</span>
-                )}
-              </div>
+              {isHub ? (
+                <span className="text-content-primary font-bold tracking-tight opacity-40 italic text-[14px]">Documentation Index</span>
+              ) : (
+                <Breadcrumb />
+              )}
             </nav>
 
 


### PR DESCRIPTION
## Summary

- Created `src/components/docs/Breadcrumb.tsx` — a standalone `"use client"` component that derives path segments from `usePathname()` and renders a `Home › Docs › … › Current Page` trail
- Each intermediate segment is a clickable `Link`; the active (last) segment renders as plain `text-content-primary` text — no link
- Separators use `ChevronRight` from lucide-react with `text-content-secondary/30` styling, matching existing design tokens
- Component returns `null` on `/docs` (hub page) — breadcrumb only appears on `/docs/[...slug]` routes
- Injects a `<script type="application/ld+json">` with a `BreadcrumbList` structured-data schema (Home + all segments) for SEO
- Integrated `<Breadcrumb />` into `DocsLayoutShell.tsx`, replacing the previous inline breadcrumb markup
- Removed now-redundant `Link`, `ChevronRight`, `Home` imports and the local `formatSegment` helper from `DocsLayoutShell` — they now live exclusively in `Breadcrumb.tsx`

## Test plan

- [ ] Visit `/docs` — confirm breadcrumb does **not** render; "Documentation Index" label still shows
- [ ] Visit `/docs/guide/escrow` (or any nested doc) — confirm `Home › Docs › Guide › Escrow` trail renders
- [ ] Confirm intermediate segment labels are clickable links; last segment is plain text
- [ ] Inspect page source for `application/ld+json` script containing `BreadcrumbList` with correct `item` URLs
- [ ] Confirm hyphenated slugs (e.g. `getting-started`) display as `Getting Started`
- [ ] Check mobile — hamburger menu button still visible alongside the breadcrumb

closes #1323