### PR TITLE
fix: deduplicate metadata titles across pages for template compatibility

### DIFF
--- a/src/app/docs/[...slug]/page.tsx
+++ b/src/app/docs/[...slug]/page.tsx
@@ -22,7 +22,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   if (!doc) notFound();
 
   return {
-    title: `${doc.frontmatter.title} — OFFER-HUB Docs`,
+    title: doc.frontmatter.title,
     description: doc.frontmatter.description,
   };
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,7 +2,9 @@ import type { Metadata } from "next";
 import { Navbar } from "@/components/layout/Navbar";
 
 export const metadata: Metadata = {
-  title: "OFFER-HUB — Trustless Payments Orchestrator for Marketplaces",
+  title: {
+    absolute: "OFFER-HUB — Trustless Payments Orchestrator for Marketplaces",
+  },
   description:
     "OFFER-HUB empowers marketplaces to provide secure, non-custodial escrow payments without building complex payment infrastructure from scratch.",
   keywords: [

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -8,7 +8,7 @@ import { Navbar } from "@/components/layout/Navbar";
 import LoadingBar from "@/components/ui/LoadingBar";
 
 export const metadata: Metadata = {
-  title: "Pricing | OFFER-HUB",
+  title: "Pricing",
   description:
     "OFFER-HUB pricing: open source core for free, free self-hosting, and enterprise support available on request.",
 };

--- a/src/app/use-cases/layout.tsx
+++ b/src/app/use-cases/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-    title: "Industry Use Cases — OFFER HUB",
+    title: "Industry Use Cases",
     description: "Explore how OFFER HUB's non-custodial escrow orchestrates payment workflows across Freelance, eCommerce, DAOs, and Real Estate.",
     keywords: [
         "use cases",


### PR DESCRIPTION
## Summary

Fixes duplicate page titles caused by child pages including 'OFFER-HUB' in their `metadata.title` while the root layout already applies a `%s | OFFER-HUB` template. Without this fix, pages like `/pricing` would render as "Pricing | OFFER-HUB | OFFER-HUB".

## Changes

- **`src/app/pricing/page.tsx`**: `"Pricing | OFFER-HUB"` → `"Pricing"` (template adds the suffix)
- **`src/app/use-cases/layout.tsx`**: `"Industry Use Cases — OFFER HUB"` → `"Industry Use Cases"` (template adds the suffix)
- **`src/app/docs/[...slug]/page.tsx`**: Removed `" — OFFER-HUB Docs"` suffix from dynamic doc titles (template adds the suffix)
- **`src/app/page.tsx`**: Used `title.absolute` to opt out of the template entirely for the home page, preserving the full marketing title

## Before / After

| Page | Before | After |
|------|--------|-------|
| `/` | OFFER-HUB — Trustless Payments Orchestrator for Marketplaces \| OFFER-HUB | OFFER-HUB — Trustless Payments Orchestrator for Marketplaces |
| `/pricing` | Pricing \| OFFER-HUB \| OFFER-HUB | Pricing \| OFFER-HUB |
| `/use-cases` | Industry Use Cases — OFFER HUB \| OFFER-HUB | Industry Use Cases \| OFFER-HUB |
| `/docs/[slug]` | Getting Started — OFFER-HUB Docs \| OFFER-HUB | Getting Started \| OFFER-HUB |
| `/other` | OFFER-HUB \| The Future of On-Chain Bounties | (unchanged — default) |

## Testing

- ✅ ESLint passes with no warnings or errors
- ✅ `metadataBase` is already set to `https://offer-hub.tech` (issue #1324)
- ✅ Root layout template (`%s | OFFER-HUB`) remains unchanged

## Related Issues

Closes #1322