### PR TITLE
fix: migrate generateVisitorId() and getSessionId() to crypto.randomUUID()

### DIFF
--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,36 +1,14 @@
 import { supabase, isSupabaseConfigured } from './supabase';
 
-// Generate a unique visitor ID (fingerprint)
+// Generate a unique visitor ID
 export function generateVisitorId(): string {
-  const getOrCreateVisitorId = () => {
-    if (localStorage.getItem('cookie_consent') !== 'accepted') return '';
-    const stored = localStorage.getItem('visitor_id');
-    if (stored) return stored;
+  if (localStorage.getItem('cookie_consent') !== 'accepted') return '';
+  const stored = localStorage.getItem('visitor_id');
+  if (stored) return stored;
 
-    // Create fingerprint from available browser data
-    const fingerprint = [
-      navigator.userAgent,
-      navigator.language,
-      new Date().getTimezoneOffset(),
-      screen.width,
-      screen.height,
-      screen.colorDepth,
-    ].join('|');
-
-    // Simple hash function
-    let hash = 0;
-    for (let i = 0; i < fingerprint.length; i++) {
-      const char = fingerprint.charCodeAt(i);
-      hash = (hash << 5) - hash + char;
-      hash = hash & hash; // Convert to 32-bit integer
-    }
-
-    const visitorId = `visitor_${Math.abs(hash)}_${Date.now()}`;
-    localStorage.setItem('visitor_id', visitorId);
-    return visitorId;
-  };
-
-  return getOrCreateVisitorId();
+  const visitorId = crypto.randomUUID();
+  localStorage.setItem('visitor_id', visitorId);
+  return visitorId;
 }
 
 // Get device type
@@ -74,7 +52,7 @@ export function getSessionId(): string {
   const stored = sessionStorage.getItem('session_id');
   if (stored) return stored;
 
-  const sessionId = `session_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+  const sessionId = crypto.randomUUID();
   sessionStorage.setItem('session_id', sessionId);
   return sessionId;
 }


### PR DESCRIPTION
## Summary

Replaces the browser fingerprinting hash in `generateVisitorId()` and the `Math.random()`-based session ID in `getSessionId()` with `crypto.randomUUID()`.

## Changes

- **`src/lib/analytics.ts`**:
  - `generateVisitorId()`: Removed the fingerprint array (userAgent, language, timezone, screen dimensions) and 32-bit hash loop. Now uses `crypto.randomUUID()` directly.
  - `getSessionId()`: Replaced `Math.random().toString(36).substr(2, 9)` with `crypto.randomUUID()`.
  - Removed the unnecessary `getOrCreateVisitorId()` closure wrapper — the function is now a flat, linear flow.

## Why

1. **Better uniqueness**: The fingerprint hash could produce identical IDs for users on shared devices (corporate desktops, CI environments). `crypto.randomUUID()` produces 128-bit cryptographically random IDs with zero collision probability.
2. **No deprecated APIs**: Removed `Math.random().toString(36).substr(2, 9)` which uses the deprecated `substr` method and has weak entropy.
3. **Simpler code**: 30 lines removed, 8 added. No imports needed — `crypto.randomUUID()` is globally available in all modern browsers and Node.js 14.17+.

## Backward Compatibility

Existing visitor IDs stored in `localStorage` under `visitor_id` are preserved. The check-before-create pattern (`if (stored) return stored`) ensures returning users keep their existing ID.

## Testing

- ✅ ESLint passes with no warnings or errors
- ✅ Existing visitor IDs in localStorage are preserved (no disruption for returning users)
- ✅ New visitors get a UUID-format ID instead of `visitor_<hash>_<timestamp>`
- ✅ Session IDs are now UUIDs instead of `session_<timestamp>_<random>`

## Related Issues

Closes #1318