### PR TITLE
feat: add Cookie Preferences link in Footer to re-open consent banner

### DIFF
--- a/src/components/CookieConsentBanner.tsx
+++ b/src/components/CookieConsentBanner.tsx
@@ -12,6 +12,11 @@ export default function CookieConsentBanner() {
     if (!localStorage.getItem(CONSENT_KEY)) {
       setVisible(true);
     }
+
+    const handleReopen = () => setVisible(true);
+    window.addEventListener("cookie-preferences-open", handleReopen);
+    return () =>
+      window.removeEventListener("cookie-preferences-open", handleReopen);
   }, []);
 
   const accept = () => {

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -28,6 +28,7 @@ const navColumns = [
     links: [
       { href: "/terms", label: "Terms of Service" },
       { href: "/privacy", label: "Privacy Policy" },
+      { href: "#", label: "Cookie Preferences", isCookieLink: true },
     ],
   },
 ];
@@ -113,12 +114,26 @@ export function Footer() {
                   <ul className="flex flex-col gap-3">
                     {col.links.map((link) => (
                       <li key={link.label}>
-                        <a
-                          href={link.href}
-                          className="text-sm text-content-secondary hover:text-content-primary transition-colors duration-200"
-                        >
-                          {link.label}
-                        </a>
+                        {"isCookieLink" in link && link.isCookieLink ? (
+                          <button
+                            type="button"
+                            onClick={() =>
+                              window.dispatchEvent(
+                                new CustomEvent("cookie-preferences-open")
+                              )
+                            }
+                            className="text-sm text-content-secondary hover:text-content-primary transition-colors duration-200"
+                          >
+                            {link.label}
+                          </button>
+                        ) : (
+                          <a
+                            href={link.href}
+                            className="text-sm text-content-secondary hover:text-content-primary transition-colors duration-200"
+                          >
+                            {link.label}
+                          </a>
+                        )}
                       </li>
                     ))}
                   </ul>


### PR DESCRIPTION
## Summary
Adds a "Cookie Preferences" link to the Legal column in the Footer that re-opens the cookie consent banner, allowing users to change their consent choice at any time.

## Changes
- Added "Cookie Preferences" button to the Legal column in `Footer.tsx`
- `CookieConsentBanner.tsx` now listens for a `cookie-preferences-open` custom DOM event to re-show the banner
- Clicking the footer link dispatches this event, re-opening the banner with the user's current preference pre-loaded

## GDPR Compliance
This satisfies **GDPR Article 7(3)**: withdrawing consent must be as easy as giving it. Without this link, users who accepted/rejected cookies had no way to change their preference.

## Testing
1. Visit any page and accept/reject the cookie consent banner
2. Scroll to the footer → Legal column
3. Click "Cookie Preferences"
4. Verify the consent banner re-appears
5. Change your preference → verify it updates `localStorage`

## Related Issues
Fixes #1313