### PR TITLE
feat(docs): add copy source button to Mermaid diagrams

### DIFF
--- a/src/components/docs/MermaidDiagram.tsx
+++ b/src/components/docs/MermaidDiagram.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { useEffect, useRef, useState, ReactNode } from "react";
+import { Copy, Check } from "lucide-react";
 import mermaid from "mermaid";
 import { useTheme } from "@/components/providers/ThemeProvider";
+import { cn } from "@/lib/cn";
 
 interface MermaidDiagramProps {
   chart?: string;
@@ -35,9 +37,20 @@ export function MermaidDiagram({
   const [svg, setSvg] = useState<string>("");
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const [copied, setCopied] = useState(false);
 
   const chartContent = extractChartContent(chart, children);
   const { resolvedTheme } = useTheme();
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(chartContent);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error("Failed to copy!", err);
+    }
+  }
 
   useEffect(() => {
     let cancelled = false;
@@ -177,6 +190,29 @@ export function MermaidDiagram({
               Mermaid
             </span>
           </div>
+
+          {chartContent && (
+            <button
+              type="button"
+              onClick={handleCopy}
+              aria-label={copied ? "Copied" : "Copy diagram source"}
+              className={cn(
+                "relative flex items-center gap-2.5 px-4 py-2 rounded-xl text-[10.5px] font-black uppercase tracking-widest transition-all duration-300",
+                copied
+                  ? "text-white bg-theme-primary shadow-lg shadow-theme-primary/25"
+                  : "text-content-secondary bg-bg-base shadow-neu-raised-sm hover:text-content-primary hover:bg-theme-primary/10 active:scale-95"
+              )}
+            >
+              <span className="flex items-center gap-2">
+                {copied ? (
+                  <Check size={14} className="stroke-[3.5]" />
+                ) : (
+                  <Copy size={14} className="stroke-[2.5]" />
+                )}
+                <span>{copied ? "Copied" : "Copy source"}</span>
+              </span>
+            </button>
+          )}
         </div>
 
         <div


### PR DESCRIPTION
# 📝 Pull Request

## 🔧 Title:

feat(docs): add copy-to-clipboard for Mermaid diagram source

## 🛠️ Issue

- Closes #1326

## 📚 Description

Documentation Mermaid diagrams render as SVG but did not expose the underlying source. Developers often need that syntax to adapt diagrams or paste into [Mermaid Live Editor](https://mermaid.live). This change adds a **Copy source** control to the diagram header, matching the existing copy UX in `CodeBlock`.

## ✅ Changes applied

- Added **Copy source** button to the header bar of `MermaidDiagram.tsx`, aligned to the right (same layout as `CodeBlock`)
- Copies raw `chartContent` via `navigator.clipboard.writeText()`
- `aria-label="Copy diagram source"` toggles to `"Copied"` for 2 seconds after a successful copy
- Reused `Copy` / `Check` icons from `lucide-react` and the same neumorphic button styles (`bg-bg-base shadow-neu-raised-sm`, teal fill when copied)
- Button is not rendered when `chartContent` is empty

## 🔍 Evidence/Media (screenshots/videos)

https://github.com/user-attachments/assets/cbc7236b-47d8-45e0-b676-5176c157cfb6

## 🧪 Test
- `npm run lint` — no ESLint warnings or errors
- `npm run build` — compiled successfully; static docs routes (including `/docs/guide/escrow`) generated without errors
- Manual verification recommended: run `npm run dev`, open `/docs/guide/escrow`, click **Copy source** on a diagram, paste into a text editor or mermaid.live, and confirm the 2s **Copied** state and `aria-label` in DevTools
