### PR TITLE
Feat add back to button

### DIFF
--- a/src/components/docs/BackToTopButton.tsx
+++ b/src/components/docs/BackToTopButton.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { ChevronUp } from "lucide-react";
+
+const SCROLL_THRESHOLD = 400;
+
+export function BackToTopButton() {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    let ticking = false;
+    const onScroll = () => {
+      if (!ticking) {
+        ticking = true;
+        requestAnimationFrame(() => {
+          setIsVisible(window.scrollY > SCROLL_THRESHOLD);
+          ticking = false;
+        });
+      }
+    };
+
+    onScroll();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
+  const scrollToTop = useCallback(() => {
+    const prefersReducedMotion = window.matchMedia(
+      "(prefers-reduced-motion: reduce)"
+    ).matches;
+
+    window.scrollTo({
+      top: 0,
+      behavior: prefersReducedMotion ? "instant" : "smooth",
+    });
+  }, []);
+
+  if (!isVisible) return null;
+
+  return (
+    <button
+      type="button"
+      onClick={scrollToTop}
+      aria-label="Back to top"
+      className="fixed z-40 bottom-20 right-6 md:bottom-52 md:right-6 flex h-11 w-11 items-center justify-center rounded-full bg-bg-base text-[#149A9B] shadow-neu-raised transition-shadow hover:shadow-neu-raised-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-[#149A9B]/50 print:hidden"
+    >
+      <ChevronUp size={22} aria-hidden />
+    </button>
+  );
+}

--- a/src/components/docs/DocsLayoutShell.tsx
+++ b/src/components/docs/DocsLayoutShell.tsx
@@ -8,6 +8,7 @@ import {
 } from "lucide-react";
 
 import type { Heading, SidebarSection } from "@/lib/mdx";
+import { BackToTopButton } from "@/components/docs/BackToTopButton";
 import { DocsSidebar } from "@/components/docs/DocsSidebar";
 import { TableOfContents } from "@/components/docs/TableOfContents";
 import { Navbar } from "@/components/layout/Navbar";
@@ -183,6 +184,8 @@ export function DocsLayoutShell({ nav, children }: DocsLayoutShellProps) {
           </div>
         </div>
       </div>
+
+      <BackToTopButton />
 
       {isDrawerOpen && (
         <div className="fixed inset-0 z-50 lg:hidden print:hidden">


### PR DESCRIPTION
# 📝 Pull Request

## 🔧 Title:

feat: Add Back to Top button in DocsLayoutShell for long documentation pages

## 🛠️ Issue

- Closes #1320

## 📚 Description

Documentation pages can be very long, and the table of contents is hidden on mobile viewports. This change adds a fixed **Back to top** control that appears after scrolling past 400px, so readers can return to the top without manual scrolling.

The button lives in `DocsLayoutShell`, so it only appears on documentation routes. It follows the existing neumorphic styling (`bg-bg-base`, `shadow-neu-raised`, teal `ChevronUp` icon) and respects `prefers-reduced-motion` by using instant scroll when reduced motion is enabled.

On mobile, the button is positioned at `bottom-20` to avoid the browser’s bottom navigation chrome. On `md+` viewports it sits at `right-6` and `bottom-52` so it stays aligned with the design system while clearing the global `FloatingCTA` card (`bottom-6 right-6`).

## ✅ Changes applied

- Added `src/components/docs/BackToTopButton.tsx` with:
  - Window scroll listener (rAF-throttled, same pattern as `Navbar.tsx`)
  - Visibility toggle after 400px scroll
  - `window.scrollTo({ top: 0, behavior: 'smooth' | 'instant' })` based on `prefers-reduced-motion`
  - `aria-label="Back to top"`, keyboard-focusable `<button>`, `print:hidden`
- Integrated `<BackToTopButton />` in `src/components/docs/DocsLayoutShell.tsx`

https://github.com/user-attachments/assets/be1197c5-f748-47da-920e-0ecbddf76e23

## 🔍 Evidence/Media (screenshots/videos)

## 🧪 Test
- [X] Scroll a long docs page (e.g. `/docs/guide/security`) past 400px — button appears
- [X] Scroll back near the top — button hides
- [X] Click button — smooth scroll to top (or instant with reduced motion)
- [X] Mobile: button at `bottom-20`, does not overlap browser UI
- [X] Desktop: button does not cover `FloatingCTA`
- [X] `npm run lint` and `npm run build` pass locally
