### PR TITLE
Title: - fix: Set safe CORS default instead of wildcard fallback in next.config.ts

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,11 +1,22 @@
 import type { NextConfig } from "next";
 import { getSecurityHeaders } from "./config/security-headers";
 
+// Startup validation for production NEXT_PUBLIC_SITE_URL environment variable
+if (process.env.NODE_ENV === "production" && !process.env.NEXT_PUBLIC_SITE_URL) {
+  console.warn(
+    "\x1b[33m%s\x1b[0m", // Yellow ANSI escape code
+    "⚠️ WARNING: NEXT_PUBLIC_SITE_URL is not set in the production environment. " +
+    "CORS will fall back to 'https://offer-hub.tech' which may cause client-side issues if the site is hosted elsewhere."
+  );
+}
+
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://offer-hub.tech";
+
 const corsHeaders = [
   { key: "Access-Control-Allow-Credentials", value: "true" },
   {
     key: "Access-Control-Allow-Origin",
-    value: process.env.NEXT_PUBLIC_SITE_URL || "*",
+    value: siteUrl,
   },
   {
     key: "Access-Control-Allow-Methods",


### PR DESCRIPTION
Resolves #1286

# 📝 Pull Request 

## 🔧 Title:  - fix: Set safe CORS default instead of wildcard fallback in next.config.ts

## 🛠️ Issue

- Closes #1286

## 📚 Description

- This PR resolves a security configuration issue in `next.config.ts`. The previous CORS setup used a wildcard (`*`) fallback, which is explicitly incompatible with `Access-Control-Allow-Credentials: true` and presents a security risk for cross-origin requests. This update sets a secure default and adds environment validation.

## ✅ Changes applied

- Replaced the `|| "*"` CORS origin fallback with a safe default (`https://offer-hub.tech`) in `next.config.ts`.
- Implemented a startup validation that logs a warning in the console if `NEXT_PUBLIC_SITE_URL` is not set in production environments.
- Verified that `NEXT_PUBLIC_SITE_URL` is properly documented in `.env.example`.

## 🔍 Evidence/Media (screenshots/videos)

<img width="1328" height="782" alt="image" src="https://github.com/user-attachments/assets/720a8f77-7bd4-41d8-a04b-b8b1882feaf0" />

