### PR TITLE
feat: Add /contact page and replace Telegram link in Enterprise pricing CTA

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,21 +1,21 @@
-## Pull Request
+# 📝 Pull Request 
 
-Short description of the change and the motivation for the PR.
+## 🔧 Title: 
 
-## Related issues
+-
 
-- Fixes: # (issue number)
+## 🛠️ Issue
 
-## Description of changes
+- Closes #issue-ID
 
-- Summary of what changed and why.
+## 📚 Description
 
-## Checklist
+-
 
-- [ ] I have added tests where relevant
-- [ ] I have updated documentation where relevant
-- [ ] This PR is scoped and does not include unrelated changes
+## ✅ Changes applied
 
-## Screenshots / Evidence
+-
 
-- Add screenshots, recordings, or logs if helpful for reviewers.
+## 🔍 Evidence/Media (screenshots/videos)
+
+-

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,35 +1,21 @@
-# 📝 Pull Request 
+## Pull Request
 
-## 🔧 Title: 
+Short description of the change and the motivation for the PR.
 
--
+## Related issues
 
-## 🛠️ Issue
+- Fixes: # (issue number)
 
-- Closes #issue-ID
+## Description of changes
 
-## 📚 Description
+- Summary of what changed and why.
 
--
+## Checklist
 
-## 🗄️ Database changes
+- [ ] I have added tests where relevant
+- [ ] I have updated documentation where relevant
+- [ ] This PR is scoped and does not include unrelated changes
 
-- Include any DB migrations or SQL required to support this PR.
-- For the contact form feature, include the migration `sql/contact_inquiries.sql` and link to the schema doc: `docs/contact-inquiries.md`.
+## Screenshots / Evidence
 
-Example note to add to PR description:
-
-```
-Database migration: `sql/contact_inquiries.sql`
-Table: `contact_inquiries`
-Columns: `id (uuid)`, `company (text)`, `contact_name (text)`, `email (text)`, `message (text)`, `created_at (timestamptz)`.
-See docs/contact-inquiries.md for details.
-```
-
-## ✅ Changes applied
-
--
-
-## 🔍 Evidence/Media (screenshots/videos)
-
--
+- Add screenshots, recordings, or logs if helpful for reviewers.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,6 +12,20 @@
 
 -
 
+## 🗄️ Database changes
+
+- Include any DB migrations or SQL required to support this PR.
+- For the contact form feature, include the migration `sql/contact_inquiries.sql` and link to the schema doc: `docs/contact-inquiries.md`.
+
+Example note to add to PR description:
+
+```
+Database migration: `sql/contact_inquiries.sql`
+Table: `contact_inquiries`
+Columns: `id (uuid)`, `company (text)`, `contact_name (text)`, `email (text)`, `message (text)`, `created_at (timestamptz)`.
+See docs/contact-inquiries.md for details.
+```
+
 ## ✅ Changes applied
 
 -

--- a/docs/contact-inquiries.md
+++ b/docs/contact-inquiries.md
@@ -1,0 +1,47 @@
+Contact Inquiries — Supabase table
+
+Purpose
+
+This document describes the required Supabase table used by the client-side contact form at `/contact`.
+
+Table name
+
+- `contact_inquiries`
+
+Required columns
+
+- `id` — uuid primary key. Recommended default: `gen_random_uuid()` (requires `pgcrypto` or `pgcrypto` equivalent).
+- `company` — text NOT NULL. Company name provided by the submitter.
+- `contact_name` — text NOT NULL. Person to contact at the company.
+- `email` — text NOT NULL. Work email for follow-up.
+- `message` — text NULL. Optional use case / message field.
+- `created_at` — timestamptz NOT NULL DEFAULT now().
+
+Indexes (optional but recommended)
+
+- `idx_contact_inquiries_email` on `email`
+
+Example SQL
+
+Run this in the Supabase SQL editor or with the Supabase CLI:
+
+```sql
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS contact_inquiries (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  company text NOT NULL,
+  contact_name text NOT NULL,
+  email text NOT NULL,
+  message text,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_contact_inquiries_email ON contact_inquiries (email);
+```
+
+Notes for PRs
+
+- Include the SQL migration file in the PR (we added `sql/contact_inquiries.sql`).
+- In the PR description, mention the table name and required columns and link to this document.
+- If your Supabase project requires different UUID generation (for example `uuid-ossp`), adapt the SQL accordingly.

--- a/sql/contact_inquiries.sql
+++ b/sql/contact_inquiries.sql
@@ -1,0 +1,16 @@
+-- SQL migration: create contact_inquiries table for OFFER-HUB
+-- Run this in your Supabase SQL editor or via psql/supabase CLI
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS contact_inquiries (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  company text NOT NULL,
+  contact_name text NOT NULL,
+  email text NOT NULL,
+  message text,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Optional: index on email for lookups
+CREATE INDEX IF NOT EXISTS idx_contact_inquiries_email ON contact_inquiries (email);

--- a/src/app/contact/ContactForm.client.tsx
+++ b/src/app/contact/ContactForm.client.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useState } from "react";
+import { Send, User, Mail, MessageSquare, Building2, CheckCircle2, AlertCircle } from "lucide-react";
+import { supabase } from "@/lib/supabase";
+
+interface ContactFormData {
+  company: string;
+  name: string;
+  email: string;
+  message: string;
+}
+
+export default function ContactForm() {
+  const [formData, setFormData] = useState<ContactFormData>({
+    company: "",
+    name: "",
+    email: "",
+    message: "",
+  });
+  const [errors, setErrors] = useState<Partial<Record<keyof ContactFormData, string>>>({});
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSubmitted, setIsSubmitted] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const { name, value } = e.target as HTMLInputElement;
+    setFormData((p) => ({ ...p, [name]: value }));
+    setErrors((prev) => ({ ...prev, [name]: undefined }));
+    setSubmitError(null);
+  };
+
+  const validate = () => {
+    const next: Partial<Record<keyof ContactFormData, string>> = {};
+    if (!formData.company.trim()) next.company = "Company name is required";
+    if (!formData.name.trim()) next.name = "Contact name is required";
+    if (!formData.email.trim()) next.email = "Work email is required";
+    else {
+      const re = /^\S+@\S+\.\S+$/;
+      if (!re.test(formData.email)) next.email = "Enter a valid work email";
+    }
+    return next;
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitError(null);
+    const v = validate();
+    if (Object.keys(v).length) {
+      setErrors(v);
+      return;
+    }
+
+    setIsLoading(true);
+
+    try {
+      if (!supabase) {
+        setSubmitError("Contact is not configured. Please try again later.");
+        setIsLoading(false);
+        return;
+      }
+
+      const { error: sbError } = await supabase.from("contact_inquiries").insert([
+        {
+          company: formData.company,
+          contact_name: formData.name,
+          email: formData.email,
+          message: formData.message,
+        },
+      ]);
+
+      if (sbError) {
+        setSubmitError("Something went wrong. Please try again.");
+        setIsLoading(false);
+        return;
+      }
+
+      setIsSubmitted(true);
+    } catch (err) {
+      setSubmitError("Network error. Please check your connection and try again.");
+      setIsLoading(false);
+    }
+  };
+
+  if (isSubmitted) {
+    return (
+      <div className="py-24 bg-transparent flex flex-col items-center justify-center text-center px-6">
+        <div className="w-20 h-20 rounded-3xl bg-bg-elevated shadow-neu-raised flex items-center justify-center mb-8 animate-fadeInScale">
+          <CheckCircle2 size={40} className="text-theme-primary" />
+        </div>
+        <h2 className="text-3xl font-black text-content-primary tracking-tight mb-4">Thanks — we&apos;ll be in touch</h2>
+        <p className="text-content-secondary max-w-sm font-medium">A member of our enterprise team will reach out to you shortly to discuss your inquiry.</p>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="p-8 rounded-[2.5rem] bg-bg-elevated shadow-neu-raised flex flex-col gap-6">
+      {submitError && (
+        <div className="p-4 rounded-2xl bg-red-50 dark:bg-red-950/50 border border-red-200 dark:border-red-800 flex items-start gap-3 animate-fadeIn">
+          <AlertCircle size={20} className="text-red-500 flex-shrink-0 mt-0.5" />
+          <p className="text-sm text-red-700 dark:text-red-400 font-medium">{submitError}</p>
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div className="flex flex-col gap-2">
+          <label className="text-[10px] font-black uppercase tracking-widest text-content-secondary ml-2">Company Name</label>
+          <div className="relative group">
+            <Building2 size={16} className="absolute left-5 top-1/2 -translate-y-1/2 text-content-muted group-focus-within:text-theme-primary transition-colors" />
+            <input name="company" value={formData.company} onChange={handleInputChange} required className={`w-full pl-12 pr-6 py-3.5 rounded-xl bg-bg-sunken shadow-neu-sunken-subtle text-sm text-content-primary placeholder:text-content-muted border-none outline-none focus:ring-2 focus:ring-theme-primary transition-all font-medium ${errors.company ? 'ring-1 ring-red-400' : ''}`} placeholder="Company, LLC" disabled={isLoading} />
+            {errors.company && <p className="text-xs text-red-600 mt-1 pl-2">{errors.company}</p>}
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <label className="text-[10px] font-black uppercase tracking-widest text-content-secondary ml-2">Contact Name</label>
+          <div className="relative group">
+            <User size={16} className="absolute left-5 top-1/2 -translate-y-1/2 text-content-muted group-focus-within:text-theme-primary transition-colors" />
+            <input name="name" value={formData.name} onChange={handleInputChange} required className={`w-full pl-12 pr-6 py-3.5 rounded-xl bg-bg-sunken shadow-neu-sunken-subtle text-sm text-content-primary placeholder:text-content-muted border-none outline-none focus:ring-2 focus:ring-theme-primary transition-all font-medium ${errors.name ? 'ring-1 ring-red-400' : ''}`} placeholder="Jane Doe" disabled={isLoading} />
+            {errors.name && <p className="text-xs text-red-600 mt-1 pl-2">{errors.name}</p>}
+          </div>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <label className="text-[10px] font-black uppercase tracking-widest text-content-secondary ml-2">Work Email</label>
+        <div className="relative group">
+          <Mail size={16} className="absolute left-5 top-1/2 -translate-y-1/2 text-content-muted group-focus-within:text-theme-primary transition-colors" />
+          <input name="email" type="email" value={formData.email} onChange={handleInputChange} required className={`w-full pl-12 pr-6 py-3.5 rounded-xl bg-bg-sunken shadow-neu-sunken-subtle text-sm text-content-primary placeholder:text-content-muted border-none outline-none focus:ring-2 focus:ring-theme-primary transition-all font-medium ${errors.email ? 'ring-1 ring-red-400' : ''}`} placeholder="you@company.com" disabled={isLoading} />
+          {errors.email && <p className="text-xs text-red-600 mt-1 pl-2">{errors.email}</p>}
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <label className="text-[10px] font-black uppercase tracking-widest text-content-secondary ml-2">Use case / Message (optional)</label>
+        <div className="relative group">
+          <MessageSquare size={16} className="absolute left-5 top-6 text-content-muted group-focus-within:text-theme-primary transition-colors" />
+          <textarea name="message" rows={4} value={formData.message} onChange={handleInputChange} placeholder="Tell us about your integration, expected volume, or key requirements..." disabled={isLoading} className="w-full pl-12 pr-6 py-3.5 rounded-xl bg-bg-sunken shadow-neu-sunken-subtle text-sm text-content-primary placeholder:text-content-muted border-none outline-none focus:ring-2 focus:ring-theme-primary transition-all font-medium resize-none disabled:opacity-50 disabled:cursor-not-allowed" />
+        </div>
+      </div>
+
+      <button type="submit" disabled={isLoading} className="btn-neumorphic-primary mt-2 w-full py-5 rounded-2xl text-[11px] font-black uppercase tracking-[0.25em] flex items-center justify-center gap-3 group disabled:opacity-50 disabled:cursor-not-allowed">
+        {isLoading ? 'Submitting...' : 'Contact Sales'}
+        <Send size={14} className="group-hover:translate-x-1 group-hover:-translate-y-1 transition-transform" />
+      </button>
+    </form>
+  );
+}

--- a/src/app/contact/ContactForm.client.tsx
+++ b/src/app/contact/ContactForm.client.tsx
@@ -76,7 +76,7 @@ export default function ContactForm() {
       }
 
       setIsSubmitted(true);
-    } catch (err) {
+    } catch (_err) {
       setSubmitError("Network error. Please check your connection and try again.");
       setIsLoading(false);
     }

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -15,7 +15,7 @@ export default function ContactPage() {
           <div className="text-center mb-12">
             <p className="text-[11px] font-black uppercase tracking-[0.4em] text-theme-primary mb-4">Contact</p>
             <h1 className="text-4xl font-black text-content-primary tracking-tight mb-4">Contact Sales</h1>
-            <p className="text-lg text-content-secondary">Share some details about your company and use case — we'll follow up to discuss enterprise integrations, SLAs, and pricing.</p>
+            <p className="text-lg text-content-secondary">Share some details about your company and use case — we&apos;ll follow up to discuss enterprise integrations, SLAs, and pricing.</p>
           </div>
 
           <ContactForm />

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,9 +1,5 @@
-"use client";
-
-import { useState } from "react";
 import type { Metadata } from "next";
-import { Send, User, Mail, MessageSquare, Building2, CheckCircle2, AlertCircle } from "lucide-react";
-import { supabase } from "@/lib/supabase";
+import ContactForm from "./ContactForm.client";
 
 export const metadata: Metadata = {
   title: "Contact Sales | OFFER-HUB",
@@ -11,97 +7,7 @@ export const metadata: Metadata = {
     "Contact OFFER-HUB sales for enterprise inquiries — tell us about your company, needs, and we'll reach out to discuss enterprise integrations and support.",
 };
 
-interface ContactFormData {
-  company: string;
-  name: string;
-  email: string;
-  message: string;
-}
-
 export default function ContactPage() {
-  const [formData, setFormData] = useState<ContactFormData>({
-    company: "",
-    name: "",
-    email: "",
-    message: "",
-  });
-  const [errors, setErrors] = useState<Partial<Record<keyof ContactFormData, string>>>({});
-  const [isLoading, setIsLoading] = useState(false);
-  const [isSubmitted, setIsSubmitted] = useState(false);
-  const [submitError, setSubmitError] = useState<string | null>(null);
-
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-    const { name, value } = e.target as HTMLInputElement;
-    setFormData((p) => ({ ...p, [name]: value }));
-    setErrors((prev) => ({ ...prev, [name]: undefined }));
-    setSubmitError(null);
-  };
-
-  const validate = () => {
-    const next: Partial<Record<keyof ContactFormData, string>> = {};
-    if (!formData.company.trim()) next.company = "Company name is required";
-    if (!formData.name.trim()) next.name = "Contact name is required";
-    if (!formData.email.trim()) next.email = "Work email is required";
-    else {
-      // simple email regex
-      const re = /^\S+@\S+\.\S+$/;
-      if (!re.test(formData.email)) next.email = "Enter a valid work email";
-    }
-    return next;
-  };
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setSubmitError(null);
-    const v = validate();
-    if (Object.keys(v).length) {
-      setErrors(v);
-      return;
-    }
-
-    setIsLoading(true);
-
-    try {
-      if (!supabase) {
-        setSubmitError("Contact is not configured. Please try again later.");
-        setIsLoading(false);
-        return;
-      }
-
-      const { error: sbError } = await supabase.from("contact_inquiries").insert([
-        {
-          company: formData.company,
-          contact_name: formData.name,
-          email: formData.email,
-          message: formData.message,
-        },
-      ]);
-
-      if (sbError) {
-        setSubmitError("Something went wrong. Please try again.");
-        setIsLoading(false);
-        return;
-      }
-
-      setIsSubmitted(true);
-    } catch (err) {
-      setSubmitError("Network error. Please check your connection and try again.");
-      setIsLoading(false);
-    }
-  };
-
-  if (isSubmitted) {
-    return (
-      <div className="py-24 bg-transparent flex flex-col items-center justify-center text-center px-6">
-        <div className="w-20 h-20 rounded-3xl bg-bg-elevated shadow-neu-raised flex items-center justify-center mb-8 animate-fadeInScale">
-          <CheckCircle2 size={40} className="text-theme-primary" />
-        </div>
-        <h2 className="text-3xl font-black text-content-primary tracking-tight mb-4">Thanks — we&apos;ll be in touch</h2>
-        <p className="text-content-secondary max-w-sm font-medium">A member of our enterprise team will reach out to you shortly to discuss your inquiry.</p>
-      </div>
-    );
-  }
-
   return (
     <div className="min-h-screen flex flex-col bg-transparent">
       <main className="flex-grow pt-28 pb-20">
@@ -109,59 +15,10 @@ export default function ContactPage() {
           <div className="text-center mb-12">
             <p className="text-[11px] font-black uppercase tracking-[0.4em] text-theme-primary mb-4">Contact</p>
             <h1 className="text-4xl font-black text-content-primary tracking-tight mb-4">Contact Sales</h1>
-            <p className="text-lg text-content-secondary">Share some details about your company and use case — we&apos;ll follow up to discuss enterprise integrations, SLAs, and pricing.</p>
+            <p className="text-lg text-content-secondary">Share some details about your company and use case — we'll follow up to discuss enterprise integrations, SLAs, and pricing.</p>
           </div>
 
-          <form onSubmit={handleSubmit} className="p-8 rounded-[2.5rem] bg-bg-elevated shadow-neu-raised flex flex-col gap-6">
-            {submitError && (
-              <div className="p-4 rounded-2xl bg-red-50 dark:bg-red-950/50 border border-red-200 dark:border-red-800 flex items-start gap-3 animate-fadeIn">
-                <AlertCircle size={20} className="text-red-500 flex-shrink-0 mt-0.5" />
-                <p className="text-sm text-red-700 dark:text-red-400 font-medium">{submitError}</p>
-              </div>
-            )}
-
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              <div className="flex flex-col gap-2">
-                <label className="text-[10px] font-black uppercase tracking-widest text-content-secondary ml-2">Company Name</label>
-                <div className="relative group">
-                  <Building2 size={16} className="absolute left-5 top-1/2 -translate-y-1/2 text-content-muted group-focus-within:text-theme-primary transition-colors" />
-                  <input name="company" value={formData.company} onChange={handleInputChange} required className={`w-full pl-12 pr-6 py-3.5 rounded-xl bg-bg-sunken shadow-neu-sunken-subtle text-sm text-content-primary placeholder:text-content-muted border-none outline-none focus:ring-2 focus:ring-theme-primary transition-all font-medium ${errors.company ? 'ring-1 ring-red-400' : ''}`} placeholder="Company, LLC" disabled={isLoading} />
-                  {errors.company && <p className="text-xs text-red-600 mt-1 pl-2">{errors.company}</p>}
-                </div>
-              </div>
-
-              <div className="flex flex-col gap-2">
-                <label className="text-[10px] font-black uppercase tracking-widest text-content-secondary ml-2">Contact Name</label>
-                <div className="relative group">
-                  <User size={16} className="absolute left-5 top-1/2 -translate-y-1/2 text-content-muted group-focus-within:text-theme-primary transition-colors" />
-                  <input name="name" value={formData.name} onChange={handleInputChange} required className={`w-full pl-12 pr-6 py-3.5 rounded-xl bg-bg-sunken shadow-neu-sunken-subtle text-sm text-content-primary placeholder:text-content-muted border-none outline-none focus:ring-2 focus:ring-theme-primary transition-all font-medium ${errors.name ? 'ring-1 ring-red-400' : ''}`} placeholder="Jane Doe" disabled={isLoading} />
-                  {errors.name && <p className="text-xs text-red-600 mt-1 pl-2">{errors.name}</p>}
-                </div>
-              </div>
-            </div>
-
-            <div className="flex flex-col gap-2">
-              <label className="text-[10px] font-black uppercase tracking-widest text-content-secondary ml-2">Work Email</label>
-              <div className="relative group">
-                <Mail size={16} className="absolute left-5 top-1/2 -translate-y-1/2 text-content-muted group-focus-within:text-theme-primary transition-colors" />
-                <input name="email" type="email" value={formData.email} onChange={handleInputChange} required className={`w-full pl-12 pr-6 py-3.5 rounded-xl bg-bg-sunken shadow-neu-sunken-subtle text-sm text-content-primary placeholder:text-content-muted border-none outline-none focus:ring-2 focus:ring-theme-primary transition-all font-medium ${errors.email ? 'ring-1 ring-red-400' : ''}`} placeholder="you@company.com" disabled={isLoading} />
-                {errors.email && <p className="text-xs text-red-600 mt-1 pl-2">{errors.email}</p>}
-              </div>
-            </div>
-
-            <div className="flex flex-col gap-2">
-              <label className="text-[10px] font-black uppercase tracking-widest text-content-secondary ml-2">Use case / Message (optional)</label>
-              <div className="relative group">
-                <MessageSquare size={16} className="absolute left-5 top-6 text-content-muted group-focus-within:text-theme-primary transition-colors" />
-                <textarea name="message" rows={4} value={formData.message} onChange={handleInputChange} placeholder="Tell us about your integration, expected volume, or key requirements..." disabled={isLoading} className="w-full pl-12 pr-6 py-3.5 rounded-xl bg-bg-sunken shadow-neu-sunken-subtle text-sm text-content-primary placeholder:text-content-muted border-none outline-none focus:ring-2 focus:ring-theme-primary transition-all font-medium resize-none disabled:opacity-50 disabled:cursor-not-allowed" />
-              </div>
-            </div>
-
-            <button type="submit" disabled={isLoading} className="btn-neumorphic-primary mt-2 w-full py-5 rounded-2xl text-[11px] font-black uppercase tracking-[0.25em] flex items-center justify-center gap-3 group disabled:opacity-50 disabled:cursor-not-allowed">
-              {isLoading ? 'Submitting...' : 'Contact Sales'}
-              <Send size={14} className="group-hover:translate-x-1 group-hover:-translate-y-1 transition-transform" />
-            </button>
-          </form>
+          <ContactForm />
         </section>
       </main>
     </div>

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { useState } from "react";
+import type { Metadata } from "next";
+import { Send, User, Mail, MessageSquare, Building2, CheckCircle2, AlertCircle } from "lucide-react";
+import { supabase } from "@/lib/supabase";
+
+export const metadata: Metadata = {
+  title: "Contact Sales | OFFER-HUB",
+  description:
+    "Contact OFFER-HUB sales for enterprise inquiries — tell us about your company, needs, and we'll reach out to discuss enterprise integrations and support.",
+};
+
+interface ContactFormData {
+  company: string;
+  name: string;
+  email: string;
+  message: string;
+}
+
+export default function ContactPage() {
+  const [formData, setFormData] = useState<ContactFormData>({
+    company: "",
+    name: "",
+    email: "",
+    message: "",
+  });
+  const [errors, setErrors] = useState<Partial<Record<keyof ContactFormData, string>>>({});
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSubmitted, setIsSubmitted] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const { name, value } = e.target as HTMLInputElement;
+    setFormData((p) => ({ ...p, [name]: value }));
+    setErrors((prev) => ({ ...prev, [name]: undefined }));
+    setSubmitError(null);
+  };
+
+  const validate = () => {
+    const next: Partial<Record<keyof ContactFormData, string>> = {};
+    if (!formData.company.trim()) next.company = "Company name is required";
+    if (!formData.name.trim()) next.name = "Contact name is required";
+    if (!formData.email.trim()) next.email = "Work email is required";
+    else {
+      // simple email regex
+      const re = /^\S+@\S+\.\S+$/;
+      if (!re.test(formData.email)) next.email = "Enter a valid work email";
+    }
+    return next;
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitError(null);
+    const v = validate();
+    if (Object.keys(v).length) {
+      setErrors(v);
+      return;
+    }
+
+    setIsLoading(true);
+
+    try {
+      if (!supabase) {
+        setSubmitError("Contact is not configured. Please try again later.");
+        setIsLoading(false);
+        return;
+      }
+
+      const { error: sbError } = await supabase.from("contact_inquiries").insert([
+        {
+          company: formData.company,
+          contact_name: formData.name,
+          email: formData.email,
+          message: formData.message,
+        },
+      ]);
+
+      if (sbError) {
+        setSubmitError("Something went wrong. Please try again.");
+        setIsLoading(false);
+        return;
+      }
+
+      setIsSubmitted(true);
+    } catch (err) {
+      setSubmitError("Network error. Please check your connection and try again.");
+      setIsLoading(false);
+    }
+  };
+
+  if (isSubmitted) {
+    return (
+      <div className="py-24 bg-transparent flex flex-col items-center justify-center text-center px-6">
+        <div className="w-20 h-20 rounded-3xl bg-bg-elevated shadow-neu-raised flex items-center justify-center mb-8 animate-fadeInScale">
+          <CheckCircle2 size={40} className="text-theme-primary" />
+        </div>
+        <h2 className="text-3xl font-black text-content-primary tracking-tight mb-4">Thanks — we&apos;ll be in touch</h2>
+        <p className="text-content-secondary max-w-sm font-medium">A member of our enterprise team will reach out to you shortly to discuss your inquiry.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen flex flex-col bg-transparent">
+      <main className="flex-grow pt-28 pb-20">
+        <section className="max-w-3xl mx-auto px-6 lg:px-8">
+          <div className="text-center mb-12">
+            <p className="text-[11px] font-black uppercase tracking-[0.4em] text-theme-primary mb-4">Contact</p>
+            <h1 className="text-4xl font-black text-content-primary tracking-tight mb-4">Contact Sales</h1>
+            <p className="text-lg text-content-secondary">Share some details about your company and use case — we&apos;ll follow up to discuss enterprise integrations, SLAs, and pricing.</p>
+          </div>
+
+          <form onSubmit={handleSubmit} className="p-8 rounded-[2.5rem] bg-bg-elevated shadow-neu-raised flex flex-col gap-6">
+            {submitError && (
+              <div className="p-4 rounded-2xl bg-red-50 dark:bg-red-950/50 border border-red-200 dark:border-red-800 flex items-start gap-3 animate-fadeIn">
+                <AlertCircle size={20} className="text-red-500 flex-shrink-0 mt-0.5" />
+                <p className="text-sm text-red-700 dark:text-red-400 font-medium">{submitError}</p>
+              </div>
+            )}
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div className="flex flex-col gap-2">
+                <label className="text-[10px] font-black uppercase tracking-widest text-content-secondary ml-2">Company Name</label>
+                <div className="relative group">
+                  <Building2 size={16} className="absolute left-5 top-1/2 -translate-y-1/2 text-content-muted group-focus-within:text-theme-primary transition-colors" />
+                  <input name="company" value={formData.company} onChange={handleInputChange} required className={`w-full pl-12 pr-6 py-3.5 rounded-xl bg-bg-sunken shadow-neu-sunken-subtle text-sm text-content-primary placeholder:text-content-muted border-none outline-none focus:ring-2 focus:ring-theme-primary transition-all font-medium ${errors.company ? 'ring-1 ring-red-400' : ''}`} placeholder="Company, LLC" disabled={isLoading} />
+                  {errors.company && <p className="text-xs text-red-600 mt-1 pl-2">{errors.company}</p>}
+                </div>
+              </div>
+
+              <div className="flex flex-col gap-2">
+                <label className="text-[10px] font-black uppercase tracking-widest text-content-secondary ml-2">Contact Name</label>
+                <div className="relative group">
+                  <User size={16} className="absolute left-5 top-1/2 -translate-y-1/2 text-content-muted group-focus-within:text-theme-primary transition-colors" />
+                  <input name="name" value={formData.name} onChange={handleInputChange} required className={`w-full pl-12 pr-6 py-3.5 rounded-xl bg-bg-sunken shadow-neu-sunken-subtle text-sm text-content-primary placeholder:text-content-muted border-none outline-none focus:ring-2 focus:ring-theme-primary transition-all font-medium ${errors.name ? 'ring-1 ring-red-400' : ''}`} placeholder="Jane Doe" disabled={isLoading} />
+                  {errors.name && <p className="text-xs text-red-600 mt-1 pl-2">{errors.name}</p>}
+                </div>
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <label className="text-[10px] font-black uppercase tracking-widest text-content-secondary ml-2">Work Email</label>
+              <div className="relative group">
+                <Mail size={16} className="absolute left-5 top-1/2 -translate-y-1/2 text-content-muted group-focus-within:text-theme-primary transition-colors" />
+                <input name="email" type="email" value={formData.email} onChange={handleInputChange} required className={`w-full pl-12 pr-6 py-3.5 rounded-xl bg-bg-sunken shadow-neu-sunken-subtle text-sm text-content-primary placeholder:text-content-muted border-none outline-none focus:ring-2 focus:ring-theme-primary transition-all font-medium ${errors.email ? 'ring-1 ring-red-400' : ''}`} placeholder="you@company.com" disabled={isLoading} />
+                {errors.email && <p className="text-xs text-red-600 mt-1 pl-2">{errors.email}</p>}
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <label className="text-[10px] font-black uppercase tracking-widest text-content-secondary ml-2">Use case / Message (optional)</label>
+              <div className="relative group">
+                <MessageSquare size={16} className="absolute left-5 top-6 text-content-muted group-focus-within:text-theme-primary transition-colors" />
+                <textarea name="message" rows={4} value={formData.message} onChange={handleInputChange} placeholder="Tell us about your integration, expected volume, or key requirements..." disabled={isLoading} className="w-full pl-12 pr-6 py-3.5 rounded-xl bg-bg-sunken shadow-neu-sunken-subtle text-sm text-content-primary placeholder:text-content-muted border-none outline-none focus:ring-2 focus:ring-theme-primary transition-all font-medium resize-none disabled:opacity-50 disabled:cursor-not-allowed" />
+              </div>
+            </div>
+
+            <button type="submit" disabled={isLoading} className="btn-neumorphic-primary mt-2 w-full py-5 rounded-2xl text-[11px] font-black uppercase tracking-[0.25em] flex items-center justify-center gap-3 group disabled:opacity-50 disabled:cursor-not-allowed">
+              {isLoading ? 'Submitting...' : 'Contact Sales'}
+              <Send size={14} className="group-hover:translate-x-1 group-hover:-translate-y-1 transition-transform" />
+            </button>
+          </form>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -71,9 +71,9 @@ const tiers: PricingTier[] = [
       "Custom support scope based on your business needs",
     ],
     ctaLabel: "Talk to Sales",
-    ctaHref: "https://t.me/offer_hub_contributors",
+    ctaHref: "/contact",
     ctaStyle: "secondary",
-    external: true,
+    external: false,
     icon: Building2,
   },
 ];
@@ -149,14 +149,9 @@ export default function PricingPage() {
           <p className="mt-10 text-center text-sm text-content-secondary">
             Need help choosing the right setup? Reach us through our
             {" "}
-            <a
-              href="https://t.me/offer_hub_contributors"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-theme-primary font-semibold hover:underline"
-            >
+            <Link href="/contact" className="text-theme-primary font-semibold hover:underline">
               contact channel
-            </a>
+            </Link>
             {" "}
             and we can recommend a path based on your business stage.
           </p>

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -12,6 +12,7 @@ const navColumns = [
     links: [
       { href: "/", label: "Home" },
       { href: "/pricing", label: "Pricing" },
+        { href: "/contact", label: "Contact" },
       { href: "/docs", label: "Docs" },
       { href: "/community", label: "Community" },
     ],


### PR DESCRIPTION
Added a dedicated enterprise contact form and wired up the UI/links. This PR adds page.tsx (neumorphic contact form that validates input and inserts into Supabase client-side), updates the Enterprise CTA on the Pricing page to `/contact`, and adds a `Contact` link in the footer. I also included DB migration contact_inquiries.sql and docs contact-inquiries.md describing the `contact_inquiries` schema; no backend route was added
Closed #1317 