### PR TITLE
feat: Add loading.tsx skeleton screens for /terms and /privacy pages

### DIFF
--- a/src/app/privacy/loading.tsx
+++ b/src/app/privacy/loading.tsx
@@ -1,0 +1,151 @@
+import { Footer } from "@/components/layout/Footer";
+import { Navbar } from "@/components/layout/Navbar";
+
+function HeaderSkeleton() {
+  return (
+    <div className="text-center mb-20">
+      <div className="h-3 w-24 bg-[#e5e7eb] rounded mx-auto mb-4 animate-pulse"></div>
+      <div className="h-10 w-60 bg-[#e5e7eb] rounded mx-auto mb-6 animate-pulse"></div>
+      <div className="h-4 w-full bg-[#e5e7eb] rounded mx-auto mb-4 animate-pulse"></div>
+      <div className="mt-8 inline-flex items-center gap-2 px-4 py-2 rounded-full bg-[#e5e7eb] text-xs font-bold text-content-secondary animate-pulse">
+        <div className="h-3 w-16 bg-gray-300 rounded"></div>
+      </div>
+    </div>
+  );
+}
+
+function FeatureSkeleton() {
+  return (
+    <div className="p-10 rounded-[2.5rem] bg-[#e5e7eb] shadow-raised flex flex-col gap-6 animate-pulse">
+      <div className="w-14 h-14 rounded-2xl shadow-raised flex items-center justify-center shrink-0 bg-[#e5e7eb]"></div>
+      <div>
+        <h3 className="h-6 w-24 bg-gray-300 rounded mb-4"></h3>
+        <p className="h-3 w-full bg-gray-300 rounded"></p>
+      </div>
+    </div>
+  );
+}
+
+function ProcessorSkeleton() {
+  return (
+    <div className="p-8 rounded-[2rem] bg-[#e5e7eb] shadow-raised flex flex-col gap-4 border animate-pulse">
+      <div className="flex items-center justify-between">
+        <h3 className="h-5 w-20 bg-gray-300 rounded"></h3>
+        <a className="text-xs font-bold text-theme-primary hover:underline flex items-center gap-1">
+          <div className="h-3 w-16 bg-gray-300 rounded"></div>
+        </a>
+      </div>
+      <div className="space-y-4">
+        <div>
+          <span className="text-[10px] font-black uppercase tracking-widest text-content-secondary block mb-1"></span>
+          <p className="h-3 w-full bg-gray-300 rounded"></p>
+        </div>
+        <div>
+          <span className="text-[10px] font-black uppercase tracking-widest text-content-secondary block mb-1"></span>
+          <p className="h-3 w-full bg-gray-300 rounded"></p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ContactCardSkeleton() {
+  return (
+    <div className="p-8 sm:p-12 md:p-14 rounded-[3rem] shadow-raised flex flex-col md:flex-row md:items-center md:justify-between gap-10 md:gap-14 mt-16 bg-[#e5e7eb]">
+      <div className="flex flex-col gap-6 md:max-w-md">
+        <div className="w-14 h-14 rounded-2xl shadow-raised flex items-center justify-center shrink-0 bg-[#e5e7eb]"></div>
+        <div>
+          <h2 className="h-8 w-32 bg-gray-300 rounded mb-4 animate-pulse"></h2>
+          <p className="h-3 w-full bg-gray-300 rounded animate-pulse"></p>
+        </div>
+      </div>
+      <div className="flex flex-col gap-5 w-full md:w-auto md:shrink-0 md:min-w-[280px]">
+        <a className="flex flex-col gap-1 rounded-2xl px-6 py-5 transition-all duration-300 shadow-raised bg-[#e5e7eb] hover:shadow-raised group">
+          <span className="text-[10px] font-black uppercase tracking-widest text-content-secondary"></span>
+          <span className="text-base font-bold text-theme-primary group-hover:text-content-primary transition-colors"></span>
+        </a>
+        <a className="flex flex-col gap-1 rounded-2xl px-6 py-5 transition-all duration-300 shadow-raised bg-[#e5e7eb] hover:shadow-raised group">
+          <span className="text-[10px] font-black uppercase tracking-widest text-content-secondary"></span>
+          <span className="text-base font-bold text-theme-primary group-hover:text-content-primary transition-colors"></span>
+        </a>
+        <div className="rounded-2xl px-6 py-5 shadow-raised bg-[#e5e7eb]">
+          <p className="text-xs leading-relaxed font-medium text-content-secondary">
+            Offer Hub Inc.
+            <br />
+            123 Market Street, Suite 400
+            <br />
+            San Francisco, CA 94105, USA
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function DataRightsSkeleton() {
+  return (
+    <div className="mt-16">
+      <div className="text-center mb-10">
+        <div className="h-3 w-16 bg-[#e5e7eb] rounded mx-auto mb-3 animate-pulse"></div>
+        <h2 className="h-8 w-32 bg-[#e5e7eb] rounded mx-auto mb-4 animate-pulse"></h2>
+        <p className="h-3 w-full bg-gray-300 rounded mx-auto max-w-xl animate-pulse"></p>
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <div className="p-8 sm:p-10 rounded-[2.5rem] bg-[#e5e7eb] shadow-raised flex flex-col gap-6 animate-pulse">
+          <div className="w-14 h-14 rounded-2xl shadow-raised flex items-center justify-center shrink-0 bg-[#e5e7eb]"></div>
+          <div>
+            <h3 className="h-5 w-24 bg-gray-300 rounded mb-2"></h3>
+            <p className="h-3 w-full bg-gray-300 rounded"></p>
+          </div>
+          <div className="h-10 w-full bg-gray-300 rounded"></div>
+          <div className="h-10 w-full bg-gray-300 rounded"></div>
+        </div>
+        <div className="p-8 sm:p-10 rounded-[2.5rem] bg-[#e5e7eb] shadow-raised flex flex-col gap-6 animate-pulse">
+          <div className="w-14 h-14 rounded-2xl shadow-raised flex items-center justify-center shrink-0 bg-[#e5e7eb]"></div>
+          <div>
+            <h3 className="h-5 w-24 bg-gray-300 rounded mb-2"></h3>
+            <p className="h-3 w-full bg-gray-300 rounded"></p>
+          </div>
+          <div className="h-10 w-full bg-gray-300 rounded"></div>
+          <div className="h-10 w-full bg-gray-300 rounded"></div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function PrivacyLoading() {
+  return (
+    <>
+      <Navbar />
+      <main className="flex-grow pt-24 sm:pt-28 md:pt-32 pb-16 sm:pb-20 px-4 sm:px-8 md:px-12 lg:px-24">
+        <HeaderSkeleton />
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6 sm:gap-8 lg:gap-10 mb-5">
+          <FeatureSkeleton />
+          <FeatureSkeleton />
+          <FeatureSkeleton />
+        </div>
+
+        <div className="mt-24 mb-24">
+          <div className="flex flex-col gap-6 mb-12">
+            <h2 className="h-6 w-40 bg-gray-300 rounded mb-4 animate-pulse"></h2>
+            <p className="h-3 w-full bg-gray-300 rounded animate-pulse"></p>
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <ProcessorSkeleton />
+            <ProcessorSkeleton />
+            <ProcessorSkeleton />
+            <ProcessorSkeleton />
+            <ProcessorSkeleton />
+          </div>
+        </div>
+
+        <ContactCardSkeleton />
+
+        <DataRightsSkeleton />
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/src/app/terms/loading.tsx
+++ b/src/app/terms/loading.tsx
@@ -1,0 +1,65 @@
+import { Footer } from "@/components/layout/Footer";
+import { Navbar } from "@/components/layout/Navbar";
+
+function HeaderSkeleton() {
+  return (
+    <header className="text-center mb-20">
+      <div className="h-3 w-24 bg-[#e5e7eb] rounded mx-auto mb-4 animate-pulse"></div>
+      <div className="h-10 w-60 bg-[#e5e7eb] rounded mx-auto mb-6 animate-pulse"></div>
+      <div className="h-4 w-full bg-[#e5e7eb] rounded mx-auto mb-8 animate-pulse"></div>
+      <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-[#e5e7eb] text-xs font-bold text-content-secondary animate-pulse">
+        <div className="h-3 w-16 bg-gray-300 rounded"></div>
+      </div>
+    </header>
+  );
+}
+
+function SectionSkeleton() {
+  return (
+    <div className="p-8 md:p-12 rounded-[2.5rem] bg-[#e5e7eb] shadow-raised animate-pulse">
+      <div className="flex items-center gap-5 mb-8">
+        <div className="w-12 h-12 rounded-xl flex items-center justify-center bg-[#e5e7eb] shadow-raised"></div>
+        <div className="h-8 w-48 bg-gray-300 rounded"></div>
+      </div>
+      <div className="space-y-4">
+        <div className="h-4 w-full bg-gray-300 rounded"></div>
+        <div className="h-4 w-5/6 bg-gray-300 rounded"></div>
+        <div className="h-4 w-4/5 bg-gray-300 rounded"></div>
+        <div className="h-4 w-full bg-gray-300 rounded"></div>
+        <div className="h-4 w-3/4 bg-gray-300 rounded"></div>
+      </div>
+    </div>
+  );
+}
+
+function DisclaimerSkeleton() {
+  return (
+    <div className="p-8 md:p-10 rounded-[2.5rem] bg-[#e5e7eb] shadow-raised animate-pulse">
+      <div className="h-3 w-full bg-gray-300 rounded mb-4"></div>
+      <div className="h-3 w-3/4 bg-gray-300 rounded mb-2"></div>
+      <div className="h-3 w-full bg-gray-300 rounded"></div>
+    </div>
+  );
+}
+
+export default function TermsLoading() {
+  return (
+    <>
+      <Navbar />
+      <main className="pt-32 pb-24 px-6 lg:px-8">
+        <div className="max-w-4xl mx-auto">
+          <HeaderSkeleton />
+          <div className="space-y-12">
+            <SectionSkeleton />
+            <SectionSkeleton />
+            <SectionSkeleton />
+            <SectionSkeleton />
+            <SectionSkeleton />
+            <DisclaimerSkeleton />
+          </div>
+        </div>
+      </main>
+      <Footer />
+    </>
+  );
+}


### PR DESCRIPTION
# 📝 Pull Request 

## 🔧 Title: 

- feat: Add loading.tsx skeleton screens for /terms and /privacy pages

## 🛠️ Issue

- Closes #1314

## 📚 Description

- Adds skeleton loading screens for `/terms` and `/privacy` routes to provide visual feedback during page load, addressing the blank white screen issue on slower connections and ensuring consistency with other major routes in the platform.

## ✅ Changes applied

- `src/app/terms/loading.tsx` - Skeleton with header and 5-6 content sections approximating the terms page layout (heading block, subtitle block, and 5 content section rows with varying widths)
- `src/app/privacy/loading.tsx` - Skeleton with header, features grid, processors list, contact card, and data rights sections

Both skeletons use `bg-[#e5e7eb]` for placeholder blocks and shadow-raised utility, consistent with the existing pattern in `src/app/community/loading.tsx`. Neither file imports or depends on the actual page components — pure static skeleton only.

## 🔍 Evidence/Media (screenshots/videos)

- Lint check passes with no errors related to the new loading files