### PR TITLE
Fix/migrate to crypto randomuuid

### DIFF
--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,36 +1,14 @@
 import { supabase, isSupabaseConfigured } from './supabase';
 
-// Generate a unique visitor ID (fingerprint)
+// Generate a unique visitor ID
 export function generateVisitorId(): string {
-  const getOrCreateVisitorId = () => {
-    if (localStorage.getItem('cookie_consent') !== 'accepted') return '';
-    const stored = localStorage.getItem('visitor_id');
-    if (stored) return stored;
+  if (localStorage.getItem('cookie_consent') !== 'accepted') return '';
+  const stored = localStorage.getItem('visitor_id');
+  if (stored) return stored;
 
-    // Create fingerprint from available browser data
-    const fingerprint = [
-      navigator.userAgent,
-      navigator.language,
-      new Date().getTimezoneOffset(),
-      screen.width,
-      screen.height,
-      screen.colorDepth,
-    ].join('|');
-
-    // Simple hash function
-    let hash = 0;
-    for (let i = 0; i < fingerprint.length; i++) {
-      const char = fingerprint.charCodeAt(i);
-      hash = (hash << 5) - hash + char;
-      hash = hash & hash; // Convert to 32-bit integer
-    }
-
-    const visitorId = `visitor_${Math.abs(hash)}_${Date.now()}`;
-    localStorage.setItem('visitor_id', visitorId);
-    return visitorId;
-  };
-
-  return getOrCreateVisitorId();
+  const visitorId = `visitor_${crypto.randomUUID()}`;
+  localStorage.setItem('visitor_id', visitorId);
+  return visitorId;
 }
 
 // Get device type
@@ -74,7 +52,7 @@ export function getSessionId(): string {
   const stored = sessionStorage.getItem('session_id');
   if (stored) return stored;
 
-  const sessionId = `session_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+  const sessionId = `session_${crypto.randomUUID()}`;
   sessionStorage.setItem('session_id', sessionId);
   return sessionId;
 }


### PR DESCRIPTION
# 📝 Pull Request 
## 🔧 Title:
Fix visitor/session ID generation using crypto.randomUUID()
## 🛠️ Issue
- Closes #1318
## 📚 Description
- Migrate generateVisitorId() and getSessionId() to crypto.randomUUID()
- Replace fingerprint hash loop with cryptographically secure UUID generation
- Replace deprecated Math.random().toString(36).substr(2, 9) with crypto.randomUUID()
- Remove unused fingerprint array and hash loop code

## Changes applied
- `generateVisitorId()`: Replaced fingerprint hash loop with `crypto.randomUUID()`, removed fingerprint array (userAgent, language, timezone, screen dimensions)
- `getSessionId()`: Replaced `Math.random().toString(36).substr(2, 9)` with `crypto.randomUUID()`, eliminated deprecated `.substr()` method
- Both functions retain localStorage/sessionStorage persistence patterns for returning users

## 🔍 Evidence/Media (screenshots/videos)
- No visual changes - analytics backend identifiers only