### PR TITLE
feat: Show keyboard shortcut hint (⌘K / Ctrl+K) inside DocsSearchBar input #1316

### DIFF
--- a/src/components/docs/DocsSearchBar.tsx
+++ b/src/components/docs/DocsSearchBar.tsx
@@ -20,6 +20,8 @@ export default function DocsSearchBar() {
     const [results, setResults] = useState<FuseResult<SearchResult>[]>([]);
     const [isOpen, setIsOpen] = useState(false);
     const [activeIndex, setActiveIndex] = useState(-1);
+    const [isMac, setIsMac] = useState<boolean | null>(null);
+    const [inputFocused, setInputFocused] = useState(false);
     const searchRef = useRef<HTMLDivElement>(null);
     const inputRef = useRef<HTMLInputElement>(null);
     const router = useRouter();
@@ -76,6 +78,13 @@ export default function DocsSearchBar() {
         return () => document.removeEventListener("keydown", handleKeyDown);
     }, []);
 
+    // Detect OS for keyboard shortcut display
+    useEffect(() => {
+        const userAgent = navigator.userAgent || navigator.platform;
+        const isMacOS = /Mac|iPhone|iPad|iPod/.test(userAgent);
+        setIsMac(isMacOS);
+    }, []);
+
     const handleKeyDown = (e: React.KeyboardEvent) => {
         if (e.key === "ArrowDown") {
             e.preventDefault();
@@ -129,6 +138,8 @@ export default function DocsSearchBar() {
                         value={query}
                         onChange={(e) => setQuery(e.target.value)}
                         onKeyDown={handleKeyDown}
+                        onFocus={() => setInputFocused(true)}
+                        onBlur={() => setInputFocused(false)}
                         role="combobox"
                         aria-expanded={isOpen && results.length > 0}
                         aria-haspopup="listbox"
@@ -145,16 +156,13 @@ export default function DocsSearchBar() {
                         >
                             <X size={18} />
                         </button>
-                    ) : (
-                        <div className="flex items-center gap-1.5 pointer-events-none text-content-secondary">
-                            <kbd className="flex items-center justify-center min-w-[24px] h-[24px] text-[11px] font-sans font-medium rounded-md shadow-neu-raised-sm bg-bg-base text-content-primary">
-                                ⌘
-                            </kbd>
-                            <kbd className="flex items-center justify-center min-w-[24px] h-[24px] text-[11px] font-sans font-medium rounded-md shadow-neu-raised-sm bg-bg-base text-content-primary">
-                                K
-                            </kbd>
+                    ) : !inputFocused && isMac !== null ? (
+                        <div className="flex items-center gap-1 pointer-events-none text-content-secondary px-2 py-1 rounded-md bg-bg-base shadow-neu-raised-sm">
+                            <span className="text-[11px] font-medium text-content-secondary">
+                                {isMac ? '⌘K' : 'Ctrl K'}
+                            </span>
                         </div>
-                    )}
+                    ) : null}
                 </div>
             </div>
 

--- a/src/components/docs/__tests__/DocsSearchBar.test.tsx
+++ b/src/components/docs/__tests__/DocsSearchBar.test.tsx
@@ -1,0 +1,183 @@
+/**
+ * Manual Test Cases for DocsSearchBar Keyboard Shortcut Badge
+ * Issue #1316: Show keyboard shortcut hint (⌘K / Ctrl+K) inside DocsSearchBar input
+ * 
+ * These tests verify the keyboard shortcut badge functionality added to DocsSearchBar
+ */
+
+// TEST CASE 1: OS Detection
+// DESCRIPTION: Badge should show OS-specific keyboard shortcut
+// STEPS:
+//   1. Open the documentation page in a browser
+//   2. Locate the DocsSearchBar component
+// EXPECTED RESULTS:
+//   - On macOS: Badge displays "⌘K"
+//   - On Windows/Linux: Badge displays "Ctrl K"
+// STATUS: Manual - Requires browser testing on different OS
+
+// TEST CASE 2: Badge Visibility on Page Load
+// DESCRIPTION: Badge should be visible when page loads and input is not focused
+// STEPS:
+//   1. Navigate to documentation page
+//   2. Wait for page to fully load
+// EXPECTED RESULTS:
+//   - Keyboard shortcut badge is visible on the right side of the search input
+//   - Badge has text-content-secondary color (muted appearance)
+//   - Badge has shadow-neu-raised-sm styling
+// STATUS: Manual
+
+// TEST CASE 3: Badge Disappears on Input Focus
+// DESCRIPTION: Badge should disappear when user focuses the input field
+// STEPS:
+//   1. Open documentation page
+//   2. Click on the search input or press Tab to focus it
+// EXPECTED RESULTS:
+//   - Badge disappears when input receives focus
+//   - Badge reappears when input loses focus (unless there's text)
+// STATUS: Manual
+
+// TEST CASE 4: Badge Disappears When Text is Entered
+// DESCRIPTION: Badge should disappear when user types in the search input
+// STEPS:
+//   1. Open documentation page
+//   2. Type any character in the search input
+// EXPECTED RESULTS:
+//   - Badge disappears as soon as first character is typed
+//   - Clear button (X) appears instead
+//   - Badge reappears when all text is cleared
+// STATUS: Manual
+
+// TEST CASE 5: Badge Styling Consistency
+// DESCRIPTION: Badge should match the neumorphic design system
+// STEPS:
+//   1. Inspect the badge element in DevTools
+//   2. Compare styling to design tokens
+// EXPECTED RESULTS:
+//   - Background: bg-bg-base (matches input background)
+//   - Shadow: shadow-neu-raised-sm (neumorphic raised effect)
+//   - Text color: text-content-secondary (muted text)
+//   - Font size: text-[11px] (small badge text)
+//   - Padding: px-2 py-1 (compact pill shape)
+//   - Border radius: rounded-md (slightly rounded corners)
+// STATUS: Manual - DevTools inspection
+
+// TEST CASE 6: Keyboard Shortcut Functionality Unchanged
+// DESCRIPTION: Cmd+K / Ctrl+K keyboard shortcut should still focus the input
+// STEPS:
+//   1. Open documentation page
+//   2. Press Cmd+K on macOS or Ctrl+K on Windows/Linux
+// EXPECTED RESULTS:
+//   - Input field receives focus (cursor appears)
+//   - Browser does not perform default action (e.g., browser search)
+//   - Badge disappears when input is focused
+// STATUS: Manual
+
+// TEST CASE 7: State Management - Focus/Blur Cycle
+// DESCRIPTION: Badge should correctly track focus state changes
+// STEPS:
+//   1. Open documentation page
+//   2. Click input to focus
+//   3. Click outside to blur
+//   4. Repeat 5 times quickly
+// EXPECTED RESULTS:
+//   - Badge appears/disappears smoothly with each focus/blur
+//   - No visual glitches or flickering
+//   - No console errors
+// STATUS: Manual
+
+// TEST CASE 8: SSR Hydration
+// DESCRIPTION: Component should not cause hydration mismatch
+// STEPS:
+//   1. Enable React Strict Mode in dev tools if available
+//   2. Open documentation page
+//   3. Check browser console
+// EXPECTED RESULTS:
+//   - No hydration errors in console
+//   - Badge appears correctly after hydration
+//   - Component functions properly after hydration
+// STATUS: Automated verification needed
+
+// TEST CASE 9: Mobile Responsiveness
+// DESCRIPTION: Badge should be properly sized and positioned on mobile
+// STEPS:
+//   1. Open documentation page on mobile device or device emulation
+//   2. View search input and badge
+// EXPECTED RESULTS:
+//   - Badge is visible and readable on small screens
+//   - Badge does not overlap with text or clear button
+//   - Touch interactions work correctly
+// STATUS: Manual
+
+// TEST CASE 10: Multiple Focus/Clear Cycles
+// DESCRIPTION: Badge behavior should be consistent across multiple interactions
+// STEPS:
+//   1. Focus input, blur, focus again
+//   2. Type text, clear text, repeat
+// EXPECTED RESULTS:
+//   - Badge appearance/disappearance is consistent
+//   - No state corruption
+//   - Component remains responsive
+// STATUS: Manual
+
+export const TEST_CASES = [
+  {
+    id: 1,
+    name: "OS Detection",
+    description: "Badge shows OS-specific keyboard shortcut",
+    manual: true,
+  },
+  {
+    id: 2,
+    name: "Badge Visibility on Load",
+    description: "Badge is visible on page load",
+    manual: true,
+  },
+  {
+    id: 3,
+    name: "Badge Disappears on Focus",
+    description: "Badge disappears when input is focused",
+    manual: true,
+  },
+  {
+    id: 4,
+    name: "Badge Disappears When Text Entered",
+    description: "Badge disappears when user types",
+    manual: true,
+  },
+  {
+    id: 5,
+    name: "Badge Styling Consistency",
+    description: "Badge matches neumorphic design",
+    manual: true,
+  },
+  {
+    id: 6,
+    name: "Keyboard Shortcut Functionality",
+    description: "Cmd+K / Ctrl+K still works correctly",
+    manual: true,
+  },
+  {
+    id: 7,
+    name: "Focus/Blur Cycle",
+    description: "Badge tracks focus state changes",
+    manual: true,
+  },
+  {
+    id: 8,
+    name: "SSR Hydration",
+    description: "No hydration mismatch",
+    manual: true,
+  },
+  {
+    id: 9,
+    name: "Mobile Responsiveness",
+    description: "Badge displays correctly on mobile",
+    manual: true,
+  },
+  {
+    id: 10,
+    name: "Multiple Focus/Clear Cycles",
+    description: "Consistent behavior across interactions",
+    manual: true,
+  },
+];


### PR DESCRIPTION
## Summary
Add a keyboard shortcut badge inside the DocsSearchBar input that displays ⌘K on macOS and Ctrl+K on Windows/Linux, improving discoverability of the search shortcut.

## Changes
- Add OS detection to show ⌘K on macOS and Ctrl+K on Windows/Linux
- Badge appears on right side of search input when idle
- Badge disappears when input is focused or text is entered
- Styled as small muted pill with shadow-neu-raised-sm and bg-bg-base tokens
- Added inputFocused state to track input focus
- Added isMac state to store OS detection result
- useEffect hook detects OS using navigator.userAgent
- No changes to existing keyboard shortcut listener behavior

## Acceptance Criteria Met
✅ Add a keyboard shortcut badge inside the search input on its right side
✅ Display ⌘K on macOS and Ctrl K on Windows/Linux
✅ Detect the OS client-side using navigator.userAgent inside useEffect
✅ Badge disappears when input is focused or when query is non-empty
✅ Styled as small muted pill with neumorphic tokens (shadow-neu-raised-sm, bg-bg-base, text-content-secondary)
✅ Only renders client-side using useState initialized to null
✅ No changes to existing shortcut listener behavior

Closes #1316