### PR TITLE
feat: add cookie preferences footer link

### DIFF
--- a/src/components/CookieConsentBanner.tsx
+++ b/src/components/CookieConsentBanner.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
 
 const CONSENT_KEY = "cookie_consent";
+const COOKIE_PREFERENCES_EVENT = "cookie-preferences-open";
 
 export default function CookieConsentBanner() {
   const [visible, setVisible] = useState(false);
@@ -12,6 +13,19 @@ export default function CookieConsentBanner() {
     if (!localStorage.getItem(CONSENT_KEY)) {
       setVisible(true);
     }
+
+    const handleOpenPreferences = () => {
+      setVisible(true);
+    };
+
+    window.addEventListener(COOKIE_PREFERENCES_EVENT, handleOpenPreferences);
+
+    return () => {
+      window.removeEventListener(
+        COOKIE_PREFERENCES_EVENT,
+        handleOpenPreferences
+      );
+    };
   }, []);
 
   const accept = () => {
@@ -37,6 +51,7 @@ export default function CookieConsentBanner() {
         <p className="text-[10px] font-black uppercase tracking-[0.3em] text-theme-primary">
           Privacy Notice
         </p>
+
         <p className="text-sm leading-relaxed text-content-secondary">
           We use cookies and analytics to improve your experience. Read our{" "}
           <Link
@@ -47,6 +62,7 @@ export default function CookieConsentBanner() {
           </Link>{" "}
           to learn what data is collected and how it is used.
         </p>
+
         <div className="flex gap-3">
           <button
             type="button"
@@ -55,6 +71,7 @@ export default function CookieConsentBanner() {
           >
             Accept all
           </button>
+
           <button
             type="button"
             onClick={reject}

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -6,6 +6,8 @@ import Link from "next/link";
 import { Twitter, Send, Github, Disc3 } from "lucide-react";
 import { useTheme } from "@/components/providers/ThemeProvider";
 
+const COOKIE_PREFERENCES_EVENT = "cookie-preferences-open";
+
 const navColumns = [
   {
     heading: "Platform",
@@ -29,6 +31,7 @@ const navColumns = [
       { href: "/terms", label: "Terms of Service" },
       { href: "/privacy", label: "Privacy Policy" },
       { href: "/accessibility", label: "Accessibility" },
+      { href: "#", label: "Cookie Preferences" },
     ],
   },
 ];
@@ -63,31 +66,36 @@ export function Footer() {
     document.fonts.ready.then(fit);
     const ro = new ResizeObserver(fit);
     ro.observe(wrap);
+
     return () => ro.disconnect();
   }, []);
 
   return (
     <footer className="bg-transparent pt-4 pb-0 relative">
       <div className="max-w-6xl mx-auto px-6 lg:px-8">
-        {/* ── Card ── */}
         <div className="rounded-3xl px-10 py-12 bg-bg-elevated shadow-neu-raised">
           <div className="flex flex-col md:flex-row gap-10 md:gap-16">
-            {/* Left — logo + desc + socials */}
             <div className="flex flex-col gap-6 md:w-72 flex-shrink-0">
               <Link href="/" className="flex items-center gap-2.5">
                 <Image
-                  src={resolvedTheme === "dark" ? "/OFFER-HUB-logo-to-darkmode.png" : "/OFFER-HUB-logo.png"}
+                  src={
+                    resolvedTheme === "dark"
+                      ? "/OFFER-HUB-logo-to-darkmode.png"
+                      : "/OFFER-HUB-logo.png"
+                  }
                   alt="OFFER-HUB"
                   width={160}
                   height={42}
                   className="h-9 w-auto object-contain"
                 />
               </Link>
+
               <p className="text-sm leading-relaxed text-content-secondary">
                 Empowering freelancers and businesses with secure,
                 blockchain-powered solutions — making work easier to find,
                 manage, and pay.
               </p>
+
               <div className="flex items-center gap-4">
                 {socialLinks.map((s) => (
                   <a
@@ -104,18 +112,30 @@ export function Footer() {
               </div>
             </div>
 
-            {/* Right — nav columns */}
             <div className="flex flex-1 gap-8 md:gap-12 flex-wrap">
               {navColumns.map((col) => (
-                <div key={col.heading} className="flex flex-col gap-4 min-w-[100px]">
+                <div
+                  key={col.heading}
+                  className="flex flex-col gap-4 min-w-[100px]"
+                >
                   <h4 className="text-sm font-semibold text-content-primary">
                     {col.heading}
                   </h4>
+
                   <ul className="flex flex-col gap-3">
                     {col.links.map((link) => (
                       <li key={link.label}>
                         <a
                           href={link.href}
+                          onClick={(e) => {
+                            if (link.label === "Cookie Preferences") {
+                              e.preventDefault();
+
+                              window.dispatchEvent(
+                                new CustomEvent(COOKIE_PREFERENCES_EVENT)
+                              );
+                            }
+                          }}
                           className="text-sm text-content-secondary hover:text-content-primary transition-colors duration-200"
                         >
                           {link.label}
@@ -128,11 +148,11 @@ export function Footer() {
             </div>
           </div>
 
-          {/* Divider + bottom bar */}
           <div className="mt-10 pt-6 flex flex-col sm:flex-row items-center justify-between gap-2 border-t border-theme-border">
             <p className="text-xs text-content-muted">
               © {new Date().getFullYear()} OFFER-HUB. All rights reserved.
             </p>
+
             <p className="text-xs text-content-muted">
               Powered by Stellar Blockchain
             </p>
@@ -140,7 +160,6 @@ export function Footer() {
         </div>
       </div>
 
-      {/* ── Watermark ── */}
       <div
         ref={wrapRef}
         className="max-w-6xl mx-auto px-6 lg:px-8 overflow-hidden"


### PR DESCRIPTION
# 📝 Pull Request

## 🔧 Title:

Add "Cookie Preferences" link in footer to re-open consent banner

## 🎯 Issue

Closes #1313

## 📖 Description

Adds a new **Cookie Preferences** link to the Legal section of the footer.

Users can now reopen the cookie consent banner after previously accepting or rejecting cookies, allowing them to update their preference at any time.

The implementation uses a custom browser event to keep communication isolated between the footer and cookie banner components without introducing additional global state.

## ✅ Changes applied

* Added **Cookie Preferences** link to the Legal footer section.
* Added custom `cookie-preferences-open` event dispatch from the footer.
* Added event listener in `CookieConsentBanner`.
* Banner can now be reopened even when a consent preference already exists.
* Existing accept/reject functionality remains unchanged.
* Maintains keyboard accessibility and visual consistency with existing footer links.

## 🧪 Testing

* Ran `npm install`
* Ran `npm run lint`
* Ran `npm run build`

Build completed successfully.

