### PR TITLE
fix: add 3s timeout to getGeolocation() fetch to prevent indefinite hangs

### DIFF
--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -88,21 +88,30 @@ export async function getGeolocation() {
       return JSON.parse(cached);
     }
 
-    const response = await fetch('https://ipapi.co/json/');
-    if (!response.ok) throw new Error('Failed to fetch geolocation');
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 3000);
 
-    const data = await response.json();
-    const geo = {
-      ip: data.ip,
-      country: data.country_name,
-      country_code: data.country_code,
-      city: data.city,
-      region: data.region,
-      timezone: data.timezone,
-    };
+    try {
+      const response = await fetch('https://ipapi.co/json/', {
+        signal: controller.signal,
+      });
+      if (!response.ok) throw new Error('Failed to fetch geolocation');
 
-    sessionStorage.setItem(CACHE_KEY, JSON.stringify(geo));
-    return geo;
+      const data = await response.json();
+      const geo = {
+        ip: data.ip,
+        country: data.country_name,
+        country_code: data.country_code,
+        city: data.city,
+        region: data.region,
+        timezone: data.timezone,
+      };
+
+      sessionStorage.setItem(CACHE_KEY, JSON.stringify(geo));
+      return geo;
+    } finally {
+      clearTimeout(timeoutId);
+    }
   } catch {
     // Cache the empty result so we don't retry on every navigation
     sessionStorage.setItem(CACHE_KEY, JSON.stringify(emptyGeo));


### PR DESCRIPTION
Close #1312 


## Fix: Add Request Timeout to `getGeolocation()` 

### 🎯 Problem
The `getGeolocation()` function in `src/lib/analytics.ts` calls `fetch('https://ipapi.co/json/')` without a timeout. When the API is unavailable, rate-limiting clients, or responding slowly, the promise hangs for the browser's default timeout (~2 minutes), blocking visitor analytics and wasting open connections.

### ✅ Solution
Wrapped the fetch call with an `AbortController` and a 3-second timeout:
- Created `AbortController` to manage fetch lifecycle
- Set `setTimeout()` to abort the request after 3000ms
- Pass `{ signal: controller.signal }` to fetch options
- Clear the timeout in a `finally` block to prevent memory leaks
- Return the existing `emptyGeo` fallback on timeout (no behavior change for callers)

### 📝 Changes
- **File**: `src/lib/analytics.ts`
- **Function**: `getGeolocation()`
- **Lines Modified**: 82-120

### ✅ Testing
- ✅ Successful geolocation loads within 3 seconds and caches in `sessionStorage`
- ✅ On timeout, `AbortError` is caught and `emptyGeo` fallback is returned
- ✅ Session cache logic works correctly on both success and timeout paths
- ✅ No breaking changes to existing API consumers

