### PR TITLE
fix: address four UI correctness issues (noscript, footer links, ToC observer, progress timers)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -117,6 +117,25 @@ export default function RootLayout({
   return (
     <html lang="en" className={`${inter.variable} ${jetbrainsMono.variable}`} suppressHydrationWarning>
       <body className={`${inter.className} antialiased relative min-h-screen`}>
+        <noscript>
+          <div
+            style={{
+              position: "fixed",
+              top: 0,
+              left: 0,
+              right: 0,
+              background: "#1a1a2e",
+              color: "#f1f3f7",
+              textAlign: "center",
+              padding: "12px",
+              fontFamily: "sans-serif",
+              fontSize: "14px",
+              zIndex: 9999,
+            }}
+          >
+            This site requires JavaScript to function. Please enable JavaScript in your browser settings.
+          </div>
+        </noscript>
         <a
           href="#main-content"
           className="sr-only focus:not-sr-only focus:absolute focus:top-6 focus:left-6  focus:z-[9999] px-8 py-10 rounded-full text-sm font-semibold btn-neumorphic-primary outline-none transition-none"

--- a/src/components/docs/TableOfContents.tsx
+++ b/src/components/docs/TableOfContents.tsx
@@ -30,7 +30,7 @@ export function TableOfContents({ headings }: TableOfContentsProps) {
         }
       },
       {
-        rootMargin: "-100px 0px -40% 0px",
+        rootMargin: "-72px 0px -60% 0px",
         threshold: [0, 1],
       }
     );

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -125,21 +125,27 @@ export function Footer() {
                   <ul className="flex flex-col gap-3">
                     {col.links.map((link) => (
                       <li key={link.label}>
-                        <a
-                          href={link.href}
-                          onClick={(e) => {
-                            if (link.label === "Cookie Preferences") {
+                        {link.label === "Cookie Preferences" ? (
+                          <a
+                            href={link.href}
+                            onClick={(e) => {
                               e.preventDefault();
-
                               window.dispatchEvent(
                                 new CustomEvent(COOKIE_PREFERENCES_EVENT)
                               );
-                            }
-                          }}
-                          className="text-sm text-content-secondary hover:text-content-primary transition-colors duration-200"
-                        >
-                          {link.label}
-                        </a>
+                            }}
+                            className="text-sm text-content-secondary hover:text-content-primary transition-colors duration-200"
+                          >
+                            {link.label}
+                          </a>
+                        ) : (
+                          <Link
+                            href={link.href}
+                            className="text-sm text-content-secondary hover:text-content-primary transition-colors duration-200"
+                          >
+                            {link.label}
+                          </Link>
+                        )}
                       </li>
                     ))}
                   </ul>

--- a/src/components/ui/NavigationProgress.tsx
+++ b/src/components/ui/NavigationProgress.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 import { usePathname, useSearchParams } from "next/navigation";
 
 export function NavigationProgress() {
@@ -8,12 +8,16 @@ export function NavigationProgress() {
   const searchParams = useSearchParams();
   const [isLoading, setIsLoading] = useState(false);
   const [progress, setProgress] = useState(0);
+  const stepTimerRefs = useRef<ReturnType<typeof setTimeout>[]>([]);
+  const completeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const startLoading = useCallback(() => {
+    stepTimerRefs.current.forEach(clearTimeout);
+    stepTimerRefs.current = [];
+
     setIsLoading(true);
     setProgress(0);
 
-    // Animate progress: quick start, then slow down
     const steps = [
       { value: 30, delay: 0 },
       { value: 50, delay: 100 },
@@ -22,18 +26,30 @@ export function NavigationProgress() {
     ];
 
     steps.forEach(({ value, delay }) => {
-      setTimeout(() => {
+      const id = setTimeout(() => {
         setProgress((prev) => (prev < value ? value : prev));
       }, delay);
+      stepTimerRefs.current.push(id);
     });
   }, []);
 
   const completeLoading = useCallback(() => {
+    if (completeTimerRef.current !== null) {
+      clearTimeout(completeTimerRef.current);
+    }
     setProgress(100);
-    setTimeout(() => {
+    completeTimerRef.current = setTimeout(() => {
       setIsLoading(false);
       setProgress(0);
+      completeTimerRef.current = null;
     }, 200);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      stepTimerRefs.current.forEach(clearTimeout);
+      if (completeTimerRef.current !== null) clearTimeout(completeTimerRef.current);
+    };
   }, []);
 
   // Listen for route changes


### PR DESCRIPTION
# 📝 Pull Request 

## 🔧 Title: Fix four UI correctness issues — noscript fallback, footer Link migration, ToC rootMargin, NavigationProgress timer cleanup

## 🛠️ Issue

- Closes #1401
- Closes #1399
- Closes #1395
- Closes #1398

## 📚 Description

This PR bundles four independent correctness fixes across the frontend:

1. **`<noscript>` fallback** (`src/app/layout.tsx`): Users with JavaScript disabled saw a blank page. A fixed-position banner with inline styles (no Tailwind dependency) now informs them that JS is required.

2. **Footer `<Link>` migration** (`src/components/layout/Footer.tsx`): Internal nav-column links (`/pricing`, `/docs`, `/community`, etc.) were using raw `<a>` tags, causing full page reloads. Replaced with Next.js `<Link>`. The "Cookie Preferences" entry retains `<a>` since it fires a custom event and doesn't navigate. External social links are unchanged.

3. **TableOfContents `rootMargin`** (`src/components/docs/TableOfContents.tsx`): Updated `rootMargin` from `-100px 0px -40% 0px` to `-72px 0px -60% 0px` to correctly account for the fixed Navbar height (~64px) and shrink the detection window, so the active ToC entry highlights the section actually visible to the user.

4. **NavigationProgress timer cleanup** (`src/components/ui/NavigationProgress.tsx`): The four `setTimeout` calls in `startLoading()` and the one in `completeLoading()` were never cleared. On fast navigations, stale timers called `setProgress` after `completeLoading()` ran, causing flicker. Timer IDs are now stored in refs (`stepTimerRefs`, `completeTimerRef`), cleared before each new animation, and cleaned up on unmount.

## ✅ Changes applied

- Added `<noscript>` banner with inline styles before `<ThemeProvider>` in root layout
- Replaced `<a href>` with `<Link href>` for all internal footer nav routes; kept `<a>` for Cookie Preferences and social icons
- Updated `IntersectionObserver` `rootMargin` in `TableOfContents` to `-72px 0px -60% 0px`
- Added `stepTimerRefs` and `completeTimerRef` refs in `NavigationProgress`; clear timers at start of each animation and in `useEffect` cleanup

## 🔍 Evidence/Media (screenshots/videos)

- Lint passes (`npm run lint`) with no new warnings
- TypeScript errors present are pre-existing (missing `docs-index.json`) and unrelated to these changes