### PR TITLE
fix(#1400): Add maxLength validation to text inputs in RegistrationForm

### DIFF
--- a/src/app/accessibility/page.tsx
+++ b/src/app/accessibility/page.tsx
@@ -3,7 +3,7 @@
 import { Navbar } from "@/components/layout/Navbar";
 import { Footer } from "@/components/layout/Footer";
 import LoadingBar from "@/components/ui/LoadingBar";
-import { Mail, AlertCircle, CheckCircle, ExternalLink, Headphones, Eye, Hand, Brain, Zap, MessageSquare } from "lucide-react";
+import { Mail, AlertCircle, CheckCircle, ExternalLink, Headphones, Eye, Hand, Brain, MessageSquare } from "lucide-react";
 
 const features = [
      {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next";
 import { Inter, JetBrains_Mono } from "next/font/google";
 import { Suspense } from "react";
-// @ts-ignore: CSS side-effect import declarations are handled by Next.js
 import "./globals.css";
 import Analytics from "@/components/Analytics";
 import { ClientBackground } from "@/components/layout/ClientBackground";

--- a/src/components/community/RegistrationForm.tsx
+++ b/src/components/community/RegistrationForm.tsx
@@ -220,6 +220,7 @@ export default function RegistrationForm() {
                                 value={formData.name}
                                 onChange={handleInputChange}
                                 placeholder="John Doe"
+                                maxLength={100}
                                 disabled={isLoading || cooldownSeconds > 0}
                                 className="w-full pl-12 pr-6 py-3.5 rounded-xl bg-bg-sunken shadow-neu-sunken-subtle text-sm text-content-primary placeholder:text-content-muted border-none transition-all font-medium disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-2 focus-visible:outline-theme-primary focus-visible:outline-offset-2 focus-visible:ring-2 focus-visible:ring-theme-primary"
                             />
@@ -237,6 +238,7 @@ export default function RegistrationForm() {
                                 value={formData.email}
                                 onChange={handleInputChange}
                                 placeholder="john@example.com"
+                                maxLength={320}
                                 disabled={isLoading || cooldownSeconds > 0}
                                 className="w-full pl-12 pr-6 py-3.5 rounded-xl bg-bg-sunken shadow-neu-sunken-subtle text-sm text-content-primary placeholder:text-content-muted border-none transition-all font-medium disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-2 focus-visible:outline-theme-primary focus-visible:outline-offset-2 focus-visible:ring-2 focus-visible:ring-theme-primary"
                             />
@@ -244,7 +246,18 @@ export default function RegistrationForm() {
                     </div>
 
                     <div className="flex flex-col gap-2">
-                        <label className="text-[10px] font-black uppercase tracking-widest text-content-secondary ml-2">For what would you use Offer Hub?</label>
+                        <div className="flex justify-between items-center ml-2">
+                            <label className="text-[10px] font-black uppercase tracking-widest text-content-secondary">For what would you use Offer Hub?</label>
+                            <span className={`text-[10px] font-bold tracking-wider transition-colors duration-200 ${
+                                formData.purpose.length >= 480
+                                    ? "text-red-500"
+                                    : formData.purpose.length >= 400
+                                    ? "text-amber-500"
+                                    : "text-content-muted"
+                            }`}>
+                                {formData.purpose.length}/500
+                            </span>
+                        </div>
                         <div className="relative group">
                             <MessageSquare size={16} className="absolute left-5 top-6 text-content-muted group-focus-within:text-theme-primary transition-colors" />
                             <textarea
@@ -254,6 +267,7 @@ export default function RegistrationForm() {
                                 value={formData.purpose}
                                 onChange={handleInputChange}
                                 placeholder="Tell us about your marketplace or project..."
+                                maxLength={500}
                                 disabled={isLoading || cooldownSeconds > 0}
                                 className="w-full pl-12 pr-6 py-3.5 rounded-xl bg-bg-sunken shadow-neu-sunken-subtle text-sm text-content-primary placeholder:text-content-muted border-none transition-all font-medium resize-none disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-2 focus-visible:outline-theme-primary focus-visible:outline-offset-2 focus-visible:ring-2 focus-visible:ring-theme-primary"
                             />
@@ -271,6 +285,7 @@ export default function RegistrationForm() {
                                 value={formData.referral}
                                 onChange={handleInputChange}
                                 placeholder="X, Telegram, Friend, etc."
+                                maxLength={200}
                                 disabled={isLoading || cooldownSeconds > 0}
                                 className="w-full pl-12 pr-6 py-3.5 rounded-xl bg-bg-sunken shadow-neu-sunken-subtle text-sm text-content-primary placeholder:text-content-muted border-none transition-all font-medium disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-2 focus-visible:outline-theme-primary focus-visible:outline-offset-2 focus-visible:ring-2 focus-visible:ring-theme-primary"
                             />


### PR DESCRIPTION
# 📝 Pull Request 

## 🔧 Title: 

- fix: Add maxLength validation to all text inputs in RegistrationForm

## 🛠️ Issue

- Closes #1400

## 📚 Description

- Adds client-side maxLength constraints to name (100), email (320), purpose (500), and referral (200) fields in the RegistrationForm as specified by the acceptance criteria. Also adds a dynamic character counter to the purpose textarea for improved UX.

## ✅ Changes applied

- Added `maxLength={100}` to the `name` input field.
- Added `maxLength={320}` to the `email` input field (RFC 5321).
- Added `maxLength={500}` to the `purpose` textarea.
- Added `maxLength={200}` to the `referral` input field.
- Implemented a dynamic character counter next to the `purpose` label that changes color (amber/red) to visually warn the user as they approach the 500-character limit.

## 🔍 Evidence/Media (screenshots/videos)

<img width="1842" height="986" alt="image" src="https://github.com/user-attachments/assets/21e05ac4-20fb-4ac7-a24a-bc3b00ab99a8" />

