### PR TITLE
manual test of the issue #1354

### DIFF
--- a/reports/issue-1354/Report_CancelOrder_Issue_1354.md
+++ b/reports/issue-1354/Report_CancelOrder_Issue_1354.md
@@ -1,0 +1,156 @@
+# Manual Test Report: Cancel Order
+**Issue #1354**
+**Date:** 2026-06-02
+**Tester:** Keshinro Tanitoluwa Joseph
+**Environment:** https://www.offer-hub.org
+
+> **Note:** Screenshots for each test step are embedded in the PR description.
+
+---
+
+## Test Execution Summary
+❌ **PARTIAL PASS — 3 STEPS FAILED**
+
+---
+
+## Real Profile Data
+
+**Username:** T-kesh
+**Email:** tanitoluwakeshinro@gmail.com
+**First Name:** Tanitoluwa
+**Last Name:** Keshinro
+**Professional Title:** Frontend Developer
+**Location:** Ondo, Akure
+**Profile Photo:** Uploaded
+**Screenshot:** *[profile_screenshot.png — attach to PR]*
+
+---
+
+## Real Service Published
+
+**Service Title:** Full Stack Developer
+**Category:** Mobile Development
+**Description:** I offer premium looks, minimalistic designs and good code quality
+**Price:** $500
+**Delivery Time:** 10 days
+**Status:** Active
+**Screenshot:** *[service_screenshot.png — attach to PR]*
+
+---
+
+## Real Offer Published
+
+**Offer Title:** I need a minimalistic, premium design for my work
+**Category:** Mobile Development
+**Description:** it's a gaming app and i need a gamey design for it. the idea is a flying squirrel 
+let's talk more after you've accepted the offer
+**Budget:** $500
+**Timeline:** 27 days
+**Status:** Active
+**Screenshot:** *[offer_screenshot.png — attach to PR]*
+
+---
+
+## Prerequisites
+
+An active order in **Created** or **Confirmed** status (before completion) must exist. The order used for this test:
+
+- **Order ID:** #pn3raxgb
+- **Service:** Software development
+- **Amount:** $300
+- **Seller:** Afolami Anu
+- **Client:** Keshinro Tanitoluwa
+- **Status at Test Start:** In Progress
+
+---
+
+## Test Steps & Results
+
+### ✅ Step 1: Navigate to Order Detail Page
+**Action:** Logged in and navigated to Dashboard → My Orders, then opened the active order.
+
+**Order Details Shown:**
+- Order ID: #pn3raxgb
+- Service: Software development
+- Amount: $300
+- Current Status: In progress
+
+**Expected Result:** Order detail page loads with a "Cancel Order" button visible.
+**Actual Result:** Order detail page actually loads with a "cancel order" button
+**Status:** ✅ Pass
+**Screenshot:** *[step1_order_detail.png — attach to PR]*
+
+---
+
+### ✅ Step 2: Click "Cancel Order" Button
+**Action:** Clicked the "Cancel Order" button on the order detail page.
+
+**Expected Result:** A confirmation dialog or modal appears asking the user to confirm cancellation before proceeding.
+**Actual Result:** An alert message popped up asking if I actually wanted to cancel the order
+**Status:** ✅ Pass
+**Screenshot:** *[step2_cancel_button_clicked.png — attach to PR]*
+
+---
+
+### ❌ Step 3: Confirm Cancellation in Dialog
+**Action:** Clicked the confirm/yes button inside the cancellation dialog.
+
+**Expected Result:** Cancellation is processed and a success message appears (e.g. "Order cancelled successfully").
+**Actual Result:** It was an alert message so i clicked okay. After that, a review page popped up instead of a success message.
+**Status:** ❌ Fail 
+**Screenshot:** *[step3_confirm_dialog.png — attach to PR]*
+
+---
+
+### ❌ Step 4: Order Status Updates to "Cancelled"
+**Action:** Observed the order detail page after confirming cancellation.
+
+**Expected Result:** Order status changes to "Cancelled" and the progress timeline or status badge reflects it.
+**Actual Result:** while it does show that the order has been cancelled successfully, it updates to completed instead of cancelled.
+**Status:** ❌ Fail
+**Screenshot:** *[step4_cancelled_status.png — attach to PR]*
+
+---
+
+### ❌ Step 5: Cancelled Order Appears Correctly in Orders List
+**Action:** Navigated to Dashboard → My Orders list.
+
+**Expected Result:** The order is listed with status "Cancelled" and no further action buttons visible (e.g. no Complete or Cancel button).
+**Actual Result:** The order is listed with the status "closed" from the list and after clicking on the issue itself, the order progress UI is labelled with "complete".
+**Status:** ❌ Fail
+**Screenshot:** *[step5_orders_list.png — attach to PR]*
+
+---
+
+### ✅ Step 6 (Edge Case): Attempt Cancellation After Order is Completed
+**Action:** Opened a completed order and checked whether the Cancel Order button is present.
+
+**Expected Result:** Cancel button is not visible or is disabled on a completed order.
+**Actual Result:** Cancel button is not visible on a completed order.
+**Status:** ✅ Pass
+**Screenshot:** *[step6_no_cancel_on_completed.png — attach to PR]*
+
+---
+
+## Acceptance Criteria Results
+
+| Criterion | Expected | Actual | Status |
+|-----------|----------|--------|--------|
+| Order can be cancelled before completion | "Cancel Order" button visible on active orders | Cancel Order button was present and clickable on the active order | ✅ |
+| Cancellation confirmation is requested before proceeding | A dialog/modal prompts the user to confirm | A browser alert appeared asking for confirmation before proceeding | ✅ |
+| Cancelled order status is reflected correctly | Status changes to "Cancelled" and UI updates | Order status updated to "completed" instead of "cancelled"; orders list shows "closed" | ❌ |
+
+---
+
+## Issues Found
+- The cancelled order status is not reflecting in the order progress UI
+
+## Recommendations
+- I don't know how hard it might be to work on but a cancelled order status in the order progress UI would be nice.
+
+---
+
+## Summary
+The Cancel Order flow partially passed. The cancel button was correctly visible on active orders, and a confirmation alert appeared before proceeding — both working as expected. However, three issues were found: after confirming cancellation, a review page appeared instead of a success message; the order status updated to "completed" rather than "cancelled"; and the orders list displayed the status as "closed" instead of "cancelled". The core cancellation confirmation requirement is met, but the status handling after cancellation is incorrect.
+
+**Overall Test Result:** ❌ **PARTIAL PASS — 3 STEPS FAILED**

--- a/reports/issue-1354/Report_CompleteOrder_Issue_1354.md
+++ b/reports/issue-1354/Report_CompleteOrder_Issue_1354.md
@@ -1,0 +1,145 @@
+# Manual Test Report: Complete Order
+**Issue #1354**
+**Date:** 2026-06-02
+**Tester:** Keshinro Tanitoluwa Joseph
+**Environment:** https://www.offer-hub.org
+
+> **Note:** Screenshots for each test step are embedded in the PR description.
+
+---
+
+## Test Execution Summary
+⚠️ **MOSTLY PASSED — 1 ISSUE FOUND**
+
+---
+
+## Real Profile Data
+
+**Username:** T-kesh
+**Email:** tanitoluwakeshinro@gmail.com
+**First Name:** Tanitoluwa
+**Last Name:** Keshinro
+**Professional Title:** Frontend Developer
+**Location:** Ondo, Akure
+**Profile Photo:** Uploaded
+**Screenshot:** *[profile_screenshot.png — attach to PR]*
+
+---
+
+## Real Service Published
+
+**Service Title:** App testing
+**Category:** Mobile Development
+**Description:** Hi there, my name is Joseph and I'm a professional app tester. I test for bugs, design flaws and provide areas for improvement based on what I learn.
+**Price:** $100
+**Delivery Time:** 3 days
+**Status:** Active
+**Screenshot:** *[service_screenshot.png — attach to PR]*
+
+---
+
+## Real Offer Published
+
+**Offer Title:** I need a minimalistic, premium design for my work
+**Category:** Mobile Development
+**Description:** it's a gaming app and i need a gamey design for it. the idea is a flying squirrel 
+let's talk more after you've accepted the offer.
+**Budget:** $500
+**Timeline:** 27 days
+**Status:** Active
+**Screenshot:** *[offer_screenshot.png — attach to PR]*
+
+---
+
+## Prerequisites
+
+Before testing Complete Order, an active order must exist. The order used for this test:
+
+- **Order ID:** #7gq1fspb
+- **Service:** graphic design and website development
+- **Amount:** $50
+- **Seller:** Excellence Komolafe
+- **Client:** Keshinro Tanitoluwa
+
+---
+
+## Test Steps & Results
+
+### ✅ Step 1: Navigate to Order Detail Page
+**Action:** Logged in and navigated to Dashboard → My Orders → My Purchases (or My Sales), then opened the order.
+
+**Order Details Shown:**
+- Order ID: #7gq1fspb
+- Service: graphic design and website development
+- Amount: $50
+- Current Status: Created
+
+**Expected Result:** Order detail page loads with current status visible and a "Mark as Complete" or "Complete Order" button available.
+**Actual Result:** A complete order button is present.
+**Status:** ✅ Pass
+**Screenshot:** *[step1_order_detail.png — attach to PR]*
+
+---
+
+### ✅ Step 2: Click "Complete Order" / "Mark as Complete" Button
+**Action:** Clicked the button to mark the order as complete.
+
+**Expected Result:** Button is visible and clickable; triggers completion flow.
+**Actual Result:** Button is clickable and triggers completion workflow.
+**Status:** ✅ Pass
+**Screenshot:** *[step2_complete_button.png — attach to PR]*
+
+---
+
+### ✅ Step 3: Confirmation / Success Feedback
+**Action:** Observed the UI response after clicking Complete.
+
+**Expected Result:** A success message or confirmation toast appears (e.g. "Order completed successfully").
+**Actual Result:** There is a success message right under the order progress UI.
+**Status:** ✅ Pass
+**Screenshot:** *[step3_success_message.png — attach to PR]*
+
+---
+
+### ✅ Step 4: Order Status Updates to "Completed"
+**Action:** Checked the order detail page and/or orders list after completion.
+
+**Expected Result:** Order status changes to "Completed" and the progress timeline reflects the final stage.
+**Actual Result:** The progress timeline changes to "complete" and the order status is marked as completed.
+**Status:** ✅ Pass 
+**Screenshot:** *[step4_completed_status.png — attach to PR]*
+
+---
+
+### ✅ Step 5: Completed Order Appears Correctly in Orders List
+**Action:** Navigated to Dashboard → My Orders list.
+
+**Expected Result:** The order is listed with status "Completed" and no further action buttons (e.g. no Cancel button visible).
+**Actual Result:** While there are no further actions required, the order is listed with the status closed instead of completed. This should be addressed later.
+**Status:** ❌ Fail
+**Screenshot:** *[step5_orders_list.png — attach to PR]*
+
+---
+
+## Acceptance Criteria Results
+
+| Criterion | Expected | Actual | Status |
+|-----------|----------|--------|--------|
+| Order can be marked as complete by the appropriate party | "Complete Order" button visible and functional | Button present and successfully triggered order completion | ✅ |
+| Status changes to "Completed" | Status field updates immediately | Progress timeline updates to "complete" and order marked as completed | ✅ |
+| UI reflects the completed status | Progress timeline and status badge update | Order listed with status "closed" instead of "completed" in orders list | ❌ |
+
+---
+
+## Issues Found
+- There was an issue when i was trying to approve confirmation. It took a while to load but got stuck. I refreshed and it was showing a backward shift in the progress UI until i refreshed again. It's not something too important but it's worth looking into.
+
+## Recommendations
+- The UI should be updated for the orders.
+
+---
+
+## Summary
+The Complete Order flow works correctly end-to-end. The "Complete Order" button was present and functional, the completion flow triggered successfully with a visible success message, and the progress timeline updated to the final stage. One issue was found: the orders list displays the status as "closed" instead of "completed", which is a UI label inconsistency worth addressing. A secondary issue was observed where the progress UI briefly shifted backward after a slow confirmation load before correcting itself on refresh.
+
+**Overall Test Result:** ⚠️ **MOSTLY PASSED — 1 ISSUE FOUND**


### PR DESCRIPTION
# 📝 Pull Request 

## 🔧 Title: 
Manual Test: Complete Order + Cancel Order — Issue #1354

## 🛠️ Issue

- Closes #1354

## 📚 Description

Manual testing of the Complete Order and Cancel Order flows on https://www.offer-hub.org.
Two report files have been added covering all acceptance criteria, including bugs found during testing.

## ✅ Changes applied

- Added `reports/issue-1354/Report_CompleteOrder_Issue_1354.md`
- Added `reports/issue-1354/Report_CancelOrder_Issue_1354.md`

## 🔍 Evidence/Media (screenshots/videos)

### Profile
- <img width="1280" height="674" alt="profile_screenshot" src="https://github.com/user-attachments/assets/c442789d-ba8c-4f6d-a3af-f94c55d3b883" />

### Service
- <img width="1209" height="575" alt="service_screenshot" src="https://github.com/user-attachments/assets/611fb586-1465-4076-8752-ac1672791fc7" />

### Offer
- <img width="968" height="731" alt="offer_screenshot" src="https://github.com/user-attachments/assets/b1fe282a-29b1-4897-a349-d7918a9dce41" />

### Complete Order
- <img width="640" height="454" alt="step1_order_detail" src="https://github.com/user-attachments/assets/944b6155-716e-4787-844a-b155d75476d5" />— Order detail page with Complete button visible
- <img width="628" height="455" alt="step2_complete_button" src="https://github.com/user-attachments/assets/a978b1df-f7ce-4137-96ec-177c7da0304c" /> — Complete button clicked
- <img width="1084" height="644" alt="step3_success_message" src="https://github.com/user-attachments/assets/0e301e26-2dc5-4895-9b42-ba36e587848c" /> — Success message shown
- <img width="1084" height="644" alt="step3_success_message" src="https://github.com/user-attachments/assets/cf33e647-1129-43c8-aa9e-2028889222ca" /> — Progress timeline updated to complete
- <img width="917" height="526" alt="step6_no_cancel_on_completed" src="https://github.com/user-attachments/assets/f94f5ea7-e791-4fa1-84d7-ea796413e981" /> — Orders list showing "closed" instead of "completed" (bug)

### Cancel Order
- <img width="928" height="852" alt="step1_order_detail" src="https://github.com/user-attachments/assets/bc2c1841-e0f7-4813-ad35-083a23291c97" /> — Order detail page with Cancel button visible
- <img width="643" height="242" alt="step2_cancel_button_clicked" src="https://github.com/user-attachments/assets/b39d6cb0-bbcd-40fb-9bb6-35a11bac715a" /> — Confirmation alert shown
- <img width="807" height="873" alt="step3_confirm_dialog" src="https://github.com/user-attachments/assets/ea978af4-7ce1-4b72-beac-7b22ce6bfb54" /> — Review page shown after confirming (unexpected behavior)
- <img width="916" height="648" alt="step4_cancelled_status" src="https://github.com/user-attachments/assets/9fd15182-3bd5-4aa8-8231-579e17bc3e45" /> — Status updated to "completed" instead of "cancelled" (bug)
- <img width="987" height="524" alt="step5_orders_list" src="https://github.com/user-attachments/assets/c5726b92-809f-4b96-82ec-c36d1bb68d53" /> — Orders list showing "closed" instead of "cancelled" (bug)
- <img width="917" height="526" alt="step6_no_cancel_on_completed" src="https://github.com/user-attachments/assets/f9a5ffd7-22cd-4413-9421-a500c8573e77" /> — No Cancel button on completed order (edge case pass)
