### PR TITLE
feat(architecture): add /architecture page for SCF Build Award #44 submission

### DIFF
--- a/src/app/architecture/loading.tsx
+++ b/src/app/architecture/loading.tsx
@@ -1,0 +1,61 @@
+import { Navbar } from "@/components/layout/Navbar";
+import { Footer } from "@/components/layout/Footer";
+
+function HeroSkeleton() {
+  return (
+    <section className="relative pt-44 md:pt-48 pb-20 bg-transparent">
+      <div className="max-w-7xl mx-auto px-6 lg:px-8 text-center flex flex-col items-center">
+        <div className="h-[clamp(3rem,10vw,7.75rem)] w-2/3 rounded-2xl bg-[#e5e7eb] dark:bg-[#1e2a4a] animate-pulse mb-6" />
+        <div className="h-8 w-48 rounded-full bg-[#e5e7eb] dark:bg-[#1e2a4a] animate-pulse mb-8" />
+        <div className="h-16 w-3/4 rounded-xl bg-[#e5e7eb] dark:bg-[#1e2a4a] animate-pulse mb-3" />
+        <div className="h-16 w-2/3 rounded-xl bg-[#e5e7eb] dark:bg-[#1e2a4a] animate-pulse mb-8" />
+        <div className="h-5 w-2/3 bg-[#e5e7eb] dark:bg-[#1e2a4a] rounded animate-pulse mb-2" />
+        <div className="h-5 w-1/2 bg-[#e5e7eb] dark:bg-[#1e2a4a] rounded animate-pulse mb-12" />
+        <div className="w-full max-w-3xl rounded-[2rem] bg-[#e5e7eb] dark:bg-[#1e2a4a] animate-pulse h-48" />
+      </div>
+    </section>
+  );
+}
+
+function NavSkeleton() {
+  return (
+    <div className="sticky top-[80px] z-40 py-6 pointer-events-none">
+      <div className="max-w-3xl mx-auto px-6 flex justify-center">
+        <div className="pointer-events-auto flex items-center gap-1.5 p-2 rounded-2xl bg-[#e5e7eb] dark:bg-[#1e2a4a] animate-pulse">
+          {["Overview", "System", "Payment Flow", "Integrations", "Roadmap"].map((label) => (
+            <div key={label} className="h-10 w-24 sm:w-28 rounded-xl bg-[#d1d5db] dark:bg-[#3d3d5c]" />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SectionSkeleton({ tall = false }: { tall?: boolean }) {
+  return (
+    <section className="px-6 py-24 bg-transparent">
+      <div className="mx-auto max-w-7xl">
+        <div
+          className={`rounded-[2.5rem] bg-[#e5e7eb] dark:bg-[#1e2a4a] animate-pulse p-10 ${tall ? "h-[600px]" : "h-96"}`}
+        />
+      </div>
+    </section>
+  );
+}
+
+export default function ArchitectureLoading() {
+  return (
+    <div className="min-h-screen flex flex-col bg-transparent">
+      <Navbar />
+      <main className="flex-grow">
+        <HeroSkeleton />
+        <NavSkeleton />
+        <SectionSkeleton tall />
+        <SectionSkeleton tall />
+        <SectionSkeleton />
+        <SectionSkeleton />
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/app/architecture/page.tsx
+++ b/src/app/architecture/page.tsx
@@ -1,0 +1,54 @@
+import type { Metadata } from "next";
+import { Navbar } from "@/components/layout/Navbar";
+import { Footer } from "@/components/layout/Footer";
+import LoadingBar from "@/components/ui/LoadingBar";
+
+import ArchitectureHero from "@/components/architecture/ArchitectureHero";
+import ArchitectureSectionNav from "@/components/architecture/ArchitectureSectionNav";
+import SystemArchitectureDiagram from "@/components/architecture/SystemArchitectureDiagram";
+import PaymentFlowDiagram from "@/components/architecture/PaymentFlowDiagram";
+import IntegrationsMap from "@/components/architecture/IntegrationsMap";
+import SCFTrancheRoadmap from "@/components/architecture/SCFTrancheRoadmap";
+import WhyStellarSection from "@/components/architecture/WhyStellarSection";
+import TractionSection from "@/components/architecture/TractionSection";
+
+export const metadata: Metadata = {
+  title: "Technical Architecture",
+  description:
+    "Complete technical architecture of OFFER-HUB: non-custodial escrow on Stellar, Stellar Wallets Kit integration, BlindPay and Abroad off-ramp corridors across 7 LATAM markets. SCF Build Award #44.",
+  keywords: [
+    "architecture",
+    "stellar",
+    "soroban",
+    "escrow",
+    "TrustlessWork",
+    "BlindPay",
+    "Abroad",
+    "SCF",
+    "OFFER-HUB",
+    "USDC",
+    "LATAM",
+  ],
+};
+
+export default function ArchitecturePage() {
+  return (
+    <div className="min-h-screen flex flex-col bg-transparent">
+      <LoadingBar />
+      <Navbar />
+
+      <main className="flex-grow">
+        <ArchitectureHero />
+        <ArchitectureSectionNav />
+        <SystemArchitectureDiagram />
+        <PaymentFlowDiagram />
+        <IntegrationsMap />
+        <SCFTrancheRoadmap />
+        <WhyStellarSection />
+        <TractionSection />
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/src/components/CookieConsentBanner.tsx
+++ b/src/components/CookieConsentBanner.tsx
@@ -47,7 +47,7 @@ export default function CookieConsentBanner() {
       aria-label="Cookie consent"
       className="fixed bottom-4 left-4 right-4 md:left-auto md:right-6 md:bottom-6 md:max-w-sm z-50 animate-fadeInUp"
     >
-      <div className="rounded-3xl bg-bg-elevated shadow-neu-raised px-6 py-5 flex flex-col gap-4 border border-theme-border/20">
+      <div className="rounded-3xl bg-bg-elevated shadow-neu-raised px-6 py-5 flex flex-col gap-4">
         <p className="text-[10px] font-black uppercase tracking-[0.3em] text-theme-primary">
           Privacy Notice
         </p>

--- a/src/components/architecture/ArchitectureHero.tsx
+++ b/src/components/architecture/ArchitectureHero.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { Cpu } from "lucide-react";
+import { ARCHITECTURE_SCROLL_MARGIN_PX } from "@/lib/architecture-nav";
+
+const container = {
+  hidden: { opacity: 0 },
+  show: { opacity: 1, transition: { staggerChildren: 0.1, delayChildren: 0.04 } },
+};
+
+const item = {
+  hidden: { opacity: 0, y: 18 },
+  show: { opacity: 1, y: 0, transition: { duration: 0.48, ease: [0.22, 1, 0.36, 1] as const } },
+};
+
+const layers = [
+  { label: "Client", sublabel: "Next.js 15 + SWK", color: "var(--color-primary)" },
+  { label: "API", sublabel: "NestJS + Prisma", color: "var(--color-secondary)" },
+  { label: "Stellar", sublabel: "Soroban + USDC", color: "var(--color-primary)" },
+];
+
+export default function ArchitectureHero() {
+  return (
+    <section
+      id="overview"
+      className="relative isolate overflow-hidden pt-44 md:pt-48 pb-20 bg-transparent"
+      style={{ scrollMarginTop: ARCHITECTURE_SCROLL_MARGIN_PX }}
+    >
+      <div
+        className="absolute inset-0 pointer-events-none z-0"
+        style={{
+          background:
+            "radial-gradient(ellipse 58% 48% at 50% 38%, rgba(20,154,155,0.085) 0%, transparent 68%)",
+        }}
+      />
+
+      <div className="relative z-10 max-w-7xl mx-auto px-6 lg:px-8 text-center flex flex-col items-center">
+        <motion.div
+          variants={container}
+          initial="hidden"
+          animate="show"
+          className="flex flex-col items-center w-full"
+        >
+          <motion.div variants={item} className="mb-6">
+            <div
+              className="text-[clamp(3rem,10vw,7.75rem)] font-black tracking-tight leading-none whitespace-nowrap select-none"
+              style={{
+                backgroundImage:
+                  "linear-gradient(90deg, rgba(31,184,185,1) 0%, rgba(20,154,155,1) 45%, rgba(34,224,226,0.95) 100%)",
+                WebkitBackgroundClip: "text",
+                backgroundClip: "text",
+                color: "transparent",
+              }}
+              aria-label="OFFER-HUB"
+            >
+              OFFER-HUB
+            </div>
+          </motion.div>
+
+          <motion.div variants={item}>
+            <div className="px-5 py-2 rounded-full text-xs font-bold uppercase tracking-[0.2em] mb-8 shadow-neu-raised text-theme-primary bg-bg-base inline-flex items-center gap-2.5">
+              <Cpu size={14} className="shrink-0 opacity-90" aria-hidden />
+              SCF Build Award #44 — Integration Track
+            </div>
+          </motion.div>
+
+          <motion.h1
+            variants={item}
+            className="text-5xl md:text-7xl font-black tracking-tight mb-8 text-content-primary max-w-4xl"
+          >
+            Technical Architecture
+          </motion.h1>
+
+          <motion.p
+            variants={item}
+            className="text-lg md:text-xl font-medium max-w-2xl mx-auto leading-relaxed mb-12 text-content-secondary"
+          >
+            Complete system design for a non-custodial freelance marketplace on Stellar — from
+            client-side Soroban signing to fiat settlement across 7 LATAM markets.
+          </motion.p>
+
+          {/* Mini 3-layer diagram */}
+          <motion.div variants={item} className="w-full max-w-2xl">
+            <div className="rounded-[2rem] bg-bg-elevated p-8 md:p-10 shadow-neu-raised">
+              <div className="flex flex-col items-center gap-0">
+                {layers.map((layer, i) => (
+                  <div key={layer.label} className="w-full flex flex-col items-center">
+                    <div className="w-full rounded-2xl bg-bg-base shadow-neu-raised-sm px-6 py-4 flex items-center justify-between">
+                      <div className="flex items-center gap-3">
+                        <div
+                          className="w-2 h-2 rounded-full animate-blockchainPulse"
+                          style={{ backgroundColor: layer.color }}
+                        />
+                        <span className="text-sm font-bold text-content-primary">{layer.label}</span>
+                      </div>
+                      <span className="text-xs text-content-secondary">{layer.sublabel}</span>
+                    </div>
+                    {i < layers.length - 1 && (
+                      <div className="flex flex-col items-center my-1">
+                        <svg width="2" height="20" className="overflow-visible">
+                          <line
+                            x1="1" y1="0" x2="1" y2="20"
+                            stroke="var(--color-primary)"
+                            strokeOpacity="0.4"
+                            strokeWidth="2"
+                            strokeDasharray="4 3"
+                            className="animate-connectorDash"
+                          />
+                        </svg>
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+              <p className="mt-6 text-xs font-medium uppercase tracking-[0.2em] text-content-secondary text-center">
+                Non-custodial · On-chain · LATAM-native
+              </p>
+            </div>
+          </motion.div>
+        </motion.div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/architecture/ArchitectureSectionNav.tsx
+++ b/src/components/architecture/ArchitectureSectionNav.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useEffect, useRef, useState, type MouseEvent } from "react";
+import { motion, LayoutGroup } from "framer-motion";
+import { cn } from "@/lib/cn";
+import { ARCHITECTURE_SECTIONS, ARCHITECTURE_SCROLL_MARGIN_PX } from "@/lib/architecture-nav";
+
+export default function ArchitectureSectionNav() {
+  const [activeSection, setActiveSection] = useState("overview");
+  const [isNavPinned, setIsNavPinned] = useState(false);
+  const navRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        let best = entries[0];
+        entries.forEach((entry) => {
+          if (entry.intersectionRatio > best.intersectionRatio) best = entry;
+        });
+        if (best?.isIntersecting && best.target.id) {
+          setActiveSection(best.target.id);
+        }
+      },
+      { threshold: [0.08, 0.25, 0.45, 0.65], rootMargin: "-14% 0px -14% 0px" }
+    );
+
+    ARCHITECTURE_SECTIONS.forEach(({ id }) => {
+      const el = document.getElementById(id);
+      if (el) observer.observe(el);
+    });
+
+    let ticking = false;
+    const onScroll = () => {
+      if (!ticking) {
+        ticking = true;
+        requestAnimationFrame(() => {
+          if (navRef.current) {
+            setIsNavPinned(navRef.current.getBoundingClientRect().top <= 81);
+          }
+          ticking = false;
+        });
+      }
+    };
+
+    window.addEventListener("scroll", onScroll, { passive: true });
+    onScroll();
+
+    return () => {
+      observer.disconnect();
+      window.removeEventListener("scroll", onScroll);
+    };
+  }, []);
+
+  const scrollToId = (e: MouseEvent<HTMLAnchorElement>, id: string) => {
+    e.preventDefault();
+    const el = document.getElementById(id);
+    if (!el) return;
+    const top = el.getBoundingClientRect().top + window.scrollY - ARCHITECTURE_SCROLL_MARGIN_PX;
+    window.scrollTo({ top, behavior: "smooth" });
+  };
+
+  return (
+    <motion.div
+      ref={navRef}
+      initial={{ opacity: 0, y: 18 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.48, delay: 0.38, ease: [0.22, 1, 0.36, 1] }}
+      className="sticky top-[80px] z-40 py-6 pointer-events-none"
+    >
+      <div className="max-w-3xl mx-auto px-6 flex justify-center">
+        <div
+          className={cn(
+            "pointer-events-auto flex items-center p-2 rounded-2xl transition-all duration-500 bg-bg-base",
+            isNavPinned ? "shadow-neu-raised-scrolled" : "shadow-neu-raised"
+          )}
+        >
+          <LayoutGroup id="architectureSectionNav">
+            <nav className="flex flex-wrap items-center justify-center gap-1 sm:gap-1.5">
+              {ARCHITECTURE_SECTIONS.map(({ id, label }) => {
+                const isActive = activeSection === id;
+                return (
+                  <a
+                    key={id}
+                    href={`#${id}`}
+                    onClick={(e) => scrollToId(e, id)}
+                    className={cn(
+                      "relative px-4 sm:px-5 py-2.5 rounded-xl text-sm font-bold transition-colors duration-300",
+                      isActive
+                        ? "text-theme-primary z-10"
+                        : "text-content-secondary hover:text-content-primary"
+                    )}
+                  >
+                    {isActive ? (
+                      <motion.span
+                        layoutId="architectureNavActivePill"
+                        className="absolute inset-0 rounded-xl bg-bg-base shadow-neu-sunken -z-10"
+                        transition={{ type: "spring", stiffness: 420, damping: 34 }}
+                      />
+                    ) : null}
+                    <span className="relative z-10">{label}</span>
+                  </a>
+                );
+              })}
+            </nav>
+          </LayoutGroup>
+        </div>
+      </div>
+    </motion.div>
+  );
+}

--- a/src/components/architecture/DiagramZoomModal.tsx
+++ b/src/components/architecture/DiagramZoomModal.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useEffect, type ReactNode } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { X } from "lucide-react";
+
+type Props = {
+  title: string;
+  isOpen: boolean;
+  onClose: () => void;
+  children: ReactNode;
+};
+
+export default function DiagramZoomModal({ title, isOpen, onClose, children }: Props) {
+  useEffect(() => {
+    document.body.style.overflow = isOpen ? "hidden" : "";
+    return () => { document.body.style.overflow = ""; };
+  }, [isOpen]);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
+    if (isOpen) window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [isOpen, onClose]);
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.22 }}
+          className="fixed inset-0 z-[200] flex items-center justify-center bg-[var(--color-bg-base)]/90 backdrop-blur-sm p-4 md:p-8"
+          onClick={onClose}
+        >
+          <motion.div
+            initial={{ opacity: 0, scale: 0.96 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.96 }}
+            transition={{ duration: 0.22 }}
+            className="relative w-full max-w-6xl max-h-[90vh] overflow-auto rounded-[2.5rem] bg-bg-elevated shadow-neu-raised-l2 flex flex-col p-6 md:p-8"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-center justify-between mb-6 shrink-0">
+              <span className="text-xs font-bold uppercase tracking-[0.2em] text-content-muted">
+                {title}
+              </span>
+              <button
+                onClick={onClose}
+                className="rounded-2xl bg-bg-base shadow-neu-raised-sm p-2.5 hover:shadow-neu-sunken transition-all text-content-secondary hover:text-content-primary"
+                aria-label="Close"
+              >
+                <X size={16} />
+              </button>
+            </div>
+            <div className="flex-1 w-full rounded-[2rem] bg-bg-base shadow-neu-sunken p-6 overflow-auto">
+              {children}
+            </div>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/components/architecture/IntegrationsMap.tsx
+++ b/src/components/architecture/IntegrationsMap.tsx
@@ -1,0 +1,162 @@
+import { BlueprintMotionSection } from "@/components/blueprint/BlueprintMotionSection";
+import { Info } from "lucide-react";
+
+export default function IntegrationsMap() {
+  return (
+    <BlueprintMotionSection id="integrations" className="px-6 py-24 bg-transparent">
+      <div className="max-w-6xl mx-auto">
+        <div className="flex flex-col items-center text-center mb-6">
+          <span className="inline-block rounded-full bg-bg-base shadow-neu-sunken px-4 py-2 text-xs font-semibold uppercase tracking-[0.24em] text-theme-primary mb-6">
+            Ecosystem Integrations
+          </span>
+          <h2 className="text-3xl md:text-4xl font-bold text-content-primary mb-4 tracking-tight">
+            Hub and Spoke Architecture
+          </h2>
+          <p className="text-content-secondary max-w-2xl text-lg mb-8">
+            OfferHub acts as the orchestrator, integrating best-in-class solutions for wallet management, escrow, and global fiat off-ramps.
+          </p>
+        </div>
+
+        <div className="rounded-2xl bg-bg-base shadow-neu-sunken-subtle px-5 py-4 mb-12 flex gap-3 items-start max-w-4xl mx-auto">
+          <Info size={15} className="text-theme-primary shrink-0 mt-0.5" />
+          <p className="text-sm text-content-secondary leading-relaxed">
+            OfferHub uses three building blocks from the official SCF Integration List. Stellar Wallets Kit handles non-custodial wallet connection and client-side Soroban signing. BlindPay routes USDC to bank accounts across 7 LATAM corridors via SPEI, Pix, PSE, and Transfer 3.0. Abroad delivers funds to mobile wallets (Nequi, Daviplata, Bre-B) for unbanked users. The NestJS orchestrator selects the off-ramp route automatically based on freelancer country and payout preference.
+          </p>
+        </div>
+
+        {/* Desktop Hub & Spoke / Mobile Stack */}
+        <div className="relative w-full max-w-5xl mx-auto flex flex-col md:block min-h-[600px] gap-8">
+          
+          {/* Animated SVG Lines (Desktop Only) */}
+          <svg className="hidden md:block absolute inset-0 w-full h-full pointer-events-none z-0" xmlns="http://www.w3.org/2000/svg">
+            <style>
+              {`
+                @keyframes dash-flow-left {
+                  to { stroke-dashoffset: -20; }
+                }
+                @keyframes dash-flow-right {
+                  to { stroke-dashoffset: 20; }
+                }
+                .anim-line-left { stroke-dasharray: 10; animation: dash-flow-left 1s linear infinite; }
+                .anim-line-right { stroke-dasharray: 10; animation: dash-flow-right 1s linear infinite; }
+              `}
+            </style>
+            
+            {/* Hub to SWK (Left) */}
+            <path d="M 500 300 Q 350 300 250 300" fill="none" stroke="#149A9B" strokeWidth="2" opacity="0.4" className="anim-line-left" />
+            
+            {/* Hub to BlindPay (Top Right) */}
+            <path d="M 500 300 Q 650 200 750 150" fill="none" stroke="#149A9B" strokeWidth="2" opacity="0.4" className="anim-line-right" />
+            
+            {/* Hub to Abroad (Bottom Right) */}
+            <path d="M 500 300 Q 650 400 750 450" fill="none" stroke="#149A9B" strokeWidth="2" opacity="0.4" className="anim-line-right" />
+          </svg>
+
+          {/* Mobile Connectors */}
+          <div className="md:hidden absolute inset-0 w-full h-full flex justify-center pointer-events-none z-0">
+             <div className="w-px h-full border-l-2 border-dashed border-[var(--color-primary)] opacity-40"></div>
+          </div>
+
+          {/* Center Hub: OfferHub */}
+          <div className="relative z-10 w-full md:absolute md:left-1/2 md:top-1/2 md:-translate-x-1/2 md:-translate-y-1/2 md:w-[220px]">
+            <div className="rounded-[2rem] bg-bg-elevated shadow-neu-raised p-6 flex flex-col items-center text-center border border-[var(--color-border)]">
+              <div className="w-4 h-4 rounded-full bg-[#149A9B] animate-pulse mb-3 shadow-[0_0_15px_rgba(20,154,155,0.6)]"></div>
+              <h3 className="text-xl font-bold text-content-primary">OfferHub</h3>
+              <p className="text-sm text-theme-primary font-medium mt-1 mb-3">NestJS Orchestrator</p>
+              <div className="rounded-xl bg-bg-base shadow-neu-sunken-subtle p-3 w-full">
+                <p className="text-xs text-content-secondary">Routes USDC based on freelancer country</p>
+              </div>
+            </div>
+          </div>
+
+          {/* Left Spoke: SWK */}
+          <div className="relative z-10 w-full md:absolute md:left-[5%] md:top-1/2 md:-translate-y-1/2 md:w-[320px]">
+            <div className="rounded-[2rem] bg-bg-elevated shadow-neu-raised p-6 border border-[var(--color-border)]">
+              <div className="flex justify-between items-start mb-4">
+                <h3 className="text-lg font-bold text-content-primary">Stellar Wallets Kit</h3>
+                <span className="text-[10px] font-bold uppercase tracking-wider bg-bg-base shadow-neu-sunken px-2 py-1 rounded-full text-theme-primary">SCF Integration #1</span>
+              </div>
+              <p className="text-sm text-content-secondary mb-4">Non-custodial signing</p>
+              
+              <div className="flex flex-wrap gap-2 mb-4">
+                {['Freighter', 'Lobstr', 'xBull'].map(w => (
+                  <span key={w} className="text-xs bg-bg-base shadow-neu-raised-sm px-3 py-1 rounded-full text-content-primary">{w}</span>
+                ))}
+              </div>
+              
+              <div className="rounded-xl bg-bg-base shadow-neu-sunken p-4">
+                <ul className="text-xs font-mono text-content-secondary space-y-2">
+                  <li>• create_escrow</li>
+                  <li>• release_escrow</li>
+                  <li>• refund_escrow</li>
+                  <li>• resolve_dispute</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+
+          {/* Right Top Spoke: BlindPay */}
+          <div className="relative z-10 w-full md:absolute md:right-[5%] md:top-[10%] md:w-[340px]">
+            <div className="rounded-[2rem] bg-bg-elevated shadow-neu-raised p-6 border border-[var(--color-border)]">
+              <div className="flex justify-between items-start mb-4">
+                <h3 className="text-lg font-bold text-content-primary">BlindPay</h3>
+                <span className="text-[10px] font-bold uppercase tracking-wider bg-bg-base shadow-neu-sunken px-2 py-1 rounded-full text-theme-primary">SCF Integration #2</span>
+              </div>
+              
+              <div className="flex flex-wrap gap-2 mb-4">
+                <span className="text-[10px] bg-bg-base shadow-neu-sunken-subtle px-2 py-1 rounded-md text-content-muted">FinCEN MSB</span>
+                <span className="text-[10px] bg-bg-base shadow-neu-sunken-subtle px-2 py-1 rounded-md text-content-muted">YC-backed</span>
+              </div>
+              
+              <div className="grid grid-cols-3 gap-2">
+                {['MX/SPEI', 'BR/Pix', 'CO/PSE', 'AR/Transfer 3.0', 'PE', 'CL', 'CR'].map(c => (
+                  <div key={c} className="text-[10px] font-medium text-center bg-bg-base shadow-neu-raised-sm rounded-lg py-2 text-content-primary px-1">
+                    {c}
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          {/* Right Bottom Spoke: Abroad */}
+          <div className="relative z-10 w-full md:absolute md:right-[5%] md:bottom-[10%] md:w-[340px]">
+            <div className="rounded-[2rem] bg-bg-elevated shadow-neu-raised p-6 border border-[var(--color-border)]">
+              <div className="flex justify-between items-start mb-4">
+                <h3 className="text-lg font-bold text-content-primary">Abroad</h3>
+                <span className="text-[10px] font-bold uppercase tracking-wider bg-bg-base shadow-neu-sunken px-2 py-1 rounded-full text-theme-primary">SCF Integration #3</span>
+              </div>
+              
+              <div className="flex flex-wrap gap-2 mb-4">
+                <span className="text-[10px] bg-bg-base shadow-neu-sunken-subtle px-2 py-1 rounded-md text-content-muted">Circle Alliance</span>
+                <span className="text-[10px] bg-bg-base shadow-neu-sunken-subtle px-2 py-1 rounded-md text-content-muted">47% unbanked</span>
+              </div>
+              
+              <div className="grid grid-cols-2 gap-3">
+                {['Nequi', 'Daviplata', 'Bre-B', 'Pix'].map(c => (
+                  <div key={c} className="text-xs font-medium text-center bg-bg-base shadow-neu-raised-sm rounded-xl py-3 text-content-primary">
+                    {c}
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+
+        </div>
+
+        {/* Stats Strip */}
+        <div className="mt-16 flex justify-center">
+          <div className="rounded-2xl bg-bg-elevated shadow-neu-raised-sm border border-[var(--color-border)] px-8 py-4 inline-flex flex-wrap justify-center items-center gap-4 text-sm font-medium text-content-secondary">
+            <span>3 SCF Integrations</span>
+            <span className="text-[var(--color-border)]">•</span>
+            <span>7 BlindPay Corridors</span>
+            <span className="text-[var(--color-border)]">•</span>
+            <span>4 Abroad Methods</span>
+            <span className="text-[var(--color-border)]">•</span>
+            <span className="text-theme-primary font-bold">11 Total Corridors</span>
+          </div>
+        </div>
+
+      </div>
+    </BlueprintMotionSection>
+  );
+}

--- a/src/components/architecture/MermaidDiagram.tsx
+++ b/src/components/architecture/MermaidDiagram.tsx
@@ -1,0 +1,63 @@
+"use client";
+import { useEffect, useRef, useState } from "react";
+
+type Props = { chart: string; className?: string; zoom?: boolean };
+
+export default function MermaidDiagram({ chart, className, zoom = false }: Props) {
+  const [svg, setSvg] = useState<string>("");
+  const idRef = useRef(`mermaid-${Math.random().toString(36).slice(2)}`);
+
+  useEffect(() => {
+    let cancelled = false;
+    const isDark = document.documentElement.classList.contains("dark");
+
+    import("mermaid").then((m) => {
+      m.default.initialize({
+        startOnLoad: false,
+        theme: "base",
+        themeVariables: {
+          primaryColor: "#149A9B",
+          primaryTextColor: isDark ? "#f1f3f7" : "#19213D",
+          primaryBorderColor: isDark ? "#3d3d5c" : "#d1d5db",
+          lineColor: "#149A9B",
+          secondaryColor: isDark ? "#2e2e3f" : "#F1F3F7",
+          tertiaryColor: isDark ? "#1a1a26" : "#ffffff",
+          background: isDark ? "#2e2e3f" : "#ffffff",
+          mainBkg: isDark ? "#2e2e3f" : "#ffffff",
+          nodeBorder: isDark ? "#3d3d5c" : "#d1d5db",
+          clusterBkg: isDark ? "#1a1a26" : "#F1F3F7",
+          titleColor: isDark ? "#f1f3f7" : "#19213D",
+          edgeLabelBackground: isDark ? "#1a1a26" : "#F1F3F7",
+          fontFamily: "Inter, sans-serif",
+          fontSize: zoom ? "16px" : "13px",
+        },
+      });
+      m.default.render(idRef.current, chart).then(({ svg: raw }) => {
+        if (!cancelled) {
+          // Strip Mermaid's inline max-width so the SVG fills its container
+          const responsive = raw.replace(
+            /(<svg[^>]*)\sstyle="[^"]*max-width:[^"]*"/,
+            '$1 style="width: 100%; height: auto;"'
+          );
+          setSvg(responsive);
+        }
+      });
+    });
+    return () => { cancelled = true; };
+  }, [chart, zoom]);
+
+  if (!svg)
+    return (
+      <div
+        className={`rounded-2xl bg-bg-sunken shadow-neu-sunken animate-pulse ${className ?? ""}`}
+        style={{ minHeight: zoom ? 400 : 200 }}
+      />
+    );
+
+  return (
+    <div
+      className={`${zoom ? "[&>svg]:w-full" : "[&>svg]:max-w-full"} [&>svg]:h-auto ${className ?? ""}`}
+      dangerouslySetInnerHTML={{ __html: svg }}
+    />
+  );
+}

--- a/src/components/architecture/PaymentFlowDiagram.tsx
+++ b/src/components/architecture/PaymentFlowDiagram.tsx
@@ -66,7 +66,7 @@ stateDiagram-v2
         <div className="rounded-2xl bg-bg-base shadow-neu-sunken-subtle px-5 py-4 mb-6 flex gap-3 items-start">
           <Info size={15} className="text-theme-primary shrink-0 mt-0.5" />
           <p className="text-sm text-content-secondary leading-relaxed">
-            The sequence diagram traces a complete escrow lifecycle: from order creation to fiat settlement. All Soroban transactions (fund_escrow and release_escrow) are signed client-side by the user's wallet via Stellar Wallets Kit — no private keys ever touch the server. The state diagram on the right shows every valid order state, including the dispute resolution path.
+            The sequence diagram traces a complete escrow lifecycle: from order creation to fiat settlement. All Soroban transactions (fund_escrow and release_escrow) are signed client-side by the user&apos;s wallet via Stellar Wallets Kit — no private keys ever touch the server. The state diagram on the right shows every valid order state, including the dispute resolution path.
           </p>
         </div>
 

--- a/src/components/architecture/PaymentFlowDiagram.tsx
+++ b/src/components/architecture/PaymentFlowDiagram.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useState } from "react";
+import { BlueprintMotionSection } from "@/components/blueprint/BlueprintMotionSection";
+import MermaidDiagram from "./MermaidDiagram";
+import DiagramZoomModal from "./DiagramZoomModal";
+import { Info, Maximize2 } from "lucide-react";
+
+export default function PaymentFlowDiagram() {
+  const [isSeqZoomOpen, setIsSeqZoomOpen] = useState(false);
+  const [isStateZoomOpen, setIsStateZoomOpen] = useState(false);
+
+  const sequenceChart = `
+sequenceDiagram
+    participant Client as Client (buyer)
+    participant SWK as SWK
+    participant NestJS as NestJS (OfferHub API)
+    participant TW as TrustlessWork (escrow)
+    participant Offramp as BlindPay/Abroad
+
+    Client->>NestJS: POST /orders (USDC reserved)
+    NestJS->>TW: deployEscrow(buyer, seller, amount)
+    TW-->>NestJS: escrowId + contractAddress
+    NestJS-->>Client: { escrowId, contractAddress }
+    
+    Client->>SWK: signTransaction(fund_escrow)
+    SWK->>TW: fund_escrow (USDC on-chain)
+    
+    Note over TW: State: ESCROW_FUNDED → IN_PROGRESS
+    
+    Client->>SWK: signTransaction(release_escrow)
+    SWK->>TW: release_escrow
+    TW-->>NestJS: webhook: escrow_released
+    NestJS->>Offramp: POST /payout (USDC → fiat)
+    Offramp-->>Client: fiat settled (SPEI / Pix / Nequi...)
+  `;
+
+  const stateChart = `
+stateDiagram-v2
+    [*] --> CREATED
+    CREATED --> RESERVED
+    RESERVED --> ESCROW_FUNDED
+    ESCROW_FUNDED --> IN_PROGRESS
+    IN_PROGRESS --> COMPLETED
+    IN_PROGRESS --> DISPUTED
+    DISPUTED --> RESOLVED
+    COMPLETED --> [*]
+    RESOLVED --> [*]
+  `;
+
+  return (
+    <BlueprintMotionSection id="flow" className="px-6 py-24 bg-bg-base">
+      <div className="max-w-6xl mx-auto">
+        <div className="flex flex-col items-center text-center mb-12">
+          <span className="inline-block rounded-full bg-bg-elevated shadow-neu-raised-sm px-4 py-2 text-xs font-semibold uppercase tracking-[0.24em] text-theme-primary mb-6">
+            Payment Flow Lifecycle
+          </span>
+          <h2 className="text-3xl md:text-4xl font-bold text-content-primary mb-4 tracking-tight">
+            Escrow Lifecycle & Payouts
+          </h2>
+          <p className="text-content-secondary max-w-2xl text-lg">
+            A secure, non-custodial workflow powered by Soroban smart contracts and executed via Stellar Wallets Kit.
+          </p>
+        </div>
+
+        <div className="rounded-2xl bg-bg-base shadow-neu-sunken-subtle px-5 py-4 mb-6 flex gap-3 items-start">
+          <Info size={15} className="text-theme-primary shrink-0 mt-0.5" />
+          <p className="text-sm text-content-secondary leading-relaxed">
+            The sequence diagram traces a complete escrow lifecycle: from order creation to fiat settlement. All Soroban transactions (fund_escrow and release_escrow) are signed client-side by the user's wallet via Stellar Wallets Kit — no private keys ever touch the server. The state diagram on the right shows every valid order state, including the dispute resolution path.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+          <div className="rounded-[2.5rem] bg-bg-elevated shadow-neu-raised-l2 p-6 md:p-8 flex flex-col h-full">
+            <h3 className="text-xl font-bold text-content-primary mb-6 ml-2">Transaction Flow</h3>
+            <div className="relative rounded-[2rem] bg-bg-base shadow-neu-sunken p-6 flex-grow overflow-x-auto">
+              <MermaidDiagram chart={sequenceChart} className="w-full min-w-[500px]" />
+              <button
+                onClick={() => setIsSeqZoomOpen(true)}
+                className="absolute top-4 right-4 rounded-xl bg-bg-base shadow-neu-raised-sm p-2 hover:shadow-neu-sunken transition-all z-10"
+                aria-label="Expand diagram"
+              >
+                <Maximize2 size={15} className="text-theme-primary" />
+              </button>
+            </div>
+            <p className="mt-3 text-center text-xs text-content-muted">
+              For a better view, click <Maximize2 size={11} className="inline text-theme-primary mx-0.5 -mt-0.5" /> to expand
+            </p>
+            <DiagramZoomModal title="Transaction Flow" isOpen={isSeqZoomOpen} onClose={() => setIsSeqZoomOpen(false)}>
+              <MermaidDiagram chart={sequenceChart} className="w-full" zoom />
+            </DiagramZoomModal>
+          </div>
+
+          <div className="rounded-[2.5rem] bg-bg-elevated shadow-neu-raised-l2 p-6 md:p-8 flex flex-col h-full">
+            <h3 className="text-xl font-bold text-content-primary mb-6 ml-2">Escrow State Machine</h3>
+            <div className="relative rounded-[2rem] bg-bg-base shadow-neu-sunken p-6 flex-grow overflow-x-auto">
+              <MermaidDiagram chart={stateChart} className="w-full min-w-[300px]" />
+              <button
+                onClick={() => setIsStateZoomOpen(true)}
+                className="absolute top-4 right-4 rounded-xl bg-bg-base shadow-neu-raised-sm p-2 hover:shadow-neu-sunken transition-all z-10"
+                aria-label="Expand diagram"
+              >
+                <Maximize2 size={15} className="text-theme-primary" />
+              </button>
+            </div>
+            <p className="mt-3 text-center text-xs text-content-muted">
+              For a better view, click <Maximize2 size={11} className="inline text-theme-primary mx-0.5 -mt-0.5" /> to expand
+            </p>
+            <DiagramZoomModal title="Escrow State Machine" isOpen={isStateZoomOpen} onClose={() => setIsStateZoomOpen(false)}>
+              <MermaidDiagram chart={stateChart} className="w-full" zoom />
+            </DiagramZoomModal>
+          </div>
+        </div>
+      </div>
+    </BlueprintMotionSection>
+  );
+}

--- a/src/components/architecture/SCFTrancheRoadmap.tsx
+++ b/src/components/architecture/SCFTrancheRoadmap.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useState } from "react";
+import { BlueprintMotionSection } from "@/components/blueprint/BlueprintMotionSection";
+import MermaidDiagram from "./MermaidDiagram";
+import DiagramZoomModal from "./DiagramZoomModal";
+import { Info, Maximize2 } from "lucide-react";
+
+export default function SCFTrancheRoadmap() {
+  const [isZoomOpen, setIsZoomOpen] = useState(false);
+
+  const ganttChart = `
+gantt
+  title OfferHub SCF Build #44 — Delivery Roadmap
+  dateFormat YYYY-MM-DD
+  axisFormat %b %d
+
+  section T1 — Foundation ($15K)
+    SWK Wallet Connection + Balance Display    :t1a, 2026-07-01, 2026-09-01
+    Wallet-Based Auth (hybrid)                 :t1b, 2026-08-01, 2026-09-01
+
+  section T2 — Core Integrations ($47K)
+    Soroban Client-Side Signing (SWK)          :t2a, 2026-09-01, 2026-10-20
+    BlindPay — 7 LATAM Corridors               :t2b, 2026-09-01, 2026-10-20
+    Abroad — Nequi/Daviplata/Bre-B/Pix         :t2c, 2026-09-15, 2026-10-20
+    Off-ramp Orchestration + Webhooks          :t2d, 2026-09-15, 2026-10-20
+    E2E Integration Testing                    :t2e, 2026-10-01, 2026-10-20
+
+  section T3 — Mainnet & Open-Source ($18K)
+    Horizon → Stellar RPC Migration            :t3a, 2026-10-20, 2026-12-05
+    Mainnet Launch + Monitoring                :t3b, 2026-10-20, 2026-12-05
+    Open-Source Integration Adapters           :t3c, 2026-11-15, 2026-12-05
+  `;
+
+  return (
+    <BlueprintMotionSection id="roadmap" className="px-6 py-24 bg-bg-base">
+      <div className="max-w-6xl mx-auto">
+        <div className="flex flex-col items-center text-center mb-6">
+          <span className="inline-block rounded-full bg-bg-elevated shadow-neu-raised-sm px-4 py-2 text-xs font-semibold uppercase tracking-[0.24em] text-theme-primary mb-6">
+            Delivery Schedule
+          </span>
+          <h2 className="text-3xl md:text-4xl font-bold text-content-primary mb-4 tracking-tight">
+            SCF Build #44 Roadmap
+          </h2>
+          <p className="text-content-secondary max-w-2xl text-lg mb-8">
+            Detailed timeline for the execution of our $80,000 SCF Build Award milestones.
+          </p>
+        </div>
+
+        <div className="rounded-2xl bg-bg-base shadow-neu-sunken-subtle px-5 py-4 mb-12 flex gap-3 items-start max-w-4xl mx-auto">
+          <Info size={15} className="text-theme-primary shrink-0 mt-0.5" />
+          <p className="text-sm text-content-secondary leading-relaxed">
+            Three tranches, each tied to verifiable on-chain or functional deliverables. Tranche 1 ships the wallet connection layer. Tranche 2 completes all three SCF integrations on testnet. Tranche 3 migrates to Stellar RPC, launches on mainnet, records 10 live transactions as proof, and open-sources the integration adapters.
+          </p>
+        </div>
+
+        <div className="rounded-[2.5rem] bg-bg-elevated shadow-neu-raised-l2 p-6 md:p-10 mb-12">
+          <div className="relative rounded-[2rem] bg-bg-base shadow-neu-sunken p-6 overflow-x-auto w-full">
+            <MermaidDiagram chart={ganttChart} className="w-full min-w-[800px]" />
+            <button
+              onClick={() => setIsZoomOpen(true)}
+              className="absolute top-4 right-4 rounded-xl bg-bg-base shadow-neu-raised-sm p-2 hover:shadow-neu-sunken transition-all z-10"
+              aria-label="Expand diagram"
+            >
+              <Maximize2 size={15} className="text-theme-primary" />
+            </button>
+          </div>
+          <p className="mt-3 text-center text-xs text-content-muted">
+            For a better view, click <Maximize2 size={11} className="inline text-theme-primary mx-0.5 -mt-0.5" /> to expand
+          </p>
+
+          <DiagramZoomModal title="SCF Build #44 Roadmap" isOpen={isZoomOpen} onClose={() => setIsZoomOpen(false)}>
+            <MermaidDiagram chart={ganttChart} className="w-full" zoom />
+          </DiagramZoomModal>
+        </div>
+
+        <div className="rounded-[2rem] bg-bg-base shadow-neu-sunken overflow-hidden max-w-4xl mx-auto border border-[var(--color-border)]">
+          <div className="overflow-x-auto">
+            <table className="w-full text-left border-collapse">
+              <thead>
+                <tr className="bg-bg-sunken text-content-muted text-xs uppercase tracking-widest">
+                  <th className="py-4 px-6 font-semibold">Milestone</th>
+                  <th className="py-4 px-6 font-semibold">Date</th>
+                  <th className="py-4 px-6 font-semibold">Budget</th>
+                  <th className="py-4 px-6 font-semibold">SCF Payment</th>
+                  <th className="py-4 px-6 font-semibold">%</th>
+                </tr>
+              </thead>
+              <tbody className="text-sm">
+                <tr className="border-b border-[var(--color-border)]">
+                  <td className="py-4 px-6 font-medium text-content-primary">T0 Upfront</td>
+                  <td className="py-4 px-6 text-content-secondary">On award</td>
+                  <td className="py-4 px-6 text-content-secondary">—</td>
+                  <td className="py-4 px-6 text-content-secondary">$8,000</td>
+                  <td className="py-4 px-6 text-content-secondary">10%</td>
+                </tr>
+                <tr className="border-b border-[var(--color-border)]">
+                  <td className="py-4 px-6 font-medium text-content-primary">T1 Complete</td>
+                  <td className="py-4 px-6 text-content-secondary">Sept 1, 2026</td>
+                  <td className="py-4 px-6 text-content-secondary">$15,000</td>
+                  <td className="py-4 px-6 text-content-secondary">$16,000</td>
+                  <td className="py-4 px-6 text-content-secondary">20%</td>
+                </tr>
+                <tr className="border-b border-[var(--color-border)]">
+                  <td className="py-4 px-6 font-medium text-content-primary">T2 Complete</td>
+                  <td className="py-4 px-6 text-content-secondary">Oct 20, 2026</td>
+                  <td className="py-4 px-6 text-content-secondary">$47,000</td>
+                  <td className="py-4 px-6 text-content-secondary">$24,000</td>
+                  <td className="py-4 px-6 text-content-secondary">30%</td>
+                </tr>
+                <tr className="border-b border-[var(--color-border)]">
+                  <td className="py-4 px-6 font-medium text-content-primary">T3 Complete</td>
+                  <td className="py-4 px-6 text-content-secondary">Dec 5, 2026</td>
+                  <td className="py-4 px-6 text-content-secondary">$18,000</td>
+                  <td className="py-4 px-6 text-content-secondary">$32,000</td>
+                  <td className="py-4 px-6 text-content-secondary">40%</td>
+                </tr>
+                <tr className="font-bold">
+                  <td className="py-4 px-6 text-theme-primary">Total</td>
+                  <td className="py-4 px-6 text-theme-primary"></td>
+                  <td className="py-4 px-6 text-theme-primary">$80,000</td>
+                  <td className="py-4 px-6 text-theme-primary">$80,000</td>
+                  <td className="py-4 px-6 text-theme-primary">100%</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+      </div>
+    </BlueprintMotionSection>
+  );
+}

--- a/src/components/architecture/SystemArchitectureDiagram.tsx
+++ b/src/components/architecture/SystemArchitectureDiagram.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useState } from "react";
+import { BlueprintMotionSection } from "@/components/blueprint/BlueprintMotionSection";
+import MermaidDiagram from "./MermaidDiagram";
+import DiagramZoomModal from "./DiagramZoomModal";
+import { Info, Maximize2 } from "lucide-react";
+
+export default function SystemArchitectureDiagram() {
+  const [isZoomOpen, setIsZoomOpen] = useState(false);
+
+  const chart = `
+flowchart TD
+    %% Node Styling
+    classDef highlight fill:#149A9B,color:#fff,stroke:#0d7377,stroke-width:2px;
+    classDef backend fill:#002333,color:#fff,stroke:#001522,stroke-width:2px;
+    classDef subtle fill:#F1F3F7,color:#19213D,stroke:#d1d5db,stroke-width:1px;
+
+    Client["Client Layer<br/><small>Next.js 15 · React 19 · Zustand · NextAuth v5</small>"]:::highlight
+    Wallet["Wallet Layer<br/><small>Stellar Wallets Kit · Freighter · Lobstr · xBull</small>"]:::highlight
+    API["NestJS API<br/><small>Auth · Orders · Escrow · Payments · Webhooks · Off-ramp</small>"]:::backend
+    Data["Data Layer<br/><small>PostgreSQL · Redis · BullMQ</small>"]:::subtle
+    Stellar["Stellar<br/><small>Soroban Contracts · TrustlessWork · USDC</small>"]:::subtle
+    Offramp["Off-ramp<br/><small>BlindPay · Abroad</small>"]:::highlight
+
+    Client -->|HTTPS / REST| API
+    Client -->|Client-side Soroban signing| Wallet
+    API -->|Prisma ORM| Data
+    API -->|Stellar RPC| Stellar
+    Stellar -->|Webhook / on-chain event| API
+    API -->|API / Webhooks| Offramp
+    Wallet -.->|Sign & Submit| Stellar
+  `;
+
+  return (
+    <BlueprintMotionSection id="system" className="px-6 py-24 bg-transparent">
+      <div className="max-w-6xl mx-auto">
+        <div className="rounded-[2.5rem] bg-bg-elevated shadow-neu-raised-l2 p-8 md:p-12">
+          
+          <div className="flex flex-col items-center text-center mb-10">
+            <span className="inline-block rounded-full bg-bg-base shadow-neu-sunken px-4 py-2 text-xs font-semibold uppercase tracking-[0.24em] text-theme-primary mb-6">
+              Architecture Overview
+            </span>
+            <h2 className="text-3xl md:text-4xl font-bold text-content-primary mb-4 tracking-tight">
+              OfferHub System Architecture
+            </h2>
+            <p className="text-content-secondary max-w-2xl text-lg">
+              A comprehensive view of the OfferHub platform, showing the flow between our modern frontend, NestJS orchestrator, and external integrations.
+            </p>
+          </div>
+
+          <div className="rounded-2xl bg-bg-base shadow-neu-sunken-subtle px-5 py-4 mb-6 flex gap-3 items-start">
+            <Info size={15} className="text-theme-primary shrink-0 mt-0.5" />
+            <p className="text-sm text-content-secondary leading-relaxed">
+              This flowchart maps every layer of the OfferHub stack — from the browser and Stellar Wallets Kit on the client side, through the NestJS orchestration API and PostgreSQL/Redis data layer, down to Soroban smart contracts on Stellar and the BlindPay/Abroad off-ramp providers. Arrows show the protocol or method used at each boundary. Teal nodes are the three SCF Integration Track building blocks.
+            </p>
+          </div>
+
+          <div className="relative rounded-[2rem] bg-bg-base shadow-neu-sunken p-6 w-full overflow-x-auto">
+            <MermaidDiagram chart={chart} className="w-full min-w-[600px]" />
+            <button
+              onClick={() => setIsZoomOpen(true)}
+              className="absolute top-4 right-4 rounded-xl bg-bg-base shadow-neu-raised-sm p-2 hover:shadow-neu-sunken transition-all z-10"
+              aria-label="Expand diagram"
+            >
+              <Maximize2 size={15} className="text-theme-primary" />
+            </button>
+          </div>
+          <p className="mt-3 text-center text-xs text-content-muted">
+            For a better view, click <Maximize2 size={11} className="inline text-theme-primary mx-0.5 -mt-0.5" /> to expand
+          </p>
+
+          <DiagramZoomModal title="System Architecture" isOpen={isZoomOpen} onClose={() => setIsZoomOpen(false)}>
+            <MermaidDiagram chart={chart} className="w-full" zoom />
+          </DiagramZoomModal>
+
+          <div className="mt-8 flex flex-wrap justify-center gap-6 text-sm font-medium">
+            <div className="flex items-center gap-2">
+              <span className="w-3 h-3 rounded-full bg-[#149A9B] shadow-neu-raised-sm"></span>
+              <span className="text-content-secondary">SCF Integration / Client</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="w-3 h-3 rounded-full bg-[#002333] shadow-neu-raised-sm"></span>
+              <span className="text-content-secondary">Internal API</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="w-3 h-3 rounded-full bg-[#F1F3F7] border border-[var(--color-border)] shadow-neu-raised-sm"></span>
+              <span className="text-content-secondary">Persistence / Chain</span>
+            </div>
+          </div>
+
+        </div>
+      </div>
+    </BlueprintMotionSection>
+  );
+}

--- a/src/components/architecture/TractionSection.tsx
+++ b/src/components/architecture/TractionSection.tsx
@@ -1,0 +1,109 @@
+import { BlueprintMotionSection } from "@/components/blueprint/BlueprintMotionSection";
+import { Info, CheckCircle2 } from "lucide-react";
+
+export default function TractionSection() {
+  return (
+    <BlueprintMotionSection id="traction" className="px-6 py-24 bg-bg-base">
+      <div className="max-w-6xl mx-auto">
+        <div className="flex flex-col items-center text-center mb-6">
+          <span className="inline-block rounded-full bg-bg-elevated shadow-neu-raised-sm px-4 py-2 text-xs font-semibold uppercase tracking-[0.24em] text-theme-primary mb-6">
+            Platform Traction
+          </span>
+          <h2 className="text-3xl md:text-4xl font-bold text-content-primary mb-4 tracking-tight">
+            Live on testnet. Built for scale.
+          </h2>
+          <p className="text-content-secondary max-w-2xl text-lg mb-8">
+            Current platform metrics and the validated LATAM freelance market opportunity.
+          </p>
+        </div>
+
+        <div className="rounded-2xl bg-bg-base shadow-neu-sunken-subtle px-5 py-4 mb-12 flex gap-3 items-start max-w-4xl mx-auto">
+          <Info size={15} className="text-theme-primary shrink-0 mt-0.5" />
+          <p className="text-sm text-content-secondary leading-relaxed">
+            The SCF Integration Track requires verifiable traction. This section shows OfferHub's current testnet status, team readiness, and the market context that validates the integration investment.
+          </p>
+        </div>
+
+        <div className="grid md:grid-cols-2 gap-8 max-w-5xl mx-auto">
+          
+          {/* Block A — Current platform status */}
+          <div className="flex flex-col gap-6">
+            <div className="flex items-center gap-3">
+              <h3 className="text-xl font-bold text-content-primary">Platform status</h3>
+              <div className="flex items-center gap-2 rounded-full bg-bg-elevated shadow-neu-raised-sm px-3 py-1">
+                <span className="w-2 h-2 rounded-full bg-green-500 animate-pulse"></span>
+                <span className="text-xs font-bold text-content-secondary uppercase">Testnet live</span>
+              </div>
+            </div>
+
+            <div className="grid grid-cols-2 gap-3">
+              <div className="rounded-2xl bg-bg-base shadow-neu-sunken p-5 text-center flex flex-col justify-center">
+                <p className="text-sm font-bold text-content-primary mb-1">NestJS API</p>
+                <p className="text-xs text-content-secondary">12 modules in production</p>
+              </div>
+              <div className="rounded-2xl bg-bg-base shadow-neu-sunken p-5 text-center flex flex-col justify-center">
+                <p className="text-sm font-bold text-content-primary mb-1">PostgreSQL</p>
+                <p className="text-xs text-content-secondary">Orders, escrow, reviews, payments</p>
+              </div>
+              <div className="rounded-2xl bg-bg-base shadow-neu-sunken p-5 text-center flex flex-col justify-center">
+                <p className="text-sm font-bold text-content-primary mb-1">GitHub</p>
+                <p className="text-xs text-content-secondary">Open-source codebase</p>
+              </div>
+              <div className="rounded-2xl bg-bg-base shadow-neu-sunken p-5 text-center flex flex-col justify-center">
+                <p className="text-sm font-bold text-content-primary mb-1">Next.js 15</p>
+                <p className="text-xs text-content-secondary">Production frontend deployed</p>
+              </div>
+            </div>
+
+            <div className="rounded-2xl bg-bg-elevated shadow-neu-raised-sm p-5 mt-2">
+              <h4 className="text-sm font-bold text-content-primary mb-4">Build readiness</h4>
+              <ul className="space-y-3 text-sm text-content-secondary">
+                <li className="flex gap-3 items-start">
+                  <CheckCircle2 size={16} className="text-theme-primary shrink-0 mt-0.5" />
+                  <span>Full-stack TypeScript team with NestJS + Next.js experience</span>
+                </li>
+                <li className="flex gap-3 items-start">
+                  <CheckCircle2 size={16} className="text-theme-primary shrink-0 mt-0.5" />
+                  <span>Existing Stellar integration (custodial keypairs → migrating to non-custodial via SWK)</span>
+                </li>
+                <li className="flex gap-3 items-start">
+                  <CheckCircle2 size={16} className="text-theme-primary shrink-0 mt-0.5" />
+                  <span>TrustlessWork integration contracts already tested on testnet</span>
+                </li>
+                <li className="flex gap-3 items-start">
+                  <CheckCircle2 size={16} className="text-theme-primary shrink-0 mt-0.5" />
+                  <span>BlindPay and Abroad onboarding initiated — estimated 1–2 weeks to production</span>
+                </li>
+              </ul>
+            </div>
+          </div>
+
+          {/* Block B — Market opportunity */}
+          <div className="flex flex-col gap-6">
+            <h3 className="text-xl font-bold text-content-primary">The LATAM freelance gap</h3>
+            
+            <div className="flex flex-col gap-4">
+              <div className="rounded-[2rem] bg-bg-elevated shadow-neu-raised-l2-sm p-7 flex items-center justify-between">
+                <span className="text-3xl md:text-4xl font-black text-theme-primary">$85B</span>
+                <span className="text-sm text-content-muted text-right max-w-[150px]">LATAM freelance market size (2024)</span>
+              </div>
+              <div className="rounded-[2rem] bg-bg-elevated shadow-neu-raised-l2-sm p-7 flex items-center justify-between">
+                <span className="text-3xl md:text-4xl font-black text-theme-primary">47%</span>
+                <span className="text-sm text-content-muted text-right max-w-[150px]">Workforce without bank accounts — Colombia</span>
+              </div>
+              <div className="rounded-[2rem] bg-bg-elevated shadow-neu-raised-l2-sm p-7 flex items-center justify-between">
+                <span className="text-3xl md:text-4xl font-black text-theme-primary">7</span>
+                <span className="text-sm text-content-muted text-right max-w-[150px]">Countries covered by BlindPay + Abroad corridors</span>
+              </div>
+            </div>
+
+            <div className="rounded-2xl bg-bg-base shadow-neu-sunken p-5 text-sm text-content-secondary leading-relaxed mt-2">
+              Traditional platforms (Upwork, Fiverr) cannot pay unbanked LATAM freelancers directly. OfferHub + Stellar + BlindPay + Abroad closes this gap: any freelancer with a mobile wallet receives USDC-settled payments in seconds, converted to local fiat via established licensed corridors.
+            </div>
+          </div>
+
+        </div>
+      </div>
+    </BlueprintMotionSection>
+  );
+}

--- a/src/components/architecture/TractionSection.tsx
+++ b/src/components/architecture/TractionSection.tsx
@@ -20,7 +20,7 @@ export default function TractionSection() {
         <div className="rounded-2xl bg-bg-base shadow-neu-sunken-subtle px-5 py-4 mb-12 flex gap-3 items-start max-w-4xl mx-auto">
           <Info size={15} className="text-theme-primary shrink-0 mt-0.5" />
           <p className="text-sm text-content-secondary leading-relaxed">
-            The SCF Integration Track requires verifiable traction. This section shows OfferHub's current testnet status, team readiness, and the market context that validates the integration investment.
+            The SCF Integration Track requires verifiable traction. This section shows OfferHub&apos;s current testnet status, team readiness, and the market context that validates the integration investment.
           </p>
         </div>
 

--- a/src/components/architecture/WhyStellarSection.tsx
+++ b/src/components/architecture/WhyStellarSection.tsx
@@ -20,7 +20,7 @@ export default function WhyStellarSection() {
         <div className="rounded-2xl bg-bg-base shadow-neu-sunken-subtle px-5 py-4 mb-12 flex gap-3 items-start max-w-4xl mx-auto">
           <Info size={15} className="text-theme-primary shrink-0 mt-0.5" />
           <p className="text-sm text-content-secondary leading-relaxed">
-            This section answers the SCF panel's core question: why is Stellar the right foundation for OfferHub, and what value does this integration bring to the Stellar ecosystem?
+            This section answers the SCF panel&apos;s core question: why is Stellar the right foundation for OfferHub, and what value does this integration bring to the Stellar ecosystem?
           </p>
         </div>
 
@@ -32,7 +32,7 @@ export default function WhyStellarSection() {
             </div>
             <h3 className="text-base font-bold text-content-primary">USDC on Stellar</h3>
             <p className="text-sm text-content-secondary leading-relaxed">
-              Stellar's native USDC support means freelancers receive payment in a stable, internationally liquid asset — no wrapping, no bridge risk, no slippage. Every escrow is denominated in USDC, eliminating currency volatility from the payment contract.
+              Stellar&apos;s native USDC support means freelancers receive payment in a stable, internationally liquid asset — no wrapping, no bridge risk, no slippage. Every escrow is denominated in USDC, eliminating currency volatility from the payment contract.
             </p>
           </div>
 
@@ -52,7 +52,7 @@ export default function WhyStellarSection() {
             </div>
             <h3 className="text-base font-bold text-content-primary">Soroban smart contracts (TrustlessWork)</h3>
             <p className="text-sm text-content-secondary leading-relaxed">
-              Soroban enables programmable, audited escrow logic on Stellar. OfferHub integrates TrustlessWork's open-source Soroban contracts rather than building from scratch — leveraging already-audited code and contributing to Stellar's composable DeFi layer.
+              Soroban enables programmable, audited escrow logic on Stellar. OfferHub integrates TrustlessWork&apos;s open-source Soroban contracts rather than building from scratch — leveraging already-audited code and contributing to Stellar&apos;s composable DeFi layer.
             </p>
           </div>
 
@@ -62,7 +62,7 @@ export default function WhyStellarSection() {
             </div>
             <h3 className="text-base font-bold text-content-primary">Non-custodial by design</h3>
             <p className="text-sm text-content-secondary leading-relaxed">
-              Stellar Wallets Kit allows client-side transaction signing. Funds never pass through OfferHub's servers. This is the correct model for a marketplace handling freelancer payments at scale — OfferHub cannot freeze, redirect, or lose user funds.
+              Stellar Wallets Kit allows client-side transaction signing. Funds never pass through OfferHub&apos;s servers. This is the correct model for a marketplace handling freelancer payments at scale — OfferHub cannot freeze, redirect, or lose user funds.
             </p>
           </div>
 

--- a/src/components/architecture/WhyStellarSection.tsx
+++ b/src/components/architecture/WhyStellarSection.tsx
@@ -1,0 +1,93 @@
+import { BlueprintMotionSection } from "@/components/blueprint/BlueprintMotionSection";
+import { Info, DollarSign, Zap, Shield, Lock, Globe, Users } from "lucide-react";
+
+export default function WhyStellarSection() {
+  return (
+    <BlueprintMotionSection id="why-stellar" className="px-6 py-24 bg-transparent">
+      <div className="max-w-6xl mx-auto">
+        <div className="flex flex-col items-center text-center mb-6">
+          <span className="inline-block rounded-full bg-bg-base shadow-neu-sunken px-4 py-2 text-xs font-semibold uppercase tracking-[0.24em] text-theme-primary mb-6">
+            Why Stellar
+          </span>
+          <h2 className="text-3xl md:text-4xl font-bold text-content-primary mb-4 tracking-tight">
+            The case for Stellar
+          </h2>
+          <p className="text-content-secondary max-w-2xl text-lg mb-8">
+            What Stellar uniquely enables for OfferHub that no other chain or payment rail provides.
+          </p>
+        </div>
+
+        <div className="rounded-2xl bg-bg-base shadow-neu-sunken-subtle px-5 py-4 mb-12 flex gap-3 items-start max-w-4xl mx-auto">
+          <Info size={15} className="text-theme-primary shrink-0 mt-0.5" />
+          <p className="text-sm text-content-secondary leading-relaxed">
+            This section answers the SCF panel's core question: why is Stellar the right foundation for OfferHub, and what value does this integration bring to the Stellar ecosystem?
+          </p>
+        </div>
+
+        <div className="grid md:grid-cols-2 gap-5 max-w-5xl mx-auto">
+          
+          <div className="rounded-[2rem] bg-bg-elevated shadow-neu-raised-l2-sm p-7 flex flex-col gap-4">
+            <div className="rounded-2xl p-3 shadow-neu-sunken-subtle bg-bg-base w-fit">
+              <DollarSign size={24} className="text-theme-primary" />
+            </div>
+            <h3 className="text-base font-bold text-content-primary">USDC on Stellar</h3>
+            <p className="text-sm text-content-secondary leading-relaxed">
+              Stellar's native USDC support means freelancers receive payment in a stable, internationally liquid asset — no wrapping, no bridge risk, no slippage. Every escrow is denominated in USDC, eliminating currency volatility from the payment contract.
+            </p>
+          </div>
+
+          <div className="rounded-[2rem] bg-bg-elevated shadow-neu-raised-l2-sm p-7 flex flex-col gap-4">
+            <div className="rounded-2xl p-3 shadow-neu-sunken-subtle bg-bg-base w-fit">
+              <Zap size={24} className="text-theme-primary" />
+            </div>
+            <h3 className="text-base font-bold text-content-primary">Sub-second finality, ~$0.0001/tx</h3>
+            <p className="text-sm text-content-secondary leading-relaxed">
+              Stellar confirms transactions in 3–5 seconds with fees under a fraction of a cent. For a marketplace processing hundreds of escrow releases weekly, this makes on-chain payment settlement economically viable at any order size — including micro-orders under $10.
+            </p>
+          </div>
+
+          <div className="rounded-[2rem] bg-bg-elevated shadow-neu-raised-l2-sm p-7 flex flex-col gap-4">
+            <div className="rounded-2xl p-3 shadow-neu-sunken-subtle bg-bg-base w-fit">
+              <Shield size={24} className="text-[var(--color-secondary)]" />
+            </div>
+            <h3 className="text-base font-bold text-content-primary">Soroban smart contracts (TrustlessWork)</h3>
+            <p className="text-sm text-content-secondary leading-relaxed">
+              Soroban enables programmable, audited escrow logic on Stellar. OfferHub integrates TrustlessWork's open-source Soroban contracts rather than building from scratch — leveraging already-audited code and contributing to Stellar's composable DeFi layer.
+            </p>
+          </div>
+
+          <div className="rounded-[2rem] bg-bg-elevated shadow-neu-raised-l2-sm p-7 flex flex-col gap-4">
+            <div className="rounded-2xl p-3 shadow-neu-sunken-subtle bg-bg-base w-fit">
+              <Lock size={24} className="text-theme-primary" />
+            </div>
+            <h3 className="text-base font-bold text-content-primary">Non-custodial by design</h3>
+            <p className="text-sm text-content-secondary leading-relaxed">
+              Stellar Wallets Kit allows client-side transaction signing. Funds never pass through OfferHub's servers. This is the correct model for a marketplace handling freelancer payments at scale — OfferHub cannot freeze, redirect, or lose user funds.
+            </p>
+          </div>
+
+          <div className="rounded-[2rem] bg-bg-elevated shadow-neu-raised-l2-sm p-7 flex flex-col gap-4">
+            <div className="rounded-2xl p-3 shadow-neu-sunken-subtle bg-bg-base w-fit">
+              <Globe size={24} className="text-theme-primary" />
+            </div>
+            <h3 className="text-base font-bold text-content-primary">LATAM off-ramp coverage</h3>
+            <p className="text-sm text-content-secondary leading-relaxed">
+              BlindPay and Abroad together cover 11 payout corridors across 6 LATAM countries — all settled from on-chain USDC. This makes Stellar the settlement layer for a population where 47% of the workforce is unbanked and traditional payment rails are unreliable or inaccessible.
+            </p>
+          </div>
+
+          <div className="rounded-[2rem] bg-bg-elevated shadow-neu-raised-l2-sm p-7 flex flex-col gap-4">
+            <div className="rounded-2xl p-3 shadow-neu-sunken-subtle bg-bg-base w-fit">
+              <Users size={24} className="text-[var(--color-secondary)]" />
+            </div>
+            <h3 className="text-base font-bold text-content-primary">Ecosystem value OfferHub adds</h3>
+            <p className="text-sm text-content-secondary leading-relaxed">
+              OfferHub brings real freelance transaction volume to Stellar mainnet. Every completed order is an on-chain USDC escrow release followed by a fiat settlement via a Stellar anchor. Open-sourcing the SWK + BlindPay + Abroad adapters in T3 creates reusable building blocks for any future Stellar marketplace.
+            </p>
+          </div>
+
+        </div>
+      </div>
+    </BlueprintMotionSection>
+  );
+}

--- a/src/lib/architecture-nav.ts
+++ b/src/lib/architecture-nav.ts
@@ -1,0 +1,12 @@
+/** Clears fixed Navbar + sticky Architecture section nav when scrolling to `#` anchors */
+export const ARCHITECTURE_SCROLL_MARGIN_PX = 180;
+
+export const ARCHITECTURE_SECTIONS = [
+  { id: "overview", label: "Overview" },
+  { id: "system", label: "System" },
+  { id: "flow", label: "Payment Flow" },
+  { id: "integrations", label: "Integrations" },
+  { id: "roadmap", label: "Roadmap" },
+  { id: "why-stellar", label: "Why Stellar" },
+  { id: "traction", label: "Traction" },
+] as const;


### PR DESCRIPTION
# 📝 Pull Request

## 🔧 Title:
feat(architecture): add /architecture page for SCF Build Award #44 submission

## 🛠️ Issue
- Related to SCF Build Award #44 — Integration Track submission

## 📚 Description
Adds a complete `/architecture` page that documents OfferHub's technical architecture for the SCF Build Award #44 (Integration Track, $80,000). The page covers all three criteria the SCF Handbook explicitly requires: complete architecture outline, technical Stellar integration explanation, and ecosystem value/traction.

Built with Mermaid.js (already a project dependency) for real diagrams — no hardcoded card layouts.

## ✅ Changes applied

**New page & route**
- `/src/app/architecture/page.tsx` — page with SEO metadata
- `/src/app/architecture/loading.tsx` — skeleton loader

**Architecture components** (`/src/components/architecture/`)
- `ArchitectureHero.tsx` — animated hero with SCF #44 badge and 3-layer mini diagram
- `ArchitectureSectionNav.tsx` — sticky pill nav (Overview / System / Payment Flow / Integrations / Roadmap / Why Stellar / Traction)
- `MermaidDiagram.tsx` — reusable Mermaid wrapper: dark mode support, responsive SVG (strips inline `max-width`), `zoom` prop renders at larger font size
- `DiagramZoomModal.tsx` — fullscreen lightbox for any diagram; closes on Escape, backdrop click, or X button
- `SystemArchitectureDiagram.tsx` — flowchart TD: 6-layer stack with color-coded nodes and protocol labels
- `PaymentFlowDiagram.tsx` — sequence diagram (escrow lifecycle) + state machine diagram side by side
- `IntegrationsMap.tsx` — hub-and-spoke layout: SWK, BlindPay (7 corridors), Abroad (4 methods)
- `SCFTrancheRoadmap.tsx` — Gantt chart (T1/T2/T3 timelines) + payments schedule table
- `WhyStellarSection.tsx` — 6-card grid answering SCF panel's "why Stellar" requirement
- `TractionSection.tsx` — platform status + LATAM market opportunity (SCF traction requirement)

**Shared nav config**
- `/src/lib/architecture-nav.ts` — section IDs and scroll margin constant

**Bug fix**
- `CookieConsentBanner.tsx` — removed `border border-theme-border/20` that appeared as a white border in dark mode

## 🔍 Evidence/Media
Page live at `/architecture` — compiles clean, zero TypeScript errors.