### PR TITLE
Refactor/replace hardcoded hex colors

### DIFF
--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -121,7 +121,7 @@ export default function HeroSection() {
         className="absolute inset-0 pointer-events-none"
         style={{
           background:
-            "radial-gradient(ellipse 60% 45% at 50% 50%, rgba(20,154,155,0.07) 0%, transparent 70%)",
+            "radial-gradient(ellipse 60% 45% at 50% 50%, color-mix(in srgb, var(--color-primary) 7%, transparent) 0%, transparent 70%)",
         }}
       />
 
@@ -129,8 +129,8 @@ export default function HeroSection() {
       <div className="relative z-10 flex flex-col items-center text-center px-4 w-full pt-28">
         {/* Eyebrow — key value props from product docs */}
         <p
-          className="animate-fadeIn text-xs font-medium uppercase tracking-[0.4em] mb-10"
-          style={{ color: "#149A9B", animationDelay: "100ms" }}
+          className="animate-fadeIn text-xs font-medium uppercase tracking-[0.4em] mb-10 text-theme-primary"
+          style={{ animationDelay: "100ms" }}
         >
           Self-Hosted · Non-Custodial · Open Source
         </p>
@@ -152,7 +152,7 @@ export default function HeroSection() {
             color: "transparent",
             // backgroundColor is the absolute base — always visible through letters
             // even when no blob covers a given area, this solid teal shows through
-            backgroundColor: "#149A9B",
+            backgroundColor: "var(--color-primary)",
             willChange: "background-image",
           }}
         >

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -199,8 +199,8 @@ export default function HeroSection() {
 
       {/* ── Scroll indicator ── */}
       <div
-        className="animate-fadeIn absolute bottom-8 left-1/2 -translate-x-1/2 flex flex-col items-center gap-2"
-        style={{ color: "rgba(0,35,51,0.30)", animationDelay: "900ms" }}
+        className="animate-fadeIn absolute bottom-8 left-1/2 -translate-x-1/2 flex flex-col items-center gap-2 text-theme-secondary/30"
+        style={{ animationDelay: "900ms" }}
       >
         <span className="text-[10px] uppercase tracking-[0.35em] font-medium">
           Scroll

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -5,9 +5,24 @@ import Link from "next/link";
 import { ArrowRight, ChevronDown } from "lucide-react";
 
 /**
+ * Animation-only highlight tones for the liquid text effect. These are NOT
+ * design tokens — they are brighter teals derived from --color-primary to
+ * create the wet-light highlights on the blob surface. If the brand teal
+ * changes, regenerate these from --color-primary at runtime.
+ */
+const LIQUID_HIGHLIGHTS = {
+  highlight: "#1bc8ca",
+  brightest: "#22e0e2",
+} as const;
+
+/**
  * Liquid text effect: multiple radial gradient blobs orbit inside the heading
  * via requestAnimationFrame, visible through background-clip: text.
  * The dark page acts like a wall; the text is a "glass window" into the liquid.
+ *
+ * Design tokens are referenced via var(--color-*) inside the gradient strings
+ * so the browser re-evaluates them on every paint — this is what makes the
+ * effect respond to dark mode toggle without re-running the effect.
  */
 export default function HeroSection() {
   const headingRef = useRef<HTMLHeadingElement>(null);
@@ -25,7 +40,7 @@ export default function HeroSection() {
       if (shouldReduceMotion) {
         cancelAnimationFrame(frame);
         // Set a static beautiful gradient if motion is reduced
-        el.style.backgroundImage = "linear-gradient(135deg, #1bc8ca 0%, #149A9B 100%)";
+        el.style.backgroundImage = `linear-gradient(135deg, ${LIQUID_HIGHLIGHTS.highlight} 0%, var(--color-primary) 100%)`;
       } else {
         frame = requestAnimationFrame(animate);
       }
@@ -55,15 +70,15 @@ export default function HeroSection() {
       const b6y = 50 + 14 * Math.cos(t * 1.15 + 2.0);
 
       el.style.backgroundImage = [
-        `radial-gradient(ellipse 48% 55% at ${b1x}% ${b1y}%, #1bc8ca 0%, #149A9B 45%, rgba(20,154,155,0) 82%)`,
-        `radial-gradient(ellipse 38% 46% at ${b2x}% ${b2y}%, #22e0e2 0%, #1bc8ca 40%, rgba(27,200,202,0) 80%)`,
-        `radial-gradient(ellipse 32% 42% at ${b3x}% ${b3y}%, #15949C 0%, rgba(21,148,156,0) 78%)`,
-        `radial-gradient(ellipse 28% 38% at ${b4x}% ${b4y}%, #0d7377 0%, rgba(13,115,119,0) 78%)`,
-        `radial-gradient(ellipse 44% 52% at ${b5x}% ${b5y}%, #149A9B 0%, rgba(20,154,155,0) 82%)`,
-        `radial-gradient(ellipse 20% 26% at ${b6x}% ${b6y}%, #22e0e2 0%, rgba(34,224,226,0) 72%)`,
-        `radial-gradient(ellipse 62% 72% at ${b3x}% ${b2y}%, rgba(241,243,247,0.90) 0%, rgba(241,243,247,0.50) 40%, rgba(241,243,247,0) 78%)`,
-        `radial-gradient(ellipse 52% 62% at ${b5x}% ${b4y}%, rgba(241,243,247,0.80) 0%, rgba(241,243,247,0.38) 38%, rgba(241,243,247,0) 72%)`,
-        `radial-gradient(ellipse 42% 50% at ${b1x}% ${b6y}%, rgba(241,243,247,0.65) 0%, rgba(241,243,247,0.20) 45%, rgba(241,243,247,0) 70%)`,
+        `radial-gradient(ellipse 48% 55% at ${b1x}% ${b1y}%, ${LIQUID_HIGHLIGHTS.highlight} 0%, var(--color-primary) 45%, color-mix(in srgb, var(--color-primary) 0%, transparent) 82%)`,
+        `radial-gradient(ellipse 38% 46% at ${b2x}% ${b2y}%, ${LIQUID_HIGHLIGHTS.brightest} 0%, ${LIQUID_HIGHLIGHTS.highlight} 40%, color-mix(in srgb, ${LIQUID_HIGHLIGHTS.highlight} 0%, transparent) 80%)`,
+        `radial-gradient(ellipse 32% 42% at ${b3x}% ${b3y}%, var(--color-accent) 0%, color-mix(in srgb, var(--color-accent) 0%, transparent) 78%)`,
+        `radial-gradient(ellipse 28% 38% at ${b4x}% ${b4y}%, var(--color-primary-hover) 0%, color-mix(in srgb, var(--color-primary-hover) 0%, transparent) 78%)`,
+        `radial-gradient(ellipse 44% 52% at ${b5x}% ${b5y}%, var(--color-primary) 0%, color-mix(in srgb, var(--color-primary) 0%, transparent) 82%)`,
+        `radial-gradient(ellipse 20% 26% at ${b6x}% ${b6y}%, ${LIQUID_HIGHLIGHTS.brightest} 0%, color-mix(in srgb, ${LIQUID_HIGHLIGHTS.brightest} 0%, transparent) 72%)`,
+        `radial-gradient(ellipse 62% 72% at ${b3x}% ${b2y}%, color-mix(in srgb, var(--color-bg-base) 90%, transparent) 0%, color-mix(in srgb, var(--color-bg-base) 50%, transparent) 40%, color-mix(in srgb, var(--color-bg-base) 0%, transparent) 78%)`,
+        `radial-gradient(ellipse 52% 62% at ${b5x}% ${b4y}%, color-mix(in srgb, var(--color-bg-base) 80%, transparent) 0%, color-mix(in srgb, var(--color-bg-base) 38%, transparent) 38%, color-mix(in srgb, var(--color-bg-base) 0%, transparent) 72%)`,
+        `radial-gradient(ellipse 42% 50% at ${b1x}% ${b6y}%, color-mix(in srgb, var(--color-bg-base) 65%, transparent) 0%, color-mix(in srgb, var(--color-bg-base) 20%, transparent) 45%, color-mix(in srgb, var(--color-bg-base) 0%, transparent) 70%)`,
       ].join(", ");
 
       frame = requestAnimationFrame(animate);
@@ -85,7 +100,7 @@ export default function HeroSection() {
     document.addEventListener("visibilitychange", onVisibility);
 
     if (shouldReduceMotion) {
-      el.style.backgroundImage = "linear-gradient(135deg, #1bc8ca 0%, #149A9B 100%)";
+      el.style.backgroundImage = `linear-gradient(135deg, ${LIQUID_HIGHLIGHTS.highlight} 0%, var(--color-primary) 100%)`;
     } else {
       frame = requestAnimationFrame(animate);
     }

--- a/src/components/community/HeroRepoStatsSection.tsx
+++ b/src/components/community/HeroRepoStatsSection.tsx
@@ -15,10 +15,10 @@ const HeroRepoStatsSection = ({ stats }: HeroRepoStatsSectionProps) => {
   const statsUnavailable = stats === null;
 
   const repoStats = [
-    { label: "Stars", value: stats?.stars ?? "N/A", icon: Star, color: "text-[#149A9B]" },
-    { label: "Forks", value: stats?.forks ?? "N/A", icon: GitFork, color: "text-[#19213D]" },
-    { label: "Contributors", value: stats?.contributors ?? "N/A", icon: Users, color: "text-[#149A9B]" },
-    { label: "Open Issues", value: stats?.openIssues ?? "N/A", icon: AlertCircle, color: "text-[#19213D]" },
+    { label: "Stars", value: stats?.stars ?? "N/A", icon: Star, color: "text-theme-primary" },
+    { label: "Forks", value: stats?.forks ?? "N/A", icon: GitFork, color: "text-content-primary" },
+    { label: "Contributors", value: stats?.contributors ?? "N/A", icon: Users, color: "text-theme-primary" },
+    { label: "Open Issues", value: stats?.openIssues ?? "N/A", icon: AlertCircle, color: "text-content-primary" },
   ];
 
   return (
@@ -26,7 +26,7 @@ const HeroRepoStatsSection = ({ stats }: HeroRepoStatsSectionProps) => {
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
         <div className="grid grid-cols-1 gap-12 lg:grid-cols-12 items-center">
           <div className="lg:col-span-7">
-            <p className="mb-6 text-[11px] font-black uppercase tracking-[0.4em] text-[#149A9B]">
+            <p className="mb-6 text-[11px] font-black uppercase tracking-[0.4em] text-theme-primary">
               Community Network
             </p>
             <h1 className="text-5xl font-black tracking-tighter text-content-primary md:text-7xl leading-[1.05]">

--- a/src/components/community/HeroRepoStatsSection.tsx
+++ b/src/components/community/HeroRepoStatsSection.tsx
@@ -43,7 +43,7 @@ const HeroRepoStatsSection = ({ stats }: HeroRepoStatsSectionProps) => {
                 href="https://github.com/OFFER-HUB/offer-hub-monorepo"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="px-8 py-4 rounded-xl bg-[#19213D] text-white text-xs font-black uppercase tracking-widest shadow-xl shadow-[#19213D]/20 hover:bg-black transition-all"
+                className="px-8 py-4 rounded-xl bg-content-primary text-white text-xs font-black uppercase tracking-widest shadow-xl shadow-content-primary/20 hover:bg-black transition-all"
               >
                 Star on GitHub
               </a>


### PR DESCRIPTION
# 📝 Pull Request: refactor: replace hardcoded hex colors 

  ## 🔧 Title: refactor: replace hardcoded hex colors with design tokens across HeroSection and community components

  
  ## 🛠️ Issue

  - Closes #1425 

  ## 📚 Description

  Several components were bypassing the design system by hardcoding hex
  colors directly in Tailwind arbitrary values (`text-[#149A9B]`,
  `bg-[#19213D]`) or inline styles (`color: "#149A9B"`,
  `rgba(0,35,51,0.30)`, `backgroundColor: "#149A9B"`).

  This meant that theme changes — particularly the dark mode toggle —
  did **not** propagate to these surfaces, breaking visual consistency.
  The teal of the OFFER HUB title, the eyebrow text, the scroll
  indicator and the GitHub CTA button were all frozen to their light-mode
  values.

  This refactor wires those surfaces back into the design system by:

  - Using Tailwind aliases (`text-theme-primary`, `text-content-primary`,
    `bg-content-primary`, `text-theme-secondary/30`,
    `shadow-content-primary/20`) where a JSX class was the right tool.
  - Using `var(--color-*)` + `color-mix(in srgb, ..., transparent)` inside
    inline styles and the canvas/JS gradient strings, so the browser
    re-evaluates them on every paint and dark mode toggle works without
    re-running `useEffect`.
  - Isolating the animation-only brighter teals (`#1bc8ca`, `#22e0e2`) in
    a `LIQUID_HIGHLIGHTS` constant with a comment clarifying they are
    **not** design tokens — they are derived highlights for the liquid
    blob effect.

  **Technical note:** I deliberately did not use
  `getComputedStyle(document.documentElement).getPropertyValue('--color-primary')`
  inside the `useEffect`. That would take a snapshot at mount time and
  the gradient would stay frozen on dark mode toggle until the effect
  re-runs. Inlining `var()` + `color-mix()` in the gradient string lets
  the browser re-resolve the value on every paint — which is the actual
  behavior a theme-aware design system needs.

  ## ✅ Changes applied

  **`src/components/HeroSection.tsx`** (commits `6c8cb213`, `ac815c6a`,
  `d493af6c`):

  - Added `LIQUID_HIGHLIGHTS` constant for animation-only teals, with
    documentation clarifying they are not design tokens.
  - Replaced `#1bc8ca`, `#149A9B`, `#15949C`, `#0d7377`, `#22e0e2`,
    `rgba(20,154,155,0)`, `rgba(21,148,156,0)`, `rgba(13,115,119,0)`,
    `rgba(27,200,202,0)`, `rgba(34,224,226,0)` and
    `rgba(241,243,247,*)` inside the animated `radial-gradient(...)`
    strings with `var(--color-primary)`, `var(--color-primary-hover)`,
    `var(--color-accent)`, `var(--color-bg-base)` and `color-mix()`.
  - Replaced the reduced-motion fallback gradient (`#1bc8ca`,
    `#149A9B`) with `var(--color-primary)` and `LIQUID_HIGHLIGHTS`.
  - Replaced the centered teal glow inline `rgba(20,154,155,0.07)` with
    `color-mix(in srgb, var(--color-primary) 7%, transparent)`.
  - Replaced the eyebrow's inline `color: "#149A9B"` with the
    `text-theme-primary` class.
  - Replaced the `<h1>` inline `backgroundColor: "#149A9B"` with
    `var(--color-primary)`.
  - Replaced the scroll indicator's inline `color: "rgba(0,35,51,0.30)"`
    with the `text-theme-secondary/30` class.

  **`src/components/community/HeroRepoStatsSection.tsx`** (commits
  `540fd440`, `33647a9e`):

  - Replaced `text-[#149A9B]` in the `repoStats` icon palette and the
    "Community Network" eyebrow with `text-theme-primary`.
  - Replaced `text-[#19213D]` in the `repoStats` icon palette with
    `text-content-primary`.
  - Replaced `bg-[#19213D]` and `shadow-[#19213D]/20` on the "Star on
    GitHub" CTA with `bg-content-primary` and `shadow-content-primary/20`.

  **Audit:** Ran `rg '#[0-9A-Fa-f]{6}'` against both files — only
  remaining hex literals are the two animation-only teals inside
  `LIQUID_HIGHLIGHTS`, which are explicitly documented as not part of
  the design system.

  ## 🔍 Evidence/Media (screenshots/videos)
