### PR TITLE
Fix: correct ARIA semantics for CookieConsentBanner

### DIFF
--- a/src/components/CookieConsentBanner.tsx
+++ b/src/components/CookieConsentBanner.tsx
@@ -42,13 +42,17 @@ export default function CookieConsentBanner() {
 
   return (
     <div
-      role="dialog"
-      aria-modal="false"
-      aria-label="Cookie consent"
+      role="region"
+      aria-labelledby="cookie-consent-title"
+      aria-live="polite"
+      aria-atomic="true"
       className="fixed bottom-4 left-4 right-4 md:left-auto md:right-6 md:bottom-6 md:max-w-sm z-50 animate-fadeInUp"
     >
       <div className="rounded-3xl bg-bg-elevated shadow-neu-raised px-6 py-5 flex flex-col gap-4">
-        <p className="text-[10px] font-black uppercase tracking-[0.3em] text-theme-primary">
+        <p
+          id="cookie-consent-title"
+          className="text-[10px] font-black uppercase tracking-[0.3em] text-theme-primary"
+        >
           Privacy Notice
         </p>
 


### PR DESCRIPTION
# 📝 Pull Request

## 🔧 Title:

Fix: CookieConsentBanner uses valid non-modal ARIA semantics

## 🛠️ Issue

- Closes #1420

## 📚 Description

Updated `CookieConsentBanner` so it no longer exposes contradictory modal semantics. The banner is now treated as a non-modal region with an accessible name derived from its visible heading, which better matches the actual UX and avoids misleading screen readers.

## ✅ Changes applied

- Removed `role="dialog"` from the cookie banner container
- Removed `aria-modal="false"`
- Changed the wrapper to `role="region"`
- Added `aria-labelledby="cookie-consent-title"`
- Added `aria-live="polite"` and `aria-atomic="true"` so the banner can be announced when it appears
- Kept the banner non-blocking and left the interaction model unchanged

## 🔍 Evidence/Media (screenshots/videos)

- Not captured in this workspace
- Verified by code review in [`src/components/CookieConsentBanner.tsx`](/home/ryzen/Desktop/drip/offer-hub-monorepo/src/components/CookieConsentBanner.tsx)
- Local lint check could not be completed because the workspace does not have installed `node_modules`, and `npx eslint` attempted a network fetch

If you want, I can also turn this into a more GitHub-ready PR body with a short “testing” section.