### PR TITLE
refactor: remove mock exports from production PRCard component

### DIFF
--- a/src/components/community/PRCard.tsx
+++ b/src/components/community/PRCard.tsx
@@ -110,15 +110,3 @@ export default function PRCard({
   );
 }
 
-export const MOCK_PR_CARD_PROPS: PRCardProps = {
-  title: "feat: add PR card component with merged status support",
-  author: "octocat",
-  authorAvatar: "https://avatars.githubusercontent.com/u/583231?v=4",
-  mergedAt: "2026-02-20T13:24:00.000Z",
-  url: "https://github.com/OFFER-HUB/offer-hub-monorepo/pull/1016",
-  labels: ["enhancement", "frontend", "community"],
-};
-
-export function PRCardMockPreview() {
-  return <PRCard {...MOCK_PR_CARD_PROPS} />;
-}


### PR DESCRIPTION
# 📝 Pull Request 

## 🔧 Title: Remove mock exports from production PRCard component

## 🛠️ Issue

- Closes #1415

## 📚 Description

`src/components/community/PRCard.tsx` was exporting `MOCK_PR_CARD_PROPS` and `PRCardMockPreview` alongside the production component, which bundled development/demo data into every production build. A search across the codebase confirmed neither export is imported anywhere outside the file itself, so they are removed outright rather than relocated. `PRCard` itself and its `PRCardProps` interface are unchanged.

## ✅ Changes applied

- Deleted `MOCK_PR_CARD_PROPS` constant from `src/components/community/PRCard.tsx`
- Deleted `PRCardMockPreview` component from `src/components/community/PRCard.tsx`
- No other files modified; no existing usages of the removed exports were found

## 🔍 Evidence/Media (screenshots/videos)

- `grep -r "MOCK_PR_CARD_PROPS\|PRCardMockPreview" src/` returns only the definition file (now empty after removal)
- `npm run lint` passes with no new warnings