### PR TITLE
fix: validate parsed localStorage timestamp in FloatingCTA

### DIFF
--- a/src/components/ui/FloatingCTA.tsx
+++ b/src/components/ui/FloatingCTA.tsx
@@ -20,11 +20,16 @@ export function FloatingCTA() {
     // Check if dismissed recently
     const dismissedAt = localStorage.getItem(STORAGE_KEY);
     if (dismissedAt) {
-      const elapsed = Date.now() - parseInt(dismissedAt, 10);
-      if (elapsed < DISMISS_DURATION) {
-        return;
+      const parsed = parseInt(dismissedAt, 10);
+      if (!Number.isFinite(parsed) || parsed < 0) {
+        localStorage.removeItem(STORAGE_KEY);
+      } else {
+        const elapsed = Date.now() - parsed;
+        if (elapsed < DISMISS_DURATION) {
+          return;
+        }
+        localStorage.removeItem(STORAGE_KEY);
       }
-      localStorage.removeItem(STORAGE_KEY);
     }
 
     // Show CTA after a delay for better UX


### PR DESCRIPTION
# 📝 Pull Request 

## 🔧 Title: Validate parsed localStorage dismiss timestamp in FloatingCTA

## 🛠️ Issue

- Closes #1423

## 📚 Description

`FloatingCTA` read a dismiss timestamp from `localStorage` and passed it directly to `parseInt` without validating the result. If the stored value is a non-numeric string (corrupted, manually set, or from a different format), `parseInt` returns `NaN`. Because `NaN < DISMISS_DURATION` is always `false` in JavaScript, the existing key would be removed and the CTA would reappear on every page load — the opposite of the intended 7-day suppression.

The fix wraps the parsed value in a `Number.isFinite(parsed) && parsed >= 0` guard before using it in the elapsed comparison. Invalid values (NaN, Infinity, negative) are treated as "no dismiss stored": the key is cleared and the CTA is shown normally, matching the behavior described in the acceptance criteria.

## ✅ Changes applied

- Stored the result of `parseInt(dismissedAt, 10)` in `parsed`
- Added `Number.isFinite(parsed) || parsed < 0` guard in `src/components/ui/FloatingCTA.tsx`
- On invalid value: `localStorage.removeItem(STORAGE_KEY)` and fall through to show CTA
- On valid value: existing elapsed-time comparison is unchanged

## 🔍 Evidence/Media (screenshots/videos)

- `npm run lint` passes with no new warnings
- Normal dismiss flow (valid timestamp) is unaffected — only the NaN/Infinity/negative path is new