### PR TITLE
test: manual test report — Edit Personal Profile + Upload Profile Photo

### DIFF
--- a/reports/issue-1345/Report_EditProfile_Issue_1345.md
+++ b/reports/issue-1345/Report_EditProfile_Issue_1345.md
@@ -1,0 +1,106 @@
+# Manual Test Report: Edit Personal Profile
+
+## Issue Information
+- **Issue Number**: #1345
+- **Title**: Manual Test: Edit Personal Profile + Upload Profile Photo
+- **Date**: 2026-06-27
+- **Tester**: Fran19-09
+
+## Test Environment
+- **URL**: https://www.offer-hub.org
+- **Browser**: Chrome (latest)
+- **Device**: Desktop
+
+## Contributor Verification
+
+### Real Profile
+- [x] Profile completed with real information (first name, last name, username, bio, location, professional title, timezone)
+- [x] Profile photo uploaded
+- [x] Screenshot attached (see PR description)
+
+### Real Service Published
+- [x] Service created with genuine offering
+- [x] Professional title and description
+- [x] Real image uploaded
+- [x] Real price and delivery time set
+- [x] Screenshot attached (see PR description)
+
+### Real Offer Published
+- [x] Offer created with genuine need
+- [x] Professional title and description
+- [x] Real budget and timeline set
+- [x] Screenshot attached (see PR description)
+
+---
+
+## Test Steps — Edit Personal Profile
+
+### Step 1: Navigate to Profile Settings
+- **Action**: Log in to the platform and navigate to the profile editing page.
+- **Expected Result**: Profile form loads with existing user data pre-filled in all fields.
+- **Actual Result**: Profile form loaded successfully with all existing data pre-filled (first name, last name, username, date of birth, bio, phone, location, timezone, professional title).
+- **Status**: ✅ Pass
+- **Screenshot**: See PR description
+
+### Step 2: Edit First Name and Last Name
+- **Action**: Clear the first name and last name fields, enter new values, and save.
+- **Expected Result**: Fields accept input; form validates successfully; changes saved.
+- **Actual Result**: First name and last name fields accepted the new values and saved without errors.
+- **Status**: ✅ Pass
+- **Screenshot**: See PR description
+
+### Step 3: Edit Username
+- **Action**: Update the username field with a valid username and save.
+- **Expected Result**: Username updated and reflected in the UI.
+- **Actual Result**: Username was updated successfully and displayed correctly in the UI.
+- **Status**: ✅ Pass
+- **Screenshot**: See PR description
+
+### Step 4: Edit Date of Birth
+- **Action**: Update the date of birth field with a valid date.
+- **Expected Result**: Date field accepts the input and saves correctly.
+- **Actual Result**: Date of birth updated and saved without errors.
+- **Status**: ✅ Pass
+- **Screenshot**: See PR description
+
+### Step 5: Edit Bio
+- **Action**: Enter a professional bio description in the bio field and save.
+- **Expected Result**: Bio field accepts multi-line text input; changes persist after save.
+- **Actual Result**: Bio field accepted the text and saved correctly.
+- **Status**: ✅ Pass
+- **Screenshot**: See PR description
+
+### Step 6: Edit Phone, Location, and Timezone
+- **Action**: Fill in the phone number, location, and timezone fields with real data and save.
+- **Expected Result**: All three fields accept input; data persists after save.
+- **Actual Result**: Phone, location, and timezone fields saved correctly.
+- **Status**: ✅ Pass
+- **Screenshot**: See PR description
+
+### Step 7: Edit Professional Title
+- **Action**: Enter a professional title (e.g. "Frontend Developer") and save.
+- **Expected Result**: Professional title field accepts input and saves correctly.
+- **Actual Result**: Professional title updated and displayed correctly.
+- **Status**: ✅ Pass
+- **Screenshot**: See PR description
+
+### Step 8: Verify Persistence After Page Reload
+- **Action**: After saving all changes, reload the page and navigate back to the profile form.
+- **Expected Result**: All saved changes persist and are pre-filled on reload.
+- **Actual Result**: All profile changes persisted correctly after page reload. Every edited field retained its updated value.
+- **Status**: ✅ Pass
+- **Screenshot**: See PR description
+
+---
+
+## Test Results Summary
+- **Total Steps**: 8
+- **Passed**: 8
+- **Failed**: 0
+- **Overall Status**: ✅ Pass
+
+## Issues Found
+- None observed during profile editing testing.
+
+## Recommendations
+- None at this time; the profile editing form behaved as expected across all fields.

--- a/reports/issue-1345/Report_UploadPhoto_Issue_1345.md
+++ b/reports/issue-1345/Report_UploadPhoto_Issue_1345.md
@@ -1,0 +1,92 @@
+# Manual Test Report: Upload Profile Photo
+
+## Issue Information
+- **Issue Number**: #1345
+- **Title**: Manual Test: Edit Personal Profile + Upload Profile Photo
+- **Date**: 2026-06-27
+- **Tester**: Fran19-09
+
+## Test Environment
+- **URL**: https://www.offer-hub.org
+- **Browser**: Chrome (latest)
+- **Device**: Desktop
+
+## Contributor Verification
+
+### Real Profile
+- [x] Profile completed with real information (first name, last name, username, bio, location, professional title, timezone)
+- [x] Profile photo uploaded
+- [x] Screenshot attached (see PR description)
+
+### Real Service Published
+- [x] Service created with genuine offering
+- [x] Professional title and description
+- [x] Real image uploaded
+- [x] Real price and delivery time set
+- [x] Screenshot attached (see PR description)
+
+### Real Offer Published
+- [x] Offer created with genuine need
+- [x] Professional title and description
+- [x] Real budget and timeline set
+- [x] Screenshot attached (see PR description)
+
+---
+
+## Test Steps — Upload Profile Photo
+
+### Step 1: Navigate to Profile Photo Section
+- **Action**: Log in and navigate to the profile editing page; locate the profile photo upload control.
+- **Expected Result**: Photo upload control is visible and accessible.
+- **Actual Result**: Profile photo upload section loaded correctly and was accessible.
+- **Status**: ✅ Pass
+- **Screenshot**: See PR description
+
+### Step 2: Select and Upload a Profile Photo
+- **Action**: Click the upload control, select an image file from the local filesystem, and confirm.
+- **Expected Result**: File picker opens; image is accepted; upload begins.
+- **Actual Result**: File picker opened correctly; image was selected and uploaded without errors.
+- **Status**: ✅ Pass
+- **Screenshot**: See PR description
+
+### Step 3: Verify Immediate Preview
+- **Action**: Observe the profile photo area immediately after selecting the file.
+- **Expected Result**: Uploaded photo appears as a preview instantly without requiring a page reload.
+- **Actual Result**: Photo preview updated immediately after upload, displaying the new image correctly.
+- **Status**: ✅ Pass
+- **Screenshot**: See PR description
+
+### Step 4: Save Profile with New Photo
+- **Action**: Save the profile after uploading the photo.
+- **Expected Result**: Profile saves successfully; confirmation message or visual feedback displayed.
+- **Actual Result**: Profile saved successfully with the new photo; confirmation feedback was shown.
+- **Status**: ✅ Pass
+- **Screenshot**: See PR description
+
+### Step 5: Verify Photo Persists After Page Reload
+- **Action**: Reload the page and navigate back to the profile page.
+- **Expected Result**: The uploaded profile photo is still displayed; it was not reverted to a placeholder.
+- **Actual Result**: Uploaded photo persisted correctly after page reload and appeared on the profile page.
+- **Status**: ✅ Pass
+- **Screenshot**: See PR description
+
+### Step 6: Verify Photo Appears Across the UI
+- **Action**: Navigate to other sections of the platform where the profile photo is displayed (e.g., navbar avatar, public profile).
+- **Expected Result**: The new profile photo is reflected consistently across all UI locations.
+- **Actual Result**: Profile photo updated and displayed correctly in all relevant UI locations.
+- **Status**: ✅ Pass
+- **Screenshot**: See PR description
+
+---
+
+## Test Results Summary
+- **Total Steps**: 6
+- **Passed**: 6
+- **Failed**: 0
+- **Overall Status**: ✅ Pass
+
+## Issues Found
+- None observed during profile photo upload testing.
+
+## Recommendations
+- None at this time; the photo upload feature worked correctly end-to-end.


### PR DESCRIPTION
# 📝 Pull Request 

## 🔧 Title: Manual Test Report — Edit Personal Profile + Upload Profile Photo

## 🛠️ Issue

- Closes #1345

## 📚 Description

Manual testing of the profile editing form and profile photo upload feature on https://www.offer-hub.org. All acceptance criteria passed. Screenshots were captured for each step and are attached below.

## ✅ Changes applied

- `reports/issue-1345/Report_EditProfile_Issue_1345.md` — 8-step test report covering all editable profile fields (first name, last name, username, date of birth, bio, phone, location, timezone, professional title) and persistence after reload
- `reports/issue-1345/Report_UploadPhoto_Issue_1345.md` — 6-step test report covering photo selection, immediate preview, save, persistence after reload, and cross-UI propagation

## Test Results Summary

| Report | Steps | Passed | Failed | Status |
|--------|-------|--------|--------|--------|
| Edit Profile | 8 | 8 | 0 | ✅ Pass |
| Upload Photo | 6 | 6 | 0 | ✅ Pass |

## Contributor Verification

- [x] Real account used (Fran19-09)
- [x] Real profile information filled in (name, username, bio, location, professional title, timezone)
- [x] Profile photo uploaded
- [x] Real service published with professional title, description, image, price, and delivery time
- [x] Real offer published with professional title, description, budget, and timeline
- [x] Screenshots captured for all steps (attached)

## 🔍 Evidence/Media (screenshots/videos)

Screenshots were captured for all test steps and attached to this PR.