### PR TITLE
refactor: split UseCasesClient into orchestrator and lazy-loaded sect…

### DIFF
--- a/src/components/use-cases/UseCasesClient.tsx
+++ b/src/components/use-cases/UseCasesClient.tsx
@@ -1,169 +1,44 @@
 "use client";
 
-// ── Freelance imports ──
-import FreelanceHero from "@/components/use-cases/freelance/FreelanceHero";
-import FreelanceEscrowFlowDiagram from "@/components/use-cases/freelance/EscrowFlowDiagram";
-import FreelanceStellarImpactCards from "@/components/use-cases/freelance/StellarImpactCards";
-import FreelanceCodeIntegrationShowcase from "@/components/use-cases/freelance/CodeIntegrationShowcase";
-
-// ── eCommerce imports ──
-import EcommerceHero from "@/components/use-cases/ecommerce/EcommerceHero";
-import EcommerceEscrowFlowDiagram from "@/components/use-cases/ecommerce/EscrowFlowDiagram";
-import EcommerceStellarImpactCards from "@/components/use-cases/ecommerce/StellarImpactCards";
-import EcommerceCodeIntegrationShowcase from "@/components/use-cases/ecommerce/CodeIntegrationShowcase";
-
-// ── DAO Payroll imports ──
-import DaoPayrollHero from "@/components/use-cases/dao-payroll/DaoPayrollHero";
-import DaoPayrollEscrowFlowDiagram from "@/components/use-cases/dao-payroll/EscrowFlowDiagram";
-import DaoPayrollStellarImpactCards from "@/components/use-cases/dao-payroll/StellarImpactCards";
-import DaoPayrollCodeIntegrationShowcase from "@/components/use-cases/dao-payroll/CodeIntegrationShowcase";
-
-// ── Real Estate imports ──
-import RealEstateHero from "@/components/use-cases/real-estate/RealEstateHero";
-import RealEstateEscrowFlowDiagram from "@/components/use-cases/real-estate/EscrowFlowDiagram";
-import RealEstateStellarImpactCards from "@/components/use-cases/real-estate/StellarImpactCards";
-import RealEstateCodeIntegrationShowcase from "@/components/use-cases/real-estate/CodeIntegrationShowcase";
-
-// ── Service Platforms imports ──
-import ServicePlatformsHero from "@/components/use-cases/service-platforms/ServicePlatformsHero";
-import ServicePlatformsEscrowFlowDiagram from "@/components/use-cases/service-platforms/EscrowFlowDiagram";
-import ServicePlatformsStellarImpactCards from "@/components/use-cases/service-platforms/StellarImpactCards";
-import ServicePlatformsCodeIntegrationShowcase from "@/components/use-cases/service-platforms/CodeIntegrationShowcase";
+import dynamic from "next/dynamic";
+import {
+  useState,
+  useEffect,
+  useRef,
+  useCallback,
+  type ComponentType,
+  type ReactNode,
+} from "react";
 
 import { Navbar } from "@/components/layout/Navbar";
 import { Footer } from "@/components/layout/Footer";
-import { useState, useEffect, useRef, useCallback } from "react";
-import {
-  Users,
-  ShieldCheck,
-  Zap,
-  Globe,
-  BarChart3,
-  Code2,
-  ShoppingCart,
-  Coins,
-  Building2,
-  Briefcase,
-} from "lucide-react";
 import { cn } from "@/lib/cn";
 
-// ── Top-level use-case switcher ──
-const USE_CASES = [
-  { id: "freelance", label: "Freelance", icon: Users },
-  { id: "ecommerce", label: "eCommerce", icon: ShoppingCart },
-  { id: "dao-payroll", label: "DAO Payroll", icon: Coins },
-  { id: "real-estate", label: "Real Estate", icon: Building2 },
-  { id: "service-platforms", label: "Service Platforms", icon: Briefcase },
-] as const;
+import { USE_CASES, PAGE_SECTIONS, SCROLL_OFFSET } from "./constants";
+import type { UseCaseId } from "./constants";
+import { SectionLoading } from "./shared/SectionLayout";
 
-type UseCaseId = (typeof USE_CASES)[number]["id"];
+// ── Lazily-loaded use-case sections (code-split per tab) ──
+type SectionProps = { stickyNav?: ReactNode };
 
-// ── Per-use-case features content ──
-const USE_CASE_FEATURES: Record<
-  UseCaseId,
-  {
-    icon: React.FC<{ size?: number; className?: string }>;
-    title: string;
-    body: string;
-  }[]
-> = {
-  freelance: [
-    {
-      icon: ShieldCheck,
-      title: "Trustless Escrow",
-      body: "Lock client funds into secure smart contracts at project kick-off. Funds are guaranteed to exist, protecting both the freelancer and the client.",
-    },
-    {
-      icon: Zap,
-      title: "Milestone Automation",
-      body: "Trigger partial or full payments automatically when APIs dictate completion of deliverables, removing manual invoice friction.",
-    },
-    {
-      icon: Globe,
-      title: "Global Payouts",
-      body: "Settle funds instantly in USDC or fiat-backed stablecoins directly to the freelancer's wallet, bypassing multi-day bank transfer delays and high FX fees.",
-    },
-  ],
-  ecommerce: [
-    {
-      icon: ShieldCheck,
-      title: "Buyer & Seller Protection",
-      body: "Buyer funds are locked on-chain before the seller ships. Neither party can be defrauded — the escrow is the source of truth for every order.",
-    },
-    {
-      icon: Zap,
-      title: "Automatic Release on Delivery",
-      body: "Funds release the moment delivery is confirmed — by tracking API, signature scan, or a buyer click — removing payout batch delays entirely.",
-    },
-    {
-      icon: Globe,
-      title: "On-Chain Dispute Resolution",
-      body: "If an order is missing or misrepresented, the buyer opens a structured on-chain dispute. The outcome — release, refund, or split — is transparent and final.",
-    },
-  ],
-  "dao-payroll": [
-    {
-      icon: Coins,
-      title: "Governance-Gated Releases",
-      body: "DAO votes directly trigger payroll disbursements. No multisig delays — a passed proposal automatically releases contributor funds from the vault.",
-    },
-    {
-      icon: ShieldCheck,
-      title: "Contributor Trust",
-      body: "Budget is locked on-chain at the start of each epoch. Contributors can start work knowing their payment is already secured in escrow.",
-    },
-    {
-      icon: Globe,
-      title: "Multi-Currency Payouts",
-      body: "Pay contributors globally in USDC, XLM, or any Stellar-issued asset. No bank accounts required. Settlement completes in under 5 seconds.",
-    },
-  ],
-  "real-estate": [
-    {
-      icon: Building2,
-      title: "Tokenised Escrow",
-      body: "Earnest money and closing funds are held in programmable on-chain escrow, eliminating the need for a third-party title company for each step.",
-    },
-    {
-      icon: ShieldCheck,
-      title: "Condition-Based Releases",
-      body: "Funds only release when contingencies are met: inspection approval, title clearance, mortgage funding. Automated and auditable at every stage.",
-    },
-    {
-      icon: Zap,
-      title: "Instant Cross-Border Closing",
-      body: "International buyers settle in USDC with no wire delays or correspondent bank fees. Foreign national transactions close in the same time as domestic ones.",
-    },
-  ],
-  "service-platforms": [
-    {
-      icon: Briefcase,
-      title: "SOW-Backed Contracts",
-      body: "Every engagement starts with a statement of work locked on-chain. Scope, milestones, and payment terms are immutable once both parties sign.",
-    },
-    {
-      icon: ShieldCheck,
-      title: "Milestone-Gated Payments",
-      body: "Providers receive each tranche only after the corresponding deliverable is approved, eliminating late or non-payment risk for service professionals.",
-    },
-    {
-      icon: Globe,
-      title: "Structured Dispute Resolution",
-      body: "Built-in on-chain arbitration ensures every dispute has a clear, auditable outcome — release, refund, or split — visible to all stakeholders.",
-    },
-  ],
+const SECTIONS: Record<UseCaseId, ComponentType<SectionProps>> = {
+  freelance: dynamic(() => import("./freelance/FreelanceSection"), {
+    loading: () => <SectionLoading />,
+  }),
+  ecommerce: dynamic(() => import("./ecommerce/EcommerceSection"), {
+    loading: () => <SectionLoading />,
+  }),
+  "dao-payroll": dynamic(() => import("./dao-payroll/DaoPayrollSection"), {
+    loading: () => <SectionLoading />,
+  }),
+  "real-estate": dynamic(() => import("./real-estate/RealEstateSection"), {
+    loading: () => <SectionLoading />,
+  }),
+  "service-platforms": dynamic(
+    () => import("./service-platforms/ServicePlatformsSection"),
+    { loading: () => <SectionLoading /> },
+  ),
 };
-
-const PAGE_SECTIONS = [
-  { id: "overview", label: "Overview", icon: Users },
-  { id: "features", label: "Features", icon: Zap },
-  { id: "metrics", label: "Metrics", icon: BarChart3 },
-  { id: "architecture", label: "Architecture", icon: Globe },
-  { id: "sdk", label: "SDK", icon: Code2 },
-] as const;
-
-/** Offset (px) matching the sticky header height + breathing room */
-const SCROLL_OFFSET = 140;
 
 export default function UseCasesClient() {
   const [activeUseCase, setActiveUseCase] = useState<UseCaseId>("freelance");
@@ -200,46 +75,62 @@ export default function UseCasesClient() {
     });
   }, [activeSection]);
 
+  // Re-establish the scroll-spy observer whenever the active use case changes:
+  // the new section mounts lazily, so we retry on the next frame until all
+  // section elements exist in the DOM.
   useEffect(() => {
-    const sectionElements = PAGE_SECTIONS.map((s) =>
-      document.getElementById(s.id),
-    ).filter(Boolean) as HTMLElement[];
+    let raf = 0;
+    let observer: IntersectionObserver | null = null;
 
-    if (sectionElements.length === 0) return;
+    const setup = () => {
+      const sectionElements = PAGE_SECTIONS.map((s) =>
+        document.getElementById(s.id),
+      ).filter(Boolean) as HTMLElement[];
 
-    const visibilityMap = new Map<string, number>();
+      if (sectionElements.length < PAGE_SECTIONS.length) {
+        raf = requestAnimationFrame(setup);
+        return;
+      }
 
-    const observer = new IntersectionObserver(
-      (entries) => {
-        entries.forEach((entry) => {
-          visibilityMap.set(entry.target.id, entry.intersectionRatio);
-        });
+      const visibilityMap = new Map<string, number>();
 
-        let bestId: string = activeSection;
-        let bestRatio = -1;
+      observer = new IntersectionObserver(
+        (entries) => {
+          entries.forEach((entry) => {
+            visibilityMap.set(entry.target.id, entry.intersectionRatio);
+          });
 
-        visibilityMap.forEach((ratio, id) => {
-          if (ratio > bestRatio) {
-            bestRatio = ratio;
-            bestId = id;
+          let bestId: string = activeSection;
+          let bestRatio = -1;
+
+          visibilityMap.forEach((ratio, id) => {
+            if (ratio > bestRatio) {
+              bestRatio = ratio;
+              bestId = id;
+            }
+          });
+
+          if (bestRatio > 0.05 && bestId !== activeSection) {
+            setActiveSection(bestId);
           }
-        });
+        },
+        {
+          threshold: [0, 0.1, 0.25, 0.4, 0.6, 0.75, 1],
+          rootMargin: "-140px 0px -30% 0px",
+        },
+      );
 
-        if (bestRatio > 0.05 && bestId !== activeSection) {
-          setActiveSection(bestId);
-        }
-      },
-      {
-        threshold: [0, 0.1, 0.25, 0.4, 0.6, 0.75, 1],
-        rootMargin: "-140px 0px -30% 0px",
-      },
-    );
+      sectionElements.forEach((el) => observer!.observe(el));
+    };
 
-    sectionElements.forEach((el) => observer.observe(el));
+    setup();
 
-    return () => observer.disconnect();
+    return () => {
+      cancelAnimationFrame(raf);
+      observer?.disconnect();
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [activeUseCase]);
 
   useEffect(() => {
     let ticking = false;
@@ -291,7 +182,88 @@ export default function UseCasesClient() {
     window.scrollTo({ top: 0, behavior: "smooth" });
   };
 
-  const features = USE_CASE_FEATURES[activeUseCase];
+  const ActiveSection = SECTIONS[activeUseCase];
+
+  // ── Sticky Section Navigation (Neumorphic Pill) ──
+  // Built here (owns all state/refs) and injected into the active section.
+  const stickyNav = (
+    <div
+      ref={navRef}
+      className={cn(
+        "sticky z-40 pointer-events-none",
+        "top-[80px] py-6",
+        "md:top-[80px]",
+      )}
+    >
+      <div className="max-w-3xl mx-auto px-4 sm:px-6 flex justify-center">
+        <div
+          className={cn(
+            "pointer-events-auto relative flex items-center p-1.5 sm:p-2 rounded-2xl bg-bg-base",
+            "transition-shadow duration-500 will-change-[box-shadow]",
+            isNavPinned ? "shadow-neu-raised-scrolled" : "shadow-neu-raised",
+          )}
+        >
+          <div
+            ref={pillContainerRef}
+            className="relative flex items-center gap-1 sm:gap-2"
+          >
+            {pillStyle && (
+              <span
+                className="absolute top-0 h-full rounded-xl btn-neumorphic-primary pointer-events-none"
+                aria-hidden="true"
+                style={{
+                  left: pillStyle.left,
+                  width: pillStyle.width,
+                  transition:
+                    "left 350ms cubic-bezier(0.25, 1, 0.5, 1), width 300ms ease-out",
+                  willChange: "left, width",
+                }}
+              />
+            )}
+
+            {PAGE_SECTIONS.map((section) => {
+              const isActive = activeSection === section.id;
+              const isTouched = touchedId === section.id;
+              const SectionIcon = section.icon;
+
+              return (
+                <a
+                  key={section.id}
+                  ref={(el) => setLinkRef(section.id, el)}
+                  id={`nav-link-${section.id}`}
+                  href={`#${section.id}`}
+                  onClick={(e) => handleNavClick(e, section.id)}
+                  onTouchStart={() => handleTouchStart(section.id)}
+                  onTouchEnd={handleTouchEnd}
+                  onTouchCancel={handleTouchEnd}
+                  className={cn(
+                    "relative z-10 flex items-center gap-1.5",
+                    "min-w-[44px] min-h-[44px] px-4 sm:px-6 py-2.5",
+                    "rounded-xl text-xs sm:text-sm font-bold",
+                    "transition-all duration-300 select-none",
+                    "touch-manipulation",
+                    isActive
+                      ? "text-white"
+                      : "text-content-secondary hover:text-content-primary",
+                    !isActive && "hover:shadow-neu-sunken-subtle",
+                    isTouched &&
+                      !isActive &&
+                      "shadow-neu-sunken-subtle scale-[0.96]",
+                  )}
+                >
+                  <SectionIcon
+                    size={14}
+                    className="hidden sm:block flex-shrink-0"
+                  />
+                  {section.label}
+                </a>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
 
   return (
     <div className="bg-transparent min-h-[100dvh]">
@@ -328,197 +300,8 @@ export default function UseCasesClient() {
           </div>
         </section>
 
-        {/* ── Hero (swaps per use case) ── */}
-        {activeUseCase === "freelance" && <FreelanceHero />}
-        {activeUseCase === "ecommerce" && <EcommerceHero />}
-        {activeUseCase === "dao-payroll" && <DaoPayrollHero />}
-        {activeUseCase === "real-estate" && <RealEstateHero />}
-        {activeUseCase === "service-platforms" && <ServicePlatformsHero />}
-
-        {/* ── Sticky Section Navigation (Neumorphic Pill) ── */}
-        <div
-          ref={navRef}
-          className={cn(
-            "sticky z-40 pointer-events-none",
-            "top-[80px] py-6",
-            "md:top-[80px]",
-          )}
-        >
-          <div className="max-w-3xl mx-auto px-4 sm:px-6 flex justify-center">
-            <div
-              className={cn(
-                "pointer-events-auto relative flex items-center p-1.5 sm:p-2 rounded-2xl bg-bg-base",
-                "transition-shadow duration-500 will-change-[box-shadow]",
-                isNavPinned
-                  ? "shadow-neu-raised-scrolled"
-                  : "shadow-neu-raised",
-              )}
-            >
-              <div
-                ref={pillContainerRef}
-                className="relative flex items-center gap-1 sm:gap-2"
-              >
-                {pillStyle && (
-                  <span
-                    className="absolute top-0 h-full rounded-xl btn-neumorphic-primary pointer-events-none"
-                    aria-hidden="true"
-                    style={{
-                      left: pillStyle.left,
-                      width: pillStyle.width,
-                      transition:
-                        "left 350ms cubic-bezier(0.25, 1, 0.5, 1), width 300ms ease-out",
-                      willChange: "left, width",
-                    }}
-                  />
-                )}
-
-                {PAGE_SECTIONS.map((section) => {
-                  const isActive = activeSection === section.id;
-                  const isTouched = touchedId === section.id;
-                  const SectionIcon = section.icon;
-
-                  return (
-                    <a
-                      key={section.id}
-                      ref={(el) => setLinkRef(section.id, el)}
-                      id={`nav-link-${section.id}`}
-                      href={`#${section.id}`}
-                      onClick={(e) => handleNavClick(e, section.id)}
-                      onTouchStart={() => handleTouchStart(section.id)}
-                      onTouchEnd={handleTouchEnd}
-                      onTouchCancel={handleTouchEnd}
-                      className={cn(
-                        "relative z-10 flex items-center gap-1.5",
-                        "min-w-[44px] min-h-[44px] px-4 sm:px-6 py-2.5",
-                        "rounded-xl text-xs sm:text-sm font-bold",
-                        "transition-all duration-300 select-none",
-                        "touch-manipulation",
-                        isActive
-                          ? "text-white"
-                          : "text-content-secondary hover:text-content-primary",
-                        !isActive && "hover:shadow-neu-sunken-subtle",
-                        isTouched &&
-                          !isActive &&
-                          "shadow-neu-sunken-subtle scale-[0.96]",
-                      )}
-                    >
-                      <SectionIcon
-                        size={14}
-                        className="hidden sm:block flex-shrink-0"
-                      />
-                      {section.label}
-                    </a>
-                  );
-                })}
-              </div>
-            </div>
-          </div>
-        </div>
-
-        {/* ── Features Section ── */}
-        <section
-          id="features"
-          className="py-24 relative bg-transparent"
-          style={{ scrollMarginTop: `${SCROLL_OFFSET}px` }}
-        >
-          <div className="max-w-7xl mx-auto px-6 lg:px-8 relative z-10">
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
-              {features.map((feat) => {
-                const FeatIcon = feat.icon;
-                return (
-                  <div
-                    key={feat.title}
-                    className="flex flex-col items-center text-center p-10 rounded-[2rem] bg-bg-elevated shadow-neu-raised hover:shadow-neu-raised-hover transition-all duration-300 ease-out group"
-                  >
-                    <div className="w-16 h-16 rounded-2xl shadow-neu-sunken-subtle bg-bg-base flex items-center justify-center mb-8 group-hover:shadow-neu-sunken transition-all duration-300 text-theme-primary">
-                      <FeatIcon size={28} />
-                    </div>
-                    <h3 className="text-xl font-bold mb-4 text-content-primary">
-                      {feat.title}
-                    </h3>
-                    <p className="text-sm font-medium leading-relaxed text-content-secondary">
-                      {feat.body}
-                    </p>
-                  </div>
-                );
-              })}
-            </div>
-          </div>
-        </section>
-
-        {/* ── Metrics Section ── */}
-        <section
-          id="metrics"
-          className="py-24 relative bg-transparent"
-          style={{ scrollMarginTop: `${SCROLL_OFFSET}px` }}
-        >
-          <div className="max-w-7xl mx-auto px-6 lg:px-8 relative z-10">
-            {activeUseCase === "freelance" && <FreelanceStellarImpactCards />}
-            {activeUseCase === "ecommerce" && <EcommerceStellarImpactCards />}
-            {activeUseCase === "dao-payroll" && (
-              <DaoPayrollStellarImpactCards />
-            )}
-            {activeUseCase === "real-estate" && (
-              <RealEstateStellarImpactCards />
-            )}
-            {activeUseCase === "service-platforms" && (
-              <ServicePlatformsStellarImpactCards />
-            )}
-          </div>
-        </section>
-
-        {/* ── Architecture Section ── */}
-        <section
-          id="architecture"
-          className="py-24 relative bg-transparent"
-          style={{ scrollMarginTop: `${SCROLL_OFFSET}px` }}
-        >
-          <div className="max-w-7xl mx-auto px-6 lg:px-8 relative z-10 text-center">
-            <div className="w-16 h-16 rounded-2xl shadow-neu-raised bg-bg-base mx-auto mb-8 flex items-center justify-center text-theme-primary">
-              <Users size={24} />
-            </div>
-
-            <h2 className="text-4xl md:text-5xl font-black mb-6 tracking-tight text-content-primary">
-              How it works under the hood
-            </h2>
-
-            <p className="text-lg font-medium max-w-2xl mx-auto mb-16 leading-relaxed text-content-secondary">
-              A simplified view of the smart contract interactions orchestrated
-              by OFFER HUB APIs.
-            </p>
-
-            {activeUseCase === "freelance" && <FreelanceEscrowFlowDiagram />}
-            {activeUseCase === "ecommerce" && <EcommerceEscrowFlowDiagram />}
-            {activeUseCase === "dao-payroll" && <DaoPayrollEscrowFlowDiagram />}
-            {activeUseCase === "real-estate" && <RealEstateEscrowFlowDiagram />}
-            {activeUseCase === "service-platforms" && (
-              <ServicePlatformsEscrowFlowDiagram />
-            )}
-          </div>
-        </section>
-
-        {/* ── SDK / Code Integration Section ── */}
-        <section
-          id="sdk"
-          className="relative bg-transparent"
-          style={{ scrollMarginTop: `${SCROLL_OFFSET}px` }}
-        >
-          {activeUseCase === "freelance" && (
-            <FreelanceCodeIntegrationShowcase />
-          )}
-          {activeUseCase === "ecommerce" && (
-            <EcommerceCodeIntegrationShowcase />
-          )}
-          {activeUseCase === "dao-payroll" && (
-            <DaoPayrollCodeIntegrationShowcase />
-          )}
-          {activeUseCase === "real-estate" && (
-            <RealEstateCodeIntegrationShowcase />
-          )}
-          {activeUseCase === "service-platforms" && (
-            <ServicePlatformsCodeIntegrationShowcase />
-          )}
-        </section>
+        {/* ── Active use-case section (lazy, code-split per tab) ── */}
+        <ActiveSection stickyNav={stickyNav} />
       </main>
 
       <Footer />

--- a/src/components/use-cases/constants.ts
+++ b/src/components/use-cases/constants.ts
@@ -1,0 +1,34 @@
+import {
+  Users,
+  ShoppingCart,
+  Coins,
+  Building2,
+  Briefcase,
+  Zap,
+  BarChart3,
+  Globe,
+  Code2,
+} from "lucide-react";
+
+// ── Top-level use-case switcher ──
+export const USE_CASES = [
+  { id: "freelance", label: "Freelance", icon: Users },
+  { id: "ecommerce", label: "eCommerce", icon: ShoppingCart },
+  { id: "dao-payroll", label: "DAO Payroll", icon: Coins },
+  { id: "real-estate", label: "Real Estate", icon: Building2 },
+  { id: "service-platforms", label: "Service Platforms", icon: Briefcase },
+] as const;
+
+export type UseCaseId = (typeof USE_CASES)[number]["id"];
+
+// ── In-page section navigation (sticky pill) ──
+export const PAGE_SECTIONS = [
+  { id: "overview", label: "Overview", icon: Users },
+  { id: "features", label: "Features", icon: Zap },
+  { id: "metrics", label: "Metrics", icon: BarChart3 },
+  { id: "architecture", label: "Architecture", icon: Globe },
+  { id: "sdk", label: "SDK", icon: Code2 },
+] as const;
+
+/** Offset (px) matching the sticky header height + breathing room */
+export const SCROLL_OFFSET = 140;

--- a/src/components/use-cases/dao-payroll/DaoPayrollSection.tsx
+++ b/src/components/use-cases/dao-payroll/DaoPayrollSection.tsx
@@ -1,0 +1,47 @@
+import type { ReactNode } from "react";
+
+import DaoPayrollHero from "./DaoPayrollHero";
+import DaoPayrollEscrowFlowDiagram from "./EscrowFlowDiagram";
+import DaoPayrollStellarImpactCards from "./StellarImpactCards";
+import DaoPayrollCodeIntegrationShowcase from "./CodeIntegrationShowcase";
+import { featureCards } from "./data";
+
+import {
+  FeaturesGrid,
+  MetricsSection,
+  ArchitectureSection,
+  SdkSection,
+} from "../shared/SectionLayout";
+
+/**
+ * Full vertical content for the DAO Payroll use case. Owns its own page-section
+ * wrappers (#features / #metrics / #architecture / #sdk); only one use-case
+ * section is mounted at a time, so the ids never collide.
+ */
+export default function DaoPayrollSection({
+  stickyNav,
+}: {
+  stickyNav?: ReactNode;
+}) {
+  return (
+    <>
+      <DaoPayrollHero />
+
+      {stickyNav}
+
+      <FeaturesGrid features={featureCards} />
+
+      <MetricsSection>
+        <DaoPayrollStellarImpactCards />
+      </MetricsSection>
+
+      <ArchitectureSection>
+        <DaoPayrollEscrowFlowDiagram />
+      </ArchitectureSection>
+
+      <SdkSection>
+        <DaoPayrollCodeIntegrationShowcase />
+      </SdkSection>
+    </>
+  );
+}

--- a/src/components/use-cases/dao-payroll/data.tsx
+++ b/src/components/use-cases/dao-payroll/data.tsx
@@ -1,5 +1,25 @@
-import { Eye, Zap, DollarSign, ShieldCheck } from "lucide-react";
+import { Eye, Zap, DollarSign, ShieldCheck, Coins, Globe } from "lucide-react";
 import type { DetailedMetricCard } from "../shared/StellarImpactCards";
+import type { FeatureCard } from "../shared/SectionLayout";
+
+// ── Features grid content (rendered in the #features section) ──
+export const featureCards: FeatureCard[] = [
+  {
+    icon: Coins,
+    title: "Governance-Gated Releases",
+    body: "DAO votes directly trigger payroll disbursements. No multisig delays — a passed proposal automatically releases contributor funds from the vault.",
+  },
+  {
+    icon: ShieldCheck,
+    title: "Contributor Trust",
+    body: "Budget is locked on-chain at the start of each epoch. Contributors can start work knowing their payment is already secured in escrow.",
+  },
+  {
+    icon: Globe,
+    title: "Multi-Currency Payouts",
+    body: "Pay contributors globally in USDC, XLM, or any Stellar-issued asset. No bank accounts required. Settlement completes in under 5 seconds.",
+  },
+];
 
 export const stellarImpactCardsData: DetailedMetricCard[] = [
   {

--- a/src/components/use-cases/ecommerce/EcommerceSection.tsx
+++ b/src/components/use-cases/ecommerce/EcommerceSection.tsx
@@ -1,0 +1,47 @@
+import type { ReactNode } from "react";
+
+import EcommerceHero from "./EcommerceHero";
+import EcommerceEscrowFlowDiagram from "./EscrowFlowDiagram";
+import EcommerceStellarImpactCards from "./StellarImpactCards";
+import EcommerceCodeIntegrationShowcase from "./CodeIntegrationShowcase";
+import { featureCards } from "./data";
+
+import {
+  FeaturesGrid,
+  MetricsSection,
+  ArchitectureSection,
+  SdkSection,
+} from "../shared/SectionLayout";
+
+/**
+ * Full vertical content for the eCommerce use case. Owns its own page-section
+ * wrappers (#features / #metrics / #architecture / #sdk); only one use-case
+ * section is mounted at a time, so the ids never collide.
+ */
+export default function EcommerceSection({
+  stickyNav,
+}: {
+  stickyNav?: ReactNode;
+}) {
+  return (
+    <>
+      <EcommerceHero />
+
+      {stickyNav}
+
+      <FeaturesGrid features={featureCards} />
+
+      <MetricsSection>
+        <EcommerceStellarImpactCards />
+      </MetricsSection>
+
+      <ArchitectureSection>
+        <EcommerceEscrowFlowDiagram />
+      </ArchitectureSection>
+
+      <SdkSection>
+        <EcommerceCodeIntegrationShowcase />
+      </SdkSection>
+    </>
+  );
+}

--- a/src/components/use-cases/ecommerce/data.tsx
+++ b/src/components/use-cases/ecommerce/data.tsx
@@ -1,5 +1,25 @@
-import { ShieldCheck, Zap, PackageCheck } from "lucide-react";
+import { ShieldCheck, Zap, PackageCheck, Globe } from "lucide-react";
 import type { DetailedMetricCard } from "../shared/StellarImpactCards";
+import type { FeatureCard } from "../shared/SectionLayout";
+
+// ── Features grid content (rendered in the #features section) ──
+export const featureCards: FeatureCard[] = [
+  {
+    icon: ShieldCheck,
+    title: "Buyer & Seller Protection",
+    body: "Buyer funds are locked on-chain before the seller ships. Neither party can be defrauded — the escrow is the source of truth for every order.",
+  },
+  {
+    icon: Zap,
+    title: "Automatic Release on Delivery",
+    body: "Funds release the moment delivery is confirmed — by tracking API, signature scan, or a buyer click — removing payout batch delays entirely.",
+  },
+  {
+    icon: Globe,
+    title: "On-Chain Dispute Resolution",
+    body: "If an order is missing or misrepresented, the buyer opens a structured on-chain dispute. The outcome — release, refund, or split — is transparent and final.",
+  },
+];
 
 export const stellarImpactCardsData: DetailedMetricCard[] = [
   {

--- a/src/components/use-cases/freelance/FreelanceSection.tsx
+++ b/src/components/use-cases/freelance/FreelanceSection.tsx
@@ -1,0 +1,50 @@
+import type { ReactNode } from "react";
+
+import FreelanceHero from "./FreelanceHero";
+import FreelanceEscrowFlowDiagram from "./EscrowFlowDiagram";
+import FreelanceStellarImpactCards from "./StellarImpactCards";
+import FreelanceCodeIntegrationShowcase from "./CodeIntegrationShowcase";
+import { featureCards } from "./data";
+
+import {
+  FeaturesGrid,
+  MetricsSection,
+  ArchitectureSection,
+  SdkSection,
+} from "../shared/SectionLayout";
+
+/**
+ * Full vertical content for the Freelance use case. Owns its own page-section
+ * wrappers (#features / #metrics / #architecture / #sdk); only one use-case
+ * section is mounted at a time, so the ids never collide.
+ *
+ * `stickyNav` is injected by the orchestrator and rendered between the hero
+ * and the rest, matching the original page layout.
+ */
+export default function FreelanceSection({
+  stickyNav,
+}: {
+  stickyNav?: ReactNode;
+}) {
+  return (
+    <>
+      <FreelanceHero />
+
+      {stickyNav}
+
+      <FeaturesGrid features={featureCards} />
+
+      <MetricsSection>
+        <FreelanceStellarImpactCards />
+      </MetricsSection>
+
+      <ArchitectureSection>
+        <FreelanceEscrowFlowDiagram />
+      </ArchitectureSection>
+
+      <SdkSection>
+        <FreelanceCodeIntegrationShowcase />
+      </SdkSection>
+    </>
+  );
+}

--- a/src/components/use-cases/freelance/data.tsx
+++ b/src/components/use-cases/freelance/data.tsx
@@ -1,5 +1,25 @@
-import { DollarSign, Clock, ShieldCheck } from "lucide-react";
+import { DollarSign, Clock, ShieldCheck, Zap, Globe } from "lucide-react";
 import type { DetailedMetricCard } from "../shared/StellarImpactCards";
+import type { FeatureCard } from "../shared/SectionLayout";
+
+// ── Features grid content (rendered in the #features section) ──
+export const featureCards: FeatureCard[] = [
+  {
+    icon: ShieldCheck,
+    title: "Trustless Escrow",
+    body: "Lock client funds into secure smart contracts at project kick-off. Funds are guaranteed to exist, protecting both the freelancer and the client.",
+  },
+  {
+    icon: Zap,
+    title: "Milestone Automation",
+    body: "Trigger partial or full payments automatically when APIs dictate completion of deliverables, removing manual invoice friction.",
+  },
+  {
+    icon: Globe,
+    title: "Global Payouts",
+    body: "Settle funds instantly in USDC or fiat-backed stablecoins directly to the freelancer's wallet, bypassing multi-day bank transfer delays and high FX fees.",
+  },
+];
 
 export const stellarImpactCardsData: DetailedMetricCard[] = [
   {

--- a/src/components/use-cases/index.ts
+++ b/src/components/use-cases/index.ts
@@ -1,28 +1,33 @@
 // ── Freelance ──
+export { default as FreelanceSection } from "./freelance/FreelanceSection";
 export { default as FreelanceHero } from "./freelance/FreelanceHero";
 export { default as FreelanceEscrowFlowDiagram } from "./freelance/EscrowFlowDiagram";
 export { default as FreelanceStellarImpactCards } from "./freelance/StellarImpactCards";
 export { default as FreelanceCodeIntegrationShowcase } from "./freelance/CodeIntegrationShowcase";
 
 // ── eCommerce ──
+export { default as EcommerceSection } from "./ecommerce/EcommerceSection";
 export { default as EcommerceHero } from "./ecommerce/EcommerceHero";
 export { default as EcommerceEscrowFlowDiagram } from "./ecommerce/EscrowFlowDiagram";
 export { default as EcommerceStellarImpactCards } from "./ecommerce/StellarImpactCards";
 export { default as EcommerceCodeIntegrationShowcase } from "./ecommerce/CodeIntegrationShowcase";
 
 // ── DAO Payroll ──
+export { default as DaoPayrollSection } from "./dao-payroll/DaoPayrollSection";
 export { default as DaoPayrollHero } from "./dao-payroll/DaoPayrollHero";
 export { default as DaoPayrollEscrowFlowDiagram } from "./dao-payroll/EscrowFlowDiagram";
 export { default as DaoPayrollStellarImpactCards } from "./dao-payroll/StellarImpactCards";
 export { default as DaoPayrollCodeIntegrationShowcase } from "./dao-payroll/CodeIntegrationShowcase";
 
 // ── Real Estate ──
+export { default as RealEstateSection } from "./real-estate/RealEstateSection";
 export { default as RealEstateHero } from "./real-estate/RealEstateHero";
 export { default as RealEstateEscrowFlowDiagram } from "./real-estate/EscrowFlowDiagram";
 export { default as RealEstateStellarImpactCards } from "./real-estate/StellarImpactCards";
 export { default as RealEstateCodeIntegrationShowcase } from "./real-estate/CodeIntegrationShowcase";
 
 // ── Service Platforms ──
+export { default as ServicePlatformsSection } from "./service-platforms/ServicePlatformsSection";
 export { default as ServicePlatformsHero } from "./service-platforms/ServicePlatformsHero";
 export { default as ServicePlatformsEscrowFlowDiagram } from "./service-platforms/EscrowFlowDiagram";
 export { default as ServicePlatformsStellarImpactCards } from "./service-platforms/StellarImpactCards";

--- a/src/components/use-cases/real-estate/RealEstateSection.tsx
+++ b/src/components/use-cases/real-estate/RealEstateSection.tsx
@@ -1,0 +1,47 @@
+import type { ReactNode } from "react";
+
+import RealEstateHero from "./RealEstateHero";
+import RealEstateEscrowFlowDiagram from "./EscrowFlowDiagram";
+import RealEstateStellarImpactCards from "./StellarImpactCards";
+import RealEstateCodeIntegrationShowcase from "./CodeIntegrationShowcase";
+import { featureCards } from "./data";
+
+import {
+  FeaturesGrid,
+  MetricsSection,
+  ArchitectureSection,
+  SdkSection,
+} from "../shared/SectionLayout";
+
+/**
+ * Full vertical content for the Real Estate use case. Owns its own page-section
+ * wrappers (#features / #metrics / #architecture / #sdk); only one use-case
+ * section is mounted at a time, so the ids never collide.
+ */
+export default function RealEstateSection({
+  stickyNav,
+}: {
+  stickyNav?: ReactNode;
+}) {
+  return (
+    <>
+      <RealEstateHero />
+
+      {stickyNav}
+
+      <FeaturesGrid features={featureCards} />
+
+      <MetricsSection>
+        <RealEstateStellarImpactCards />
+      </MetricsSection>
+
+      <ArchitectureSection>
+        <RealEstateEscrowFlowDiagram />
+      </ArchitectureSection>
+
+      <SdkSection>
+        <RealEstateCodeIntegrationShowcase />
+      </SdkSection>
+    </>
+  );
+}

--- a/src/components/use-cases/real-estate/data.tsx
+++ b/src/components/use-cases/real-estate/data.tsx
@@ -1,5 +1,25 @@
-import { ShieldCheck, Clock, Eye } from "lucide-react";
+import { ShieldCheck, Clock, Eye, Building2, Zap } from "lucide-react";
 import type { DetailedMetricCard } from "../shared/StellarImpactCards";
+import type { FeatureCard } from "../shared/SectionLayout";
+
+// ── Features grid content (rendered in the #features section) ──
+export const featureCards: FeatureCard[] = [
+  {
+    icon: Building2,
+    title: "Tokenised Escrow",
+    body: "Earnest money and closing funds are held in programmable on-chain escrow, eliminating the need for a third-party title company for each step.",
+  },
+  {
+    icon: ShieldCheck,
+    title: "Condition-Based Releases",
+    body: "Funds only release when contingencies are met: inspection approval, title clearance, mortgage funding. Automated and auditable at every stage.",
+  },
+  {
+    icon: Zap,
+    title: "Instant Cross-Border Closing",
+    body: "International buyers settle in USDC with no wire delays or correspondent bank fees. Foreign national transactions close in the same time as domestic ones.",
+  },
+];
 
 export const stellarImpactCardsData: DetailedMetricCard[] = [
   {

--- a/src/components/use-cases/service-platforms/ServicePlatformsSection.tsx
+++ b/src/components/use-cases/service-platforms/ServicePlatformsSection.tsx
@@ -1,0 +1,47 @@
+import type { ReactNode } from "react";
+
+import ServicePlatformsHero from "./ServicePlatformsHero";
+import ServicePlatformsEscrowFlowDiagram from "./EscrowFlowDiagram";
+import ServicePlatformsStellarImpactCards from "./StellarImpactCards";
+import ServicePlatformsCodeIntegrationShowcase from "./CodeIntegrationShowcase";
+import { featureCards } from "./data";
+
+import {
+  FeaturesGrid,
+  MetricsSection,
+  ArchitectureSection,
+  SdkSection,
+} from "../shared/SectionLayout";
+
+/**
+ * Full vertical content for the Service Platforms use case. Owns its own
+ * page-section wrappers (#features / #metrics / #architecture / #sdk); only one
+ * use-case section is mounted at a time, so the ids never collide.
+ */
+export default function ServicePlatformsSection({
+  stickyNav,
+}: {
+  stickyNav?: ReactNode;
+}) {
+  return (
+    <>
+      <ServicePlatformsHero />
+
+      {stickyNav}
+
+      <FeaturesGrid features={featureCards} />
+
+      <MetricsSection>
+        <ServicePlatformsStellarImpactCards />
+      </MetricsSection>
+
+      <ArchitectureSection>
+        <ServicePlatformsEscrowFlowDiagram />
+      </ArchitectureSection>
+
+      <SdkSection>
+        <ServicePlatformsCodeIntegrationShowcase />
+      </SdkSection>
+    </>
+  );
+}

--- a/src/components/use-cases/service-platforms/data.tsx
+++ b/src/components/use-cases/service-platforms/data.tsx
@@ -1,5 +1,25 @@
-import { Zap, ShieldCheck, Eye } from "lucide-react";
+import { Zap, ShieldCheck, Eye, Briefcase, Globe } from "lucide-react";
 import type { SimpleMetricCard } from "../shared/StellarImpactCards";
+import type { FeatureCard } from "../shared/SectionLayout";
+
+// ── Features grid content (rendered in the #features section) ──
+export const featureCards: FeatureCard[] = [
+  {
+    icon: Briefcase,
+    title: "SOW-Backed Contracts",
+    body: "Every engagement starts with a statement of work locked on-chain. Scope, milestones, and payment terms are immutable once both parties sign.",
+  },
+  {
+    icon: ShieldCheck,
+    title: "Milestone-Gated Payments",
+    body: "Providers receive each tranche only after the corresponding deliverable is approved, eliminating late or non-payment risk for service professionals.",
+  },
+  {
+    icon: Globe,
+    title: "Structured Dispute Resolution",
+    body: "Built-in on-chain arbitration ensures every dispute has a clear, auditable outcome — release, refund, or split — visible to all stakeholders.",
+  },
+];
 
 export const stellarImpactCardsData: SimpleMetricCard[] = [
   {

--- a/src/components/use-cases/shared/SectionLayout.tsx
+++ b/src/components/use-cases/shared/SectionLayout.tsx
@@ -1,0 +1,111 @@
+import type { FC, ReactNode } from "react";
+import { Users } from "lucide-react";
+import { SCROLL_OFFSET } from "../constants";
+
+export type FeatureCard = {
+  icon: FC<{ size?: number; className?: string }>;
+  title: string;
+  body: string;
+};
+
+/**
+ * Shared, interactivity-free chrome reused by every use-case section
+ * component. Kept free of `"use client"` so the markup stays a Server
+ * Component; the interactive leaf pieces are passed in as children.
+ */
+
+/** ── Features Section (3-card grid, data-driven) ── */
+export function FeaturesGrid({ features }: { features: FeatureCard[] }) {
+  return (
+    <section
+      id="features"
+      className="py-24 relative bg-transparent"
+      style={{ scrollMarginTop: `${SCROLL_OFFSET}px` }}
+    >
+      <div className="max-w-7xl mx-auto px-6 lg:px-8 relative z-10">
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+          {features.map((feat) => {
+            const FeatIcon = feat.icon;
+            return (
+              <div
+                key={feat.title}
+                className="flex flex-col items-center text-center p-10 rounded-[2rem] bg-bg-elevated shadow-neu-raised hover:shadow-neu-raised-hover transition-all duration-300 ease-out group"
+              >
+                <div className="w-16 h-16 rounded-2xl shadow-neu-sunken-subtle bg-bg-base flex items-center justify-center mb-8 group-hover:shadow-neu-sunken transition-all duration-300 text-theme-primary">
+                  <FeatIcon size={28} />
+                </div>
+                <h3 className="text-xl font-bold mb-4 text-content-primary">
+                  {feat.title}
+                </h3>
+                <p className="text-sm font-medium leading-relaxed text-content-secondary">
+                  {feat.body}
+                </p>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+/** ── Metrics Section (wraps a per-use-case StellarImpactCards) ── */
+export function MetricsSection({ children }: { children: ReactNode }) {
+  return (
+    <section
+      id="metrics"
+      className="py-24 relative bg-transparent"
+      style={{ scrollMarginTop: `${SCROLL_OFFSET}px` }}
+    >
+      <div className="max-w-7xl mx-auto px-6 lg:px-8 relative z-10">
+        {children}
+      </div>
+    </section>
+  );
+}
+
+/** ── Architecture Section (shared heading + per-use-case diagram) ── */
+export function ArchitectureSection({ children }: { children: ReactNode }) {
+  return (
+    <section
+      id="architecture"
+      className="py-24 relative bg-transparent"
+      style={{ scrollMarginTop: `${SCROLL_OFFSET}px` }}
+    >
+      <div className="max-w-7xl mx-auto px-6 lg:px-8 relative z-10 text-center">
+        <div className="w-16 h-16 rounded-2xl shadow-neu-raised bg-bg-base mx-auto mb-8 flex items-center justify-center text-theme-primary">
+          <Users size={24} />
+        </div>
+
+        <h2 className="text-4xl md:text-5xl font-black mb-6 tracking-tight text-content-primary">
+          How it works under the hood
+        </h2>
+
+        <p className="text-lg font-medium max-w-2xl mx-auto mb-16 leading-relaxed text-content-secondary">
+          A simplified view of the smart contract interactions orchestrated by
+          OFFER HUB APIs.
+        </p>
+
+        {children}
+      </div>
+    </section>
+  );
+}
+
+/** ── SDK / Code Integration Section (wraps a per-use-case showcase) ── */
+export function SdkSection({ children }: { children: ReactNode }) {
+  return (
+    <section
+      id="sdk"
+      className="relative bg-transparent"
+      style={{ scrollMarginTop: `${SCROLL_OFFSET}px` }}
+    >
+      {children}
+    </section>
+  );
+}
+
+/** ── Placeholder shown while a lazily-loaded section bundle resolves ── */
+export function SectionLoading() {
+  return <div className="min-h-[60vh]" aria-hidden="true" />;
+}


### PR DESCRIPTION
# 📝 Pull Request

## 🔧 Title:

- Refactor: Split UseCasesClient into orchestrator + lazy-loaded section components

## 🛠️ Issue

- Closes #1417 
## 📚 Description

`src/components/use-cases/UseCasesClient.tsx` was a 526-line `"use client"` component that mixed three concerns: tab/section navigation state, the tab selector UI, and inline rendering of all 5 use-case family sections. Because everything lived in one client component, the whole page shipped to the client and every use-case bundle was eagerly loaded — preventing route-level code-splitting and making the file hard to navigate.

This PR reduces `UseCasesClient` to a thin orchestrator that owns only the active-tab state, the sticky pill navigation, and the scroll-spy logic. Each use-case family (`Freelance`, `Ecommerce`, `DaoPayroll`, `RealEstate`, `ServicePlatforms`) is extracted into its own section component and lazy-loaded with `next/dynamic`, so only the active tab's bundle is fetched. Tab switching, the animated pill, and the scroll-spy behavior are unchanged.

Per the agreed pragmatic approach, the shared section chrome and the new `*Section` wrappers are authored without `"use client"`; the leaf components (Hero, EscrowFlowDiagram, StellarImpactCards, CodeIntegrationShowcase) keep their existing client boundary because they rely on framer-motion/hooks.

## ✅ Changes applied

- Reduced `UseCasesClient.tsx` to an orchestrator: active-tab state + tab bar + sticky nav + a single lazy slot for the active section.
- Extracted each use-case family into its own component: `freelance/FreelanceSection.tsx`, `ecommerce/EcommerceSection.tsx`, `dao-payroll/DaoPayrollSection.tsx`, `real-estate/RealEstateSection.tsx`, `service-platforms/ServicePlatformsSection.tsx`.
- Added `constants.ts` (`USE_CASES`, `UseCaseId`, `PAGE_SECTIONS`, `SCROLL_OFFSET`) shared by the orchestrator and sections.
- Added `shared/SectionLayout.tsx` with reusable, interactivity-free chrome (`FeaturesGrid`, `MetricsSection`, `ArchitectureSection`, `SdkSection`, `SectionLoading`) — no `"use client"`.
- Moved each use case's features content into its `data.tsx` as `featureCards`.
- Applied `next/dynamic` lazy-loading to all 5 sections, each with a `SectionLoading` placeholder — only the active tab's bundle is loaded.
- Re-initialized the `IntersectionObserver` on tab change so scroll-spy keeps tracking the lazily-mounted sections; the animated pill and tab behavior are preserved.
- Injected the sticky nav into the active section via a `stickyNav` prop to keep the original page layout (hero → nav → features → metrics → architecture → sdk).
- Updated `index.ts` to export the new section components.

### Verification

- `tsc --noEmit` → 0 errors.
- `next lint` (use-cases) → 0 warnings/errors.
- `next build` → success.
- Code-splitting confirmed: each use case ships in its own chunk and `/use-cases` First Load JS dropped from **203 kB** to **135 kB** (route size 23.1 kB → 4.84 kB).

