### PR TITLE
fix(architecture): remove Abroad references from /architecture page

### DIFF
--- a/src/app/architecture/page.tsx
+++ b/src/app/architecture/page.tsx
@@ -15,7 +15,7 @@ import TractionSection from "@/components/architecture/TractionSection";
 export const metadata: Metadata = {
   title: "Technical Architecture",
   description:
-    "Complete technical architecture of OFFER-HUB: non-custodial escrow on Stellar, Stellar Wallets Kit integration, BlindPay and Abroad off-ramp corridors across 7 LATAM markets. SCF Build Award #44.",
+    "Complete technical architecture of OFFER-HUB: non-custodial escrow on Stellar, Stellar Wallets Kit integration, BlindPay off-ramp corridors across 7 LATAM markets. SCF Build Award #44.",
   keywords: [
     "architecture",
     "stellar",
@@ -23,7 +23,6 @@ export const metadata: Metadata = {
     "escrow",
     "TrustlessWork",
     "BlindPay",
-    "Abroad",
     "SCF",
     "OFFER-HUB",
     "USDC",

--- a/src/components/architecture/IntegrationsMap.tsx
+++ b/src/components/architecture/IntegrationsMap.tsx
@@ -20,7 +20,7 @@ export default function IntegrationsMap() {
         <div className="rounded-2xl bg-bg-base shadow-neu-sunken-subtle px-5 py-4 mb-12 flex gap-3 items-start max-w-4xl mx-auto">
           <Info size={15} className="text-theme-primary shrink-0 mt-0.5" />
           <p className="text-sm text-content-secondary leading-relaxed">
-            OfferHub uses three building blocks from the official SCF Integration List. Stellar Wallets Kit handles non-custodial wallet connection and client-side Soroban signing. BlindPay routes USDC to bank accounts across 7 LATAM corridors via SPEI, Pix, PSE, and Transfer 3.0. Abroad delivers funds to mobile wallets (Nequi, Daviplata, Bre-B) for unbanked users. The NestJS orchestrator selects the off-ramp route automatically based on freelancer country and payout preference.
+            OfferHub uses two building blocks from the official SCF Integration List. Stellar Wallets Kit handles non-custodial wallet connection and client-side Soroban signing. BlindPay routes USDC to bank accounts across 7 LATAM corridors via SPEI, Pix, PSE, and Transfer 3.0. The NestJS orchestrator selects the corridor automatically based on freelancer country and payout preference.
           </p>
         </div>
 
@@ -45,11 +45,8 @@ export default function IntegrationsMap() {
             {/* Hub to SWK (Left) */}
             <path d="M 500 300 Q 350 300 250 300" fill="none" stroke="#149A9B" strokeWidth="2" opacity="0.4" className="anim-line-left" />
             
-            {/* Hub to BlindPay (Top Right) */}
-            <path d="M 500 300 Q 650 200 750 150" fill="none" stroke="#149A9B" strokeWidth="2" opacity="0.4" className="anim-line-right" />
-            
-            {/* Hub to Abroad (Bottom Right) */}
-            <path d="M 500 300 Q 650 400 750 450" fill="none" stroke="#149A9B" strokeWidth="2" opacity="0.4" className="anim-line-right" />
+            {/* Hub to BlindPay (Right) */}
+            <path d="M 500 300 Q 650 300 750 300" fill="none" stroke="#149A9B" strokeWidth="2" opacity="0.4" className="anim-line-right" />
           </svg>
 
           {/* Mobile Connectors */}
@@ -95,8 +92,8 @@ export default function IntegrationsMap() {
             </div>
           </div>
 
-          {/* Right Top Spoke: BlindPay */}
-          <div className="relative z-10 w-full md:absolute md:right-[5%] md:top-[10%] md:w-[340px]">
+          {/* Right Spoke: BlindPay */}
+          <div className="relative z-10 w-full md:absolute md:right-[5%] md:top-1/2 md:-translate-y-1/2 md:w-[340px]">
             <div className="rounded-[2rem] bg-bg-elevated shadow-neu-raised p-6 border border-[var(--color-border)]">
               <div className="flex justify-between items-start mb-4">
                 <h3 className="text-lg font-bold text-content-primary">BlindPay</h3>
@@ -118,41 +115,14 @@ export default function IntegrationsMap() {
             </div>
           </div>
 
-          {/* Right Bottom Spoke: Abroad */}
-          <div className="relative z-10 w-full md:absolute md:right-[5%] md:bottom-[10%] md:w-[340px]">
-            <div className="rounded-[2rem] bg-bg-elevated shadow-neu-raised p-6 border border-[var(--color-border)]">
-              <div className="flex justify-between items-start mb-4">
-                <h3 className="text-lg font-bold text-content-primary">Abroad</h3>
-                <span className="text-[10px] font-bold uppercase tracking-wider bg-bg-base shadow-neu-sunken px-2 py-1 rounded-full text-theme-primary">SCF Integration #3</span>
-              </div>
-              
-              <div className="flex flex-wrap gap-2 mb-4">
-                <span className="text-[10px] bg-bg-base shadow-neu-sunken-subtle px-2 py-1 rounded-md text-content-muted">Circle Alliance</span>
-                <span className="text-[10px] bg-bg-base shadow-neu-sunken-subtle px-2 py-1 rounded-md text-content-muted">47% unbanked</span>
-              </div>
-              
-              <div className="grid grid-cols-2 gap-3">
-                {['Nequi', 'Daviplata', 'Bre-B', 'Pix'].map(c => (
-                  <div key={c} className="text-xs font-medium text-center bg-bg-base shadow-neu-raised-sm rounded-xl py-3 text-content-primary">
-                    {c}
-                  </div>
-                ))}
-              </div>
-            </div>
-          </div>
-
         </div>
 
         {/* Stats Strip */}
         <div className="mt-16 flex justify-center">
           <div className="rounded-2xl bg-bg-elevated shadow-neu-raised-sm border border-[var(--color-border)] px-8 py-4 inline-flex flex-wrap justify-center items-center gap-4 text-sm font-medium text-content-secondary">
-            <span>3 SCF Integrations</span>
+            <span>2 SCF Integrations</span>
             <span className="text-[var(--color-border)]">•</span>
-            <span>7 BlindPay Corridors</span>
-            <span className="text-[var(--color-border)]">•</span>
-            <span>4 Abroad Methods</span>
-            <span className="text-[var(--color-border)]">•</span>
-            <span className="text-theme-primary font-bold">11 Total Corridors</span>
+            <span className="text-theme-primary font-bold">7 BlindPay Corridors</span>
           </div>
         </div>
 

--- a/src/components/architecture/PaymentFlowDiagram.tsx
+++ b/src/components/architecture/PaymentFlowDiagram.tsx
@@ -16,7 +16,7 @@ sequenceDiagram
     participant SWK as SWK
     participant NestJS as NestJS (OfferHub API)
     participant TW as TrustlessWork (escrow)
-    participant Offramp as BlindPay/Abroad
+    participant Offramp as BlindPay
 
     Client->>NestJS: POST /orders (USDC reserved)
     NestJS->>TW: deployEscrow(buyer, seller, amount)
@@ -32,7 +32,7 @@ sequenceDiagram
     SWK->>TW: release_escrow
     TW-->>NestJS: webhook: escrow_released
     NestJS->>Offramp: POST /payout (USDC → fiat)
-    Offramp-->>Client: fiat settled (SPEI / Pix / Nequi...)
+    Offramp-->>Client: fiat settled (SPEI / Pix / PSE...)
   `;
 
   const stateChart = `

--- a/src/components/architecture/SCFTrancheRoadmap.tsx
+++ b/src/components/architecture/SCFTrancheRoadmap.tsx
@@ -19,14 +19,13 @@ gantt
     SWK Wallet Connection + Balance Display    :t1a, 2026-07-01, 2026-09-01
     Wallet-Based Auth (hybrid)                 :t1b, 2026-08-01, 2026-09-01
 
-  section T2 — Testnet: Core Integrations ($24K)
+  section T2 — Testnet: Core Integrations ($19.5K)
     Soroban Client-Side Signing (SWK)          :t2a, 2026-09-01, 2026-10-20
     BlindPay — 7 LATAM Corridors               :t2b, 2026-09-01, 2026-10-20
-    Abroad — Nequi/Daviplata/Bre-B/Pix         :t2c, 2026-09-15, 2026-10-20
     Off-ramp Orchestration + Webhooks          :t2d, 2026-09-15, 2026-10-20
     E2E Integration Testing                    :t2e, 2026-10-01, 2026-10-20
 
-  section T3 — Mainnet Launch & OS Adapters ($32K)
+  section T3 — Mainnet Launch & OS Adapters ($30.5K)
     Horizon → Stellar RPC Migration            :t3a, 2026-10-20, 2026-12-05
     Mainnet Launch + Monitoring                :t3b, 2026-10-20, 2026-12-05
     Open-Source Integration Adapters           :t3c, 2026-11-15, 2026-12-05
@@ -43,14 +42,14 @@ gantt
             SCF Build #44 Roadmap
           </h2>
           <p className="text-content-secondary max-w-2xl text-lg mb-8">
-            Detailed timeline for the execution of our $80,000 SCF Build Award milestones.
+            Detailed timeline for the execution of our $74,000 SCF Build Award milestones.
           </p>
         </div>
 
         <div className="rounded-2xl bg-bg-base shadow-neu-sunken-subtle px-5 py-4 mb-12 flex gap-3 items-start max-w-4xl mx-auto">
           <Info size={15} className="text-theme-primary shrink-0 mt-0.5" />
           <p className="text-sm text-content-secondary leading-relaxed">
-            Three tranches, each tied to verifiable on-chain or functional deliverables. Tranche 1 ships the wallet connection layer. Tranche 2 completes all three SCF integrations on testnet. Tranche 3 migrates to Stellar RPC, launches on mainnet, records 10 live transactions as proof, and open-sources the integration adapters.
+            Three tranches, each tied to verifiable on-chain or functional deliverables. Tranche 1 ships the wallet connection layer. Tranche 2 completes both SCF integrations on testnet. Tranche 3 migrates to Stellar RPC, launches on mainnet, records 10 live transactions as proof, and open-sources the integration adapters.
           </p>
         </div>
 
@@ -99,27 +98,27 @@ gantt
                   <td className="py-4 px-6 text-content-secondary">Sept 1, 2026</td>
                   <td className="py-4 px-6 text-content-secondary">$16,000</td>
                   <td className="py-4 px-6 text-content-secondary">$16,000</td>
-                  <td className="py-4 px-6 text-content-secondary">20%</td>
+                  <td className="py-4 px-6 text-content-secondary">22%</td>
                 </tr>
                 <tr className="border-b border-[var(--color-border)]">
                   <td className="py-4 px-6 font-medium text-content-primary">T2 — Testnet: Core Integrations</td>
                   <td className="py-4 px-6 text-content-secondary">Oct 20, 2026</td>
-                  <td className="py-4 px-6 text-content-secondary">$24,000</td>
-                  <td className="py-4 px-6 text-content-secondary">$24,000</td>
-                  <td className="py-4 px-6 text-content-secondary">30%</td>
+                  <td className="py-4 px-6 text-content-secondary">$19,500</td>
+                  <td className="py-4 px-6 text-content-secondary">$19,500</td>
+                  <td className="py-4 px-6 text-content-secondary">26%</td>
                 </tr>
                 <tr className="border-b border-[var(--color-border)]">
                   <td className="py-4 px-6 font-medium text-content-primary">T3 — Mainnet Launch & OS Adapters</td>
                   <td className="py-4 px-6 text-content-secondary">Dec 5, 2026</td>
-                  <td className="py-4 px-6 text-content-secondary">$32,000</td>
-                  <td className="py-4 px-6 text-content-secondary">$32,000</td>
-                  <td className="py-4 px-6 text-content-secondary">40%</td>
+                  <td className="py-4 px-6 text-content-secondary">$30,500</td>
+                  <td className="py-4 px-6 text-content-secondary">$30,500</td>
+                  <td className="py-4 px-6 text-content-secondary">41%</td>
                 </tr>
                 <tr className="font-bold">
                   <td className="py-4 px-6 text-theme-primary">Total</td>
                   <td className="py-4 px-6 text-theme-primary"></td>
-                  <td className="py-4 px-6 text-theme-primary">$80,000</td>
-                  <td className="py-4 px-6 text-theme-primary">$80,000</td>
+                  <td className="py-4 px-6 text-theme-primary">$74,000</td>
+                  <td className="py-4 px-6 text-theme-primary">$74,000</td>
                   <td className="py-4 px-6 text-theme-primary">100%</td>
                 </tr>
               </tbody>

--- a/src/components/architecture/SystemArchitectureDiagram.tsx
+++ b/src/components/architecture/SystemArchitectureDiagram.tsx
@@ -21,7 +21,7 @@ flowchart TD
     API["NestJS API<br/><small>Auth · Orders · Escrow · Payments · Webhooks · Off-ramp</small>"]:::backend
     Data["Data Layer<br/><small>PostgreSQL · Redis · BullMQ</small>"]:::subtle
     Stellar["Stellar<br/><small>Soroban Contracts · TrustlessWork · USDC</small>"]:::subtle
-    Offramp["Off-ramp<br/><small>BlindPay · Abroad</small>"]:::highlight
+    Offramp["Off-ramp<br/><small>BlindPay (7 corridors)</small>"]:::highlight
 
     Client -->|HTTPS / REST| API
     Client -->|Client-side Soroban signing| Wallet
@@ -52,7 +52,7 @@ flowchart TD
           <div className="rounded-2xl bg-bg-base shadow-neu-sunken-subtle px-5 py-4 mb-6 flex gap-3 items-start">
             <Info size={15} className="text-theme-primary shrink-0 mt-0.5" />
             <p className="text-sm text-content-secondary leading-relaxed">
-              This flowchart maps every layer of the OfferHub stack — from the browser and Stellar Wallets Kit on the client side, through the NestJS orchestration API and PostgreSQL/Redis data layer, down to Soroban smart contracts on Stellar and the BlindPay/Abroad off-ramp providers. Arrows show the protocol or method used at each boundary. Teal nodes are the three SCF Integration Track building blocks.
+              This flowchart maps every layer of the OfferHub stack — from the browser and Stellar Wallets Kit on the client side, through the NestJS orchestration API and PostgreSQL/Redis data layer, down to Soroban smart contracts on Stellar and the BlindPay off-ramp provider. Arrows show the protocol or method used at each boundary. Teal nodes are the two SCF Integration Track building blocks.
             </p>
           </div>
 

--- a/src/components/architecture/TractionSection.tsx
+++ b/src/components/architecture/TractionSection.tsx
@@ -72,7 +72,7 @@ export default function TractionSection() {
                 </li>
                 <li className="flex gap-3 items-start">
                   <CheckCircle2 size={16} className="text-theme-primary shrink-0 mt-0.5" />
-                  <span>BlindPay and Abroad onboarding initiated — estimated 1–2 weeks to production</span>
+                  <span>BlindPay onboarding initiated — estimated 1–2 weeks to production</span>
                 </li>
               </ul>
             </div>
@@ -93,12 +93,12 @@ export default function TractionSection() {
               </div>
               <div className="rounded-[2rem] bg-bg-elevated shadow-neu-raised-l2-sm p-7 flex items-center justify-between">
                 <span className="text-3xl md:text-4xl font-black text-theme-primary">7</span>
-                <span className="text-sm text-content-muted text-right max-w-[150px]">Countries covered by BlindPay + Abroad corridors</span>
+                <span className="text-sm text-content-muted text-right max-w-[150px]">Countries covered by BlindPay corridors</span>
               </div>
             </div>
 
             <div className="rounded-2xl bg-bg-base shadow-neu-sunken p-5 text-sm text-content-secondary leading-relaxed mt-2">
-              Traditional platforms (Upwork, Fiverr) cannot pay unbanked LATAM freelancers directly. OfferHub + Stellar + BlindPay + Abroad closes this gap: any freelancer with a mobile wallet receives USDC-settled payments in seconds, converted to local fiat via established licensed corridors.
+              Traditional platforms (Upwork, Fiverr) cannot pay unbanked LATAM freelancers directly. OfferHub + Stellar + BlindPay closes this gap: any freelancer with a mobile wallet receives USDC-settled payments in seconds, converted to local fiat via established licensed corridors.
             </div>
           </div>
 

--- a/src/components/architecture/WhyStellarSection.tsx
+++ b/src/components/architecture/WhyStellarSection.tsx
@@ -72,7 +72,7 @@ export default function WhyStellarSection() {
             </div>
             <h3 className="text-base font-bold text-content-primary">LATAM off-ramp coverage</h3>
             <p className="text-sm text-content-secondary leading-relaxed">
-              BlindPay and Abroad together cover 11 payout corridors across 6 LATAM countries — all settled from on-chain USDC. This makes Stellar the settlement layer for a population where 47% of the workforce is unbanked and traditional payment rails are unreliable or inaccessible.
+              BlindPay covers 7 payout corridors across 6 LATAM countries — all settled from on-chain USDC. This makes Stellar the settlement layer for a population where 47% of the workforce is unbanked and traditional payment rails are unreliable or inaccessible.
             </p>
           </div>
 
@@ -82,7 +82,7 @@ export default function WhyStellarSection() {
             </div>
             <h3 className="text-base font-bold text-content-primary">Ecosystem value OfferHub adds</h3>
             <p className="text-sm text-content-secondary leading-relaxed">
-              OfferHub brings real freelance transaction volume to Stellar mainnet. Every completed order is an on-chain USDC escrow release followed by a fiat settlement via a Stellar anchor. Open-sourcing the SWK + BlindPay + Abroad adapters in T3 creates reusable building blocks for any future Stellar marketplace.
+              OfferHub brings real freelance transaction volume to Stellar mainnet. Every completed order is an on-chain USDC escrow release followed by a fiat settlement via a Stellar anchor. Open-sourcing the SWK + BlindPay adapters in T3 creates reusable building blocks for any future Stellar marketplace.
             </p>
           </div>
 


### PR DESCRIPTION
# 📝 Pull Request

## 🔧 Title:
fix(architecture): remove Abroad references from /architecture page

## 🛠️ Issue

- N/A — internal consistency update aligned with SCF Build #44 resubmission

## 📚 Description

Abroad has been removed from the SCF Build #44 Integration Track scope. The submission now covers 2 building blocks: Stellar Wallets Kit (SWK) + BlindPay. This PR removes all Abroad references from the `/architecture` page and aligns the displayed budget with the updated $74,000 total.

## ✅ Changes applied

- `IntegrationsMap.tsx` — removed Abroad card and SVG spoke, updated info text to "2 building blocks", updated stats strip to "2 SCF Integrations · 7 BlindPay Corridors"
- `SystemArchitectureDiagram.tsx` — updated Offramp node to "BlindPay (7 corridors)", updated info text to "two SCF Integration Track building blocks"
- `PaymentFlowDiagram.tsx` — renamed participant from `BlindPay/Abroad` to `BlindPay`, updated fiat settlement example to SPEI/Pix/PSE
- `WhyStellarSection.tsx` — updated corridor count from 11 to 7, removed Abroad from open-source adapters mention
- `TractionSection.tsx` — removed Abroad from 3 locations (build readiness, market stat, closing paragraph)
- `SCFTrancheRoadmap.tsx` — removed Abroad Gantt row, updated section headers to $19.5K/$30.5K, updated description and table (T2=$19,500, T3=$30,500, Total=$74,000)
- `page.tsx` — removed Abroad from metadata description and keywords

## 🔍 Evidence/Media

N/A — text/content changes only, no visual regressions expected