### PR TITLE
fix(community): replace in-memory GitHub cache with Next.js revalidation

### DIFF
--- a/src/app/community/page.tsx
+++ b/src/app/community/page.tsx
@@ -11,6 +11,8 @@ import LoadingBar from "@/components/ui/LoadingBar";
 import { Footer } from "@/components/layout/Footer";
 import { Navbar } from "@/components/layout/Navbar";
 
+export const revalidate = 600;
+
 export const metadata: Metadata = {
   title: "Community",
   description:
@@ -119,13 +121,6 @@ const REPOS = [
   'OFFER-HUB/OFFER-HUB-Frontend'
 ];
 
-// In-memory cache for GitHub data (survives hot reloads in dev)
-let githubCache: { data: ReturnType<typeof processGitHubData> | null; timestamp: number } = {
-  data: null,
-  timestamp: 0,
-};
-const CACHE_TTL = 10 * 60 * 1000; // 10 minutes
-
 function processGitHubData(validData: NonNullable<Awaited<ReturnType<typeof fetchRepoData>>>[]): CommunityData {
   const totalStars = validData.reduce((acc, d) => acc + d.repo.stargazers_count, 0);
   const totalForks = validData.reduce((acc, d) => acc + d.repo.forks_count, 0);
@@ -190,7 +185,7 @@ function processGitHubData(validData: NonNullable<Awaited<ReturnType<typeof fetc
 }
 
 async function fetchRepoData(repo: string) {
-  const cacheOpts = { next: { revalidate: 7200 } };
+  const cacheOpts = { next: { revalidate: 600 } };
   const [repoRes, contribRes, prRes, issueRes] = await Promise.all([
     fetch(`https://api.github.com/repos/${repo}`, cacheOpts),
     fetch(`https://api.github.com/repos/${repo}/contributors?per_page=100`, cacheOpts),
@@ -209,11 +204,6 @@ async function fetchRepoData(repo: string) {
 }
 
 async function fetchGitHubData() {
-  // Return cached data if still fresh
-  if (githubCache.data && Date.now() - githubCache.timestamp < CACHE_TTL) {
-    return githubCache.data;
-  }
-
   try {
     const allPills = await Promise.all(REPOS.map(fetchRepoData));
 
@@ -221,9 +211,7 @@ async function fetchGitHubData() {
 
     if (validData.length === 0) throw new Error('Failed to fetch any repo data');
 
-    const result = processGitHubData(validData);
-    githubCache = { data: result, timestamp: Date.now() };
-    return result;
+    return processGitHubData(validData);
   } catch (error) {
     console.error('Error fetching GitHub data:', error);
     return {


### PR DESCRIPTION
## Summary

Replaces the fragile module-level `githubCache` on the community page with Next.js built-in fetch caching and ISR, making GitHub stats reliable across deployments and cold starts.

## Problem

The community page used a custom in-memory cache (`githubCache`) with a 10-minute TTL that:
- Reset on every deployment, cold start, or server restart — causing GitHub API spikes
- Shared module-level state across concurrent requests on the same instance
- Bypassed Next.js caching and ISR infrastructure

## Solution

- Removed the custom `githubCache` in-memory variable and TTL logic
- Applied `next: { revalidate: 600 }` on all GitHub API `fetch` calls
- Added `export const revalidate = 600` at the page level as ISR fallback

## Test plan

- [x] `npm run build` completes successfully
- [x] Community page builds with `revalidate: 600` (10m) confirmed in build output
- [x] No visual changes — architecture-only improvement

Closes #1422