### PR TITLE
Fix: Add contextual error.tsx boundaries for all routes with external…

### DIFF
--- a/src/app/accessibility/error.tsx
+++ b/src/app/accessibility/error.tsx
@@ -1,0 +1,19 @@
+"use client"
+
+import { RouteError } from "@/components/ui/RouteError"
+
+export default function AccessibilityError({
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  return (
+    <RouteError
+      title="Unable to load accessibility statement"
+      message="Something went wrong while loading the accessibility page. Please try again."
+      reset={reset}
+      showChrome
+    />
+  )
+}

--- a/src/app/architecture/error.tsx
+++ b/src/app/architecture/error.tsx
@@ -1,0 +1,19 @@
+"use client"
+
+import { RouteError } from "@/components/ui/RouteError"
+
+export default function ArchitectureError({
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  return (
+    <RouteError
+      title="Unable to load architecture overview"
+      message="Something went wrong while loading the system architecture page. Please try again."
+      reset={reset}
+      showChrome
+    />
+  )
+}

--- a/src/app/blueprint/error.tsx
+++ b/src/app/blueprint/error.tsx
@@ -1,0 +1,19 @@
+"use client"
+
+import { RouteError } from "@/components/ui/RouteError"
+
+export default function BlueprintError({
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  return (
+    <RouteError
+      title="Unable to load blueprint"
+      message="Something went wrong while loading the platform blueprint. Please try again."
+      reset={reset}
+      showChrome
+    />
+  )
+}

--- a/src/app/changelog/error.tsx
+++ b/src/app/changelog/error.tsx
@@ -1,0 +1,19 @@
+"use client"
+
+import { RouteError } from "@/components/ui/RouteError"
+
+export default function ChangelogError({
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  return (
+    <RouteError
+      title="Unable to load release history"
+      message="We couldn't fetch release notes from the GitHub Releases API. The changelog may be temporarily unavailable due to API limits or network issues."
+      reset={reset}
+      showChrome
+    />
+  )
+}

--- a/src/app/community/error.tsx
+++ b/src/app/community/error.tsx
@@ -1,0 +1,19 @@
+"use client"
+
+import { RouteError } from "@/components/ui/RouteError"
+
+export default function CommunityError({
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  return (
+    <RouteError
+      title="Unable to load community data"
+      message="We couldn't fetch the latest repository stats, contributors, pull requests, or issues from GitHub. The data may be temporarily unavailable due to API limits or network issues."
+      reset={reset}
+      showChrome
+    />
+  )
+}

--- a/src/app/contact/error.tsx
+++ b/src/app/contact/error.tsx
@@ -1,0 +1,19 @@
+"use client"
+
+import { RouteError } from "@/components/ui/RouteError"
+
+export default function ContactError({
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  return (
+    <RouteError
+      title="Unable to load contact page"
+      message="Something went wrong while loading the contact form. Please try again, or reach out to us directly through our community channels."
+      reset={reset}
+      secondaryLink={{ href: "/community", label: "Visit Community" }}
+    />
+  )
+}

--- a/src/app/docs/error.tsx
+++ b/src/app/docs/error.tsx
@@ -1,0 +1,20 @@
+"use client"
+
+import { RouteError } from "@/components/ui/RouteError"
+
+export default function DocsError({
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  return (
+    <RouteError
+      title="Unable to load documentation"
+      message="We couldn't read this documentation page. The file may be missing, corrupted, or temporarily unavailable."
+      reset={reset}
+      secondaryLink={{ href: "/docs", label: "Back to Docs" }}
+      variant="inline"
+    />
+  )
+}

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { motion } from "framer-motion";
+import { motion, useReducedMotion } from "framer-motion";
 import { AlertTriangle } from "lucide-react";
 
 export default function Error({
@@ -11,17 +11,19 @@ export default function Error({
   error: Error & { digest?: string };
   reset: () => void;
 }) {
+  const shouldReduceMotion = useReducedMotion();
+
   return (
     <main className="min-h-screen flex items-center justify-center bg-[var(--color-bg-base)] px-4">
       <motion.div
         initial={{ opacity: 0, scale: 0.95 }}
         animate={{ opacity: 1, scale: 1 }}
-        transition={{ duration: 0.5, ease: "easeOut" }}
+        transition={{ duration: shouldReduceMotion ? 0 : 0.5, ease: "easeOut" }}
         className="w-full max-w-md"
       >
         {/* Floating card */}
         <motion.div
-          animate={{ y: [0, -12, 0] }}
+          animate={shouldReduceMotion ? {} : { y: [0, -12, 0] }}
           transition={{
             duration: 4,
             ease: "easeInOut" as const,

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { motion } from "framer-motion";
+import { motion, MotionConfig, useReducedMotion } from "framer-motion";
 import { AlertTriangle } from "lucide-react";
 
 export default function GlobalError({
@@ -11,81 +11,85 @@ export default function GlobalError({
   error: Error & { digest?: string };
   reset: () => void;
 }) {
+  const shouldReduceMotion = useReducedMotion();
+
   return (
     <html lang="en">
       <body className="min-h-screen flex items-center justify-center bg-[var(--color-bg-base)] px-4 antialiased">
-        <motion.div
-          initial={{ opacity: 0, scale: 0.95 }}
-          animate={{ opacity: 1, scale: 1 }}
-          transition={{ duration: 0.5, ease: "easeOut" }}
-          className="w-full max-w-md"
-        >
-          {/* Floating card */}
+        <MotionConfig reducedMotion="user">
           <motion.div
-            animate={{ y: [0, -12, 0] }}
-            transition={{
-              duration: 4,
-              ease: "easeInOut" as const,
-              repeat: Infinity,
-            }}
-            className="rounded-3xl p-10 flex flex-col items-center text-center"
-            style={{
-              background: "var(--color-bg-base)",
-              boxShadow:
-                "10px 10px 20px var(--shadow-dark), -10px -10px 20px var(--shadow-light)",
-            }}
+            initial={{ opacity: 0, scale: 0.95 }}
+            animate={{ opacity: 1, scale: 1 }}
+            transition={{ duration: shouldReduceMotion ? 0 : 0.5, ease: "easeOut" }}
+            className="w-full max-w-md"
           >
-            {/* Sunken error badge */}
-            <div
-              className="w-36 h-36 rounded-2xl flex items-center justify-center mb-6"
+            {/* Floating card */}
+            <motion.div
+              animate={shouldReduceMotion ? {} : { y: [0, -12, 0] }}
+              transition={{
+                duration: 4,
+                ease: "easeInOut" as const,
+                repeat: Infinity,
+              }}
+              className="rounded-3xl p-10 flex flex-col items-center text-center"
               style={{
-                background: "var(--color-bg-sunken)",
+                background: "var(--color-bg-base)",
                 boxShadow:
-                  "inset 10px 10px 20px var(--shadow-dark), inset -10px -10px 20px var(--shadow-light)",
+                  "10px 10px 20px var(--shadow-dark), -10px -10px 20px var(--shadow-light)",
               }}
             >
-              <AlertTriangle
-                size={48}
-                strokeWidth={1.5}
-                style={{ color: "var(--color-primary)" }}
-              />
-            </div>
-
-            {/* Headline */}
-            <h1
-              className="text-xl font-bold mb-3 leading-snug"
-              style={{ color: "var(--color-text-primary)" }}
-            >
-              Something went wrong
-            </h1>
-
-            {/* Error message */}
-            <p
-              className="text-sm leading-relaxed mb-8"
-              style={{ color: "var(--color-text-secondary)" }}
-            >
-              {process.env.NODE_ENV === "development"
-                ? error.message
-                : "An unexpected error occurred. Please try again."}
-            </p>
-
-            {/* Action buttons */}
-            <div className="flex gap-3">
-              <button
-                onClick={reset}
-                className="btn-neumorphic-primary px-8 py-3 rounded-xl text-sm font-semibold"
+              {/* Sunken error badge */}
+              <div
+                className="w-36 h-36 rounded-2xl flex items-center justify-center mb-6"
+                style={{
+                  background: "var(--color-bg-sunken)",
+                  boxShadow:
+                    "inset 10px 10px 20px var(--shadow-dark), inset -10px -10px 20px var(--shadow-light)",
+                }}
               >
-                Try again
-              </button>
-              <Link
-                href="/"
-                className="btn-neumorphic-primary px-8 py-3 rounded-xl text-sm font-semibold"
+                <AlertTriangle
+                  size={48}
+                  strokeWidth={1.5}
+                  style={{ color: "var(--color-primary)" }}
+                />
+              </div>
+
+              {/* Headline */}
+              <h1
+                className="text-xl font-bold mb-3 leading-snug"
+                style={{ color: "var(--color-text-primary)" }}
               >
-                Return to Home
-              </Link>
-            </div>
+                Something went wrong
+              </h1>
+
+              {/* Error message */}
+              <p
+                className="text-sm leading-relaxed mb-8"
+                style={{ color: "var(--color-text-secondary)" }}
+              >
+                {process.env.NODE_ENV === "development"
+                  ? error.message
+                  : "An unexpected error occurred. Please try again."}
+              </p>
+
+              {/* Action buttons */}
+              <div className="flex gap-3">
+                <button
+                  onClick={reset}
+                  className="btn-neumorphic-primary px-8 py-3 rounded-xl text-sm font-semibold"
+                >
+                  Try again
+                </button>
+                <Link
+                  href="/"
+                  className="btn-neumorphic-primary px-8 py-3 rounded-xl text-sm font-semibold"
+                >
+                  Return to Home
+                </Link>
+              </div>
+            </motion.div>
           </motion.div>
-        </motion.div>
+        </MotionConfig>
       </body>
     </html>
   );

--- a/src/app/pricing/error.tsx
+++ b/src/app/pricing/error.tsx
@@ -1,0 +1,19 @@
+"use client"
+
+import { RouteError } from "@/components/ui/RouteError"
+
+export default function PricingError({
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  return (
+    <RouteError
+      title="Unable to load pricing"
+      message="Something went wrong while loading pricing information. Please try again."
+      reset={reset}
+      showChrome
+    />
+  )
+}

--- a/src/app/use-cases/error.tsx
+++ b/src/app/use-cases/error.tsx
@@ -1,0 +1,19 @@
+"use client"
+
+import { RouteError } from "@/components/ui/RouteError"
+
+export default function UseCasesError({
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  return (
+    <RouteError
+      title="Unable to load use cases"
+      message="Something went wrong while loading the industry use cases. Please try again."
+      reset={reset}
+      showChrome
+    />
+  )
+}

--- a/src/components/ui/RouteError.tsx
+++ b/src/components/ui/RouteError.tsx
@@ -1,0 +1,153 @@
+"use client"
+
+import Link from "next/link"
+import { motion, useReducedMotion } from "framer-motion"
+import { AlertTriangle } from "lucide-react"
+import { Footer } from "@/components/layout/Footer"
+import { Navbar } from "@/components/layout/Navbar"
+
+export interface RouteErrorProps {
+  title: string
+  message: string
+  reset: () => void
+  secondaryLink?: { href: string; label: string }
+  showChrome?: boolean
+  variant?: "page" | "inline"
+}
+
+const RouteErrorCard = ({
+  title,
+  message,
+  reset,
+  secondaryLink,
+}: Pick<RouteErrorProps, "title" | "message" | "reset" | "secondaryLink">) => {
+  const shouldReduceMotion = useReducedMotion()
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, scale: 0.95 }}
+      animate={{ opacity: 1, scale: 1 }}
+      transition={{ duration: shouldReduceMotion ? 0 : 0.5, ease: "easeOut" }}
+      className="w-full max-w-md"
+    >
+      <motion.div
+        animate={shouldReduceMotion ? {} : { y: [0, -12, 0] }}
+        transition={{
+          duration: 4,
+          ease: "easeInOut" as const,
+          repeat: Infinity,
+        }}
+        className="rounded-3xl p-10 flex flex-col items-center text-center"
+        style={{
+          background: "var(--color-bg-base)",
+          boxShadow:
+            "10px 10px 20px var(--shadow-dark), -10px -10px 20px var(--shadow-light)",
+        }}
+      >
+        <div
+          className="w-36 h-36 rounded-2xl flex items-center justify-center mb-6"
+          style={{
+            background: "var(--color-bg-sunken)",
+            boxShadow:
+              "inset 10px 10px 20px var(--shadow-dark), inset -10px -10px 20px var(--shadow-light)",
+          }}
+        >
+          <AlertTriangle
+            size={48}
+            strokeWidth={1.5}
+            style={{ color: "var(--color-primary)" }}
+            aria-hidden="true"
+          />
+        </div>
+
+        <h1
+          className="text-xl font-bold mb-3 leading-snug"
+          style={{ color: "var(--color-text-primary)" }}
+        >
+          {title}
+        </h1>
+
+        <p
+          className="text-sm leading-relaxed mb-8"
+          style={{ color: "var(--color-text-secondary)" }}
+        >
+          {message}
+        </p>
+
+        <div className="flex flex-wrap justify-center gap-3">
+          <button
+            type="button"
+            onClick={reset}
+            className="btn-neumorphic-primary px-8 py-3 rounded-xl text-sm font-semibold"
+          >
+            Try again
+          </button>
+          {secondaryLink && (
+            <Link
+              href={secondaryLink.href}
+              className="btn-neumorphic-primary px-8 py-3 rounded-xl text-sm font-semibold"
+            >
+              {secondaryLink.label}
+            </Link>
+          )}
+        </div>
+      </motion.div>
+    </motion.div>
+  )
+}
+
+export const RouteError = ({
+  title,
+  message,
+  reset,
+  secondaryLink,
+  showChrome = false,
+  variant = "page",
+}: RouteErrorProps) => {
+  const card = (
+    <RouteErrorCard
+      title={title}
+      message={message}
+      reset={reset}
+      secondaryLink={secondaryLink}
+    />
+  )
+
+  if (variant === "inline") {
+    return (
+      <div
+        className="flex items-center justify-center py-16 px-4"
+        role="alert"
+        aria-live="assertive"
+      >
+        {card}
+      </div>
+    )
+  }
+
+  if (showChrome) {
+    return (
+      <div className="min-h-screen flex flex-col bg-bg-base text-content-primary">
+        <Navbar />
+        <main
+          className="flex-grow flex items-center justify-center px-4 py-20"
+          role="alert"
+          aria-live="assertive"
+        >
+          {card}
+        </main>
+        <Footer />
+      </div>
+    )
+  }
+
+  return (
+    <main
+      className="min-h-screen flex items-center justify-center bg-[var(--color-bg-base)] px-4"
+      role="alert"
+      aria-live="assertive"
+    >
+      {card}
+    </main>
+  )
+}


### PR DESCRIPTION
# 📝 Pull Request 

## 🔧 Title: 

Fix: Add contextual error.tsx boundaries for all routes with external data fetching

## 🛠️ Issue

- Closes #1453 

## 📚 Description

The application previously relied on a single root-level error boundary (`src/app/error.tsx`) and `src/app/global-error.tsx`. When a route-specific failure occurred—such as a GitHub API outage on `/community` or `/changelog`, or an MDX read failure under `/docs/[...slug]`—Next.js bubbled the error up to the root boundary, replacing the entire application UI (including navigation chrome) with a generic error screen.

This PR introduces route-level error boundaries for all affected segments so failures are handled locally with contextual messaging, a `reset()` action, and preserved navigation where applicable. It also updates the root error boundaries to respect `prefers-reduced-motion` for looping animations.

## ✅ Changes applied

- Added a reusable `RouteError` client component at `src/components/ui/RouteError.tsx` with neumorphic styling consistent with the existing error UI, `useReducedMotion` support, contextual title/message props, a **Try again** button wired to `reset()`, and optional secondary navigation links.
- Created route-level `error.tsx` boundaries for:
  - `src/app/community/error.tsx` — GitHub API failure messaging (repo stats, contributors, PRs, issues)
  - `src/app/changelog/error.tsx` — GitHub Releases API failure messaging
  - `src/app/docs/error.tsx` — MDX read failure messaging with a **Back to Docs** link (`variant="inline"` so the docs layout shell remains visible)
  - `src/app/contact/error.tsx` — contact page load failure with a link to `/community`
  - `src/app/use-cases/error.tsx`
  - `src/app/architecture/error.tsx`
  - `src/app/blueprint/error.tsx`
  - `src/app/pricing/error.tsx`
  - `src/app/accessibility/error.tsx`
- Updated `src/app/error.tsx` to use `useReducedMotion` for the infinite floating-card animation (aligned with `not-found.tsx` and issue #1448).
- Updated `src/app/global-error.tsx` to wrap motion elements in `<MotionConfig reducedMotion="user">` and apply `useReducedMotion` for explicit animation control.
- Verified production build passes (`npm run build`).

## 🔍 Evidence/Media (screenshots/videos)

- N/A — error boundaries are defensive UI paths triggered only on runtime failures (GitHub API errors, missing/corrupt MDX files). Manual verification can be done by temporarily forcing a fetch/read failure on `/community`, `/changelog`, or a docs slug route and confirming the contextual error card renders with **Try again** while navigation remains usable.

Please, let me know If you need some change!