### PR TITLE
feat(seo): implement per-page Open Graph metadata and images

### DIFF
--- a/public/og/README.md
+++ b/public/og/README.md
@@ -1,0 +1,32 @@
+# Per-page Open Graph images
+
+Each non-home route declares its own OG image via `buildPageMetadata()` in
+`src/lib/seo.ts`, which defaults the path to `/og{route}.png`.
+
+**These image files do not exist yet.** Per issue #1452 the paths are declared
+first so crawlers receive distinct metadata per URL; the assets land in a
+follow-up. Until they do, a shared link resolves to a 404 image rather than the
+generic `/og-image.png` — so the follow-up should land before the next deploy
+that matters for social sharing.
+
+Expected files (1200×630 PNG each):
+
+| Route           | File                     |
+| --------------- | ------------------------ |
+| `/architecture` | `og/architecture.png`    |
+| `/blueprint`    | `og/blueprint.png`       |
+| `/changelog`    | `og/changelog.png`       |
+| `/community`    | `og/community.png`       |
+| `/contact`      | `og/contact.png`         |
+| `/pricing`      | `og/pricing.png`         |
+| `/privacy`      | `og/privacy.png`         |
+| `/terms`        | `og/terms.png`           |
+| `/use-cases`    | `og/use-cases.png`       |
+| `/accessibility`| `og/accessibility.png`   |
+
+`/` keeps the existing root-level `/og-image.png`.
+
+The alternative to static files is a per-route `opengraph-image.tsx` using the
+Next.js `ImageResponse` API, which generates these at build time from the title
+and description instead of hand-designed assets:
+https://nextjs.org/docs/app/api-reference/file-conventions/metadata/opengraph-image

--- a/src/app/accessibility/layout.tsx
+++ b/src/app/accessibility/layout.tsx
@@ -1,0 +1,29 @@
+import type { Metadata } from "next";
+import { buildPageMetadata } from "@/lib/seo";
+
+// Metadata lives in the layout because accessibility/page.tsx is a client
+// component, which cannot export a metadata object.
+export const metadata: Metadata = buildPageMetadata({
+  title: "Accessibility",
+  description:
+    "OFFER-HUB's accessibility commitment: WCAG 2.1 Level AA target, screen reader and keyboard support, known limitations, and how to report accessibility barriers.",
+  keywords: [
+    "accessibility",
+    "WCAG 2.1",
+    "a11y",
+    "screen reader",
+    "keyboard navigation",
+    "inclusive design",
+    "OFFER-HUB",
+  ],
+  path: "/accessibility",
+  ogImageAlt: "OFFER-HUB Accessibility — our WCAG 2.1 Level AA commitment",
+});
+
+export default function AccessibilityLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/src/app/architecture/page.tsx
+++ b/src/app/architecture/page.tsx
@@ -11,8 +11,9 @@ import IntegrationsMap from "@/components/architecture/IntegrationsMap";
 import SCFTrancheRoadmap from "@/components/architecture/SCFTrancheRoadmap";
 import WhyStellarSection from "@/components/architecture/WhyStellarSection";
 import TractionSection from "@/components/architecture/TractionSection";
+import { buildPageMetadata } from "@/lib/seo";
 
-export const metadata: Metadata = {
+export const metadata: Metadata = buildPageMetadata({
   title: "Technical Architecture",
   description:
     "Complete technical architecture of OFFER-HUB: non-custodial escrow on Stellar, Stellar Wallets Kit integration, BlindPay off-ramp corridors across 7 LATAM markets. SCF Build Award #44.",
@@ -28,7 +29,10 @@ export const metadata: Metadata = {
     "USDC",
     "LATAM",
   ],
-};
+  path: "/architecture",
+  ogImageAlt:
+    "OFFER-HUB Technical Architecture — non-custodial escrow on Stellar",
+});
 
 export default function ArchitecturePage() {
   return (

--- a/src/app/blueprint/page.tsx
+++ b/src/app/blueprint/page.tsx
@@ -8,8 +8,9 @@ import BlueprintSectionNav from "@/components/blueprint/BlueprintSectionNav";
 import OrchestratorShowcase from "@/components/blueprint/OrchestratorShowcase";
 import MarketplaceTemplate from "@/components/blueprint/MarketplaceTemplate";
 import EvolutionTimeline from "@/components/blueprint/EvolutionTimeline";
+import { buildPageMetadata } from "@/lib/seo";
 
-export const metadata: Metadata = {
+export const metadata: Metadata = buildPageMetadata({
   title: "Blueprint",
   description:
     "Explore the OFFER-HUB technical blueprint: orchestrator architecture, marketplace templates, and the evolution roadmap for trustless payment infrastructure.",
@@ -22,7 +23,10 @@ export const metadata: Metadata = {
     "OFFER-HUB",
     "payment infrastructure",
   ],
-};
+  path: "/blueprint",
+  ogImageAlt:
+    "OFFER-HUB Blueprint — orchestrator architecture and marketplace templates",
+});
 
 export default function BlueprintPage() {
   return (

--- a/src/app/changelog/page.tsx
+++ b/src/app/changelog/page.tsx
@@ -1,8 +1,9 @@
 import type { Metadata } from "next";
 import { Navbar } from "@/components/layout/Navbar";
 import { Footer } from "@/components/layout/Footer";
+import { buildPageMetadata } from "@/lib/seo";
 
-export const metadata: Metadata = {
+export const metadata: Metadata = buildPageMetadata({
   title: "Changelog",
   description:
     "Track every release and update to the OFFER-HUB platform — new features, improvements, and fixes across the ecosystem.",
@@ -13,7 +14,9 @@ export const metadata: Metadata = {
     "OFFER-HUB",
     "version history",
   ],
-};
+  path: "/changelog",
+  ogImageAlt: "OFFER-HUB Changelog — releases, improvements, and fixes",
+});
 
 interface GitHubRelease {
   tag_name: string;

--- a/src/app/community/page.tsx
+++ b/src/app/community/page.tsx
@@ -10,10 +10,11 @@ import RegistrationForm from "@/components/community/RegistrationForm";
 import LoadingBar from "@/components/ui/LoadingBar";
 import { Footer } from "@/components/layout/Footer";
 import { Navbar } from "@/components/layout/Navbar";
+import { buildPageMetadata } from "@/lib/seo";
 
 export const revalidate = 600;
 
-export const metadata: Metadata = {
+export const metadata: Metadata = buildPageMetadata({
   title: "Community",
   description:
     "Join the OFFER-HUB open-source community. Explore contributors, open issues, recent pull requests, and learn how to get involved.",
@@ -25,7 +26,9 @@ export const metadata: Metadata = {
     "OFFER-HUB",
     "contribute",
   ],
-};
+  path: "/community",
+  ogImageAlt: "OFFER-HUB Community — contributors, issues, and pull requests",
+});
 
 interface RepoStats {
   stars: string;

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,11 +1,24 @@
 import type { Metadata } from "next";
 import ContactForm from "./ContactForm.client";
+import { buildPageMetadata } from "@/lib/seo";
 
-export const metadata: Metadata = {
-  title: "Contact Sales | OFFER-HUB",
+// Title was "Contact Sales | OFFER-HUB", which the root layout's "%s | OFFER-HUB"
+// template rendered as "Contact Sales | OFFER-HUB | OFFER-HUB".
+export const metadata: Metadata = buildPageMetadata({
+  title: "Contact Sales",
   description:
     "Contact OFFER-HUB sales for enterprise inquiries — tell us about your company, needs, and we'll reach out to discuss enterprise integrations and support.",
-};
+  keywords: [
+    "contact",
+    "sales",
+    "enterprise",
+    "support",
+    "integrations",
+    "OFFER-HUB",
+  ],
+  path: "/contact",
+  ogImageAlt: "Contact OFFER-HUB Sales — enterprise integrations and support",
+});
 
 export default function ContactPage() {
   return (

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -6,12 +6,23 @@ import type { ComponentType } from "react";
 import { Footer } from "@/components/layout/Footer";
 import { Navbar } from "@/components/layout/Navbar";
 import LoadingBar from "@/components/ui/LoadingBar";
+import { buildPageMetadata } from "@/lib/seo";
 
-export const metadata: Metadata = {
+export const metadata: Metadata = buildPageMetadata({
   title: "Pricing",
   description:
     "OFFER-HUB pricing: open source core for free, free self-hosting, and enterprise support available on request.",
-};
+  keywords: [
+    "pricing",
+    "open source",
+    "self-hosting",
+    "enterprise",
+    "escrow pricing",
+    "OFFER-HUB",
+  ],
+  path: "/pricing",
+  ogImageAlt: "OFFER-HUB Pricing — open source core, free self-hosting, enterprise support",
+});
 
 type PricingTier = {
   name: string;

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,10 +1,28 @@
 import fs from "fs";
 import path from "path";
+import type { Metadata } from "next";
 import { Navbar } from "@/components/layout/Navbar";
 import { Footer } from "@/components/layout/Footer";
 import LoadingBar from "@/components/ui/LoadingBar";
 import { MDXRemote } from "next-mdx-remote/rsc";
 import { MDX_PRIVACY_COMPONENTS } from "@/components/mdx/PrivacyComponents";
+import { buildPageMetadata } from "@/lib/seo";
+
+export const metadata: Metadata = buildPageMetadata({
+  title: "Privacy Policy",
+  description:
+    "How OFFER-HUB collects, uses, and protects your data. Privacy is a feature, not an afterthought — read our full data governance and transparency policy.",
+  keywords: [
+    "privacy policy",
+    "data governance",
+    "GDPR",
+    "data protection",
+    "transparency",
+    "OFFER-HUB",
+  ],
+  path: "/privacy",
+  ogImageAlt: "OFFER-HUB Privacy Policy — data governance and transparency",
+});
 
 export default async function PrivacyPage() {
   const content = fs.readFileSync(path.join(process.cwd(), "src/content/privacy.mdx"), "utf-8");

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,5 +1,6 @@
 import fs from "fs";
 import path from "path";
+import type { Metadata } from "next";
 import { MDXRemote } from "next-mdx-remote/rsc";
 import remarkGfm from "remark-gfm";
 import { Navbar } from "@/components/layout/Navbar";
@@ -7,6 +8,23 @@ import { Footer } from "@/components/layout/Footer";
 import LoadingBar from "@/components/ui/LoadingBar";
 import { TERMS_MDX_COMPONENTS } from "@/components/terms/terms-mdx-components";
 import { TermsPageHeader } from "@/components/terms/TermsPageHeader";
+import { buildPageMetadata } from "@/lib/seo";
+
+export const metadata: Metadata = buildPageMetadata({
+  title: "Terms of Service",
+  description:
+    "The terms governing use of the OFFER-HUB platform — acceptable use, escrow responsibilities, liability, and the legal framework behind our payment orchestration.",
+  keywords: [
+    "terms of service",
+    "terms and conditions",
+    "legal",
+    "acceptable use",
+    "escrow terms",
+    "OFFER-HUB",
+  ],
+  path: "/terms",
+  ogImageAlt: "OFFER-HUB Terms of Service",
+});
 
 export default async function TermsOfServicePage() {
   const source = fs.readFileSync(

--- a/src/app/use-cases/layout.tsx
+++ b/src/app/use-cases/layout.tsx
@@ -1,8 +1,12 @@
 import type { Metadata } from "next";
+import { buildPageMetadata } from "@/lib/seo";
 
-export const metadata: Metadata = {
+// Metadata lives in the layout because UseCasesClient owns the whole page and
+// runs on the client, which cannot export a metadata object.
+export const metadata: Metadata = buildPageMetadata({
     title: "Industry Use Cases",
-    description: "Explore how OFFER HUB's non-custodial escrow orchestrates payment workflows across Freelance, eCommerce, DAOs, and Real Estate.",
+    description:
+        "Explore how OFFER-HUB's non-custodial escrow orchestrates payment workflows across Freelance, eCommerce, DAO payroll, Real Estate, and service platforms.",
     keywords: [
         "use cases",
         "freelance",
@@ -13,7 +17,10 @@ export const metadata: Metadata = {
         "OFFER-HUB",
         "marketplace",
     ],
-};
+    path: "/use-cases",
+    ogImageAlt:
+        "OFFER-HUB use cases across freelance, eCommerce, DAO payroll, and real estate",
+});
 
 export default function UseCasesLayout({
     children,

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,0 +1,58 @@
+import type { Metadata } from "next";
+
+export const SITE_URL = "https://offer-hub.tech";
+export const SITE_NAME = "OFFER-HUB";
+
+type PageSeoInput = {
+  /** Feeds `metadata.title`, so the root layout's "%s | OFFER-HUB" template applies */
+  title: string;
+  description: string;
+  keywords: string[];
+  /** Route path, e.g. "/privacy". Drives canonical, og:url, and the default OG image */
+  path: string;
+  /** Social title. The title template does NOT apply to openGraph/twitter titles */
+  socialTitle?: string;
+  /** Defaults to `/og{path}.png` — see public/og/README.md */
+  ogImage?: string;
+  ogImageAlt: string;
+};
+
+/**
+ * Builds the per-page metadata block: canonical, Open Graph, and Twitter card.
+ * Without this, pages fall back to the root layout's generic /og-image.png and
+ * its canonical of "/", which points every sub-route at the homepage.
+ */
+export function buildPageMetadata({
+  title,
+  description,
+  keywords,
+  path,
+  socialTitle,
+  ogImage = `/og${path}.png`,
+  ogImageAlt,
+}: PageSeoInput): Metadata {
+  const url = `${SITE_URL}${path}`;
+  const social = socialTitle ?? `${title} | ${SITE_NAME}`;
+
+  return {
+    title,
+    description,
+    keywords,
+    alternates: { canonical: url },
+    openGraph: {
+      title: social,
+      description,
+      url,
+      siteName: SITE_NAME,
+      images: [{ url: ogImage, width: 1200, height: 630, alt: ogImageAlt }],
+      locale: "en_US",
+      type: "website",
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: social,
+      description,
+      images: [ogImage],
+    },
+  };
+}


### PR DESCRIPTION
# 📝 Pull Request

## 🔧 Title:

- fix(seo): add per-page metadata, canonical URLs, and openGraph images to all route pages

## 🛠️ Issue

- Closes #1452

## 📚 Description

Four pages exported no metadata at all, and no page overrode `openGraph.images` or `alternates.canonical`. Every non-home route therefore inherited the root layout's generic `/og-image.png` and a canonical of `/`, so a link shared to `/community` or `/architecture` showed the homepage's social card and pointed search engines back at the homepage.

This PR gives all 10 non-home routes their own `title`, `description`, `keywords`, `alternates.canonical`, `openGraph`, and `twitter` blocks. `/` keeps the root-level metadata unchanged.

Rather than repeat ~40 lines of near-identical metadata across 10 files, the shared shape lives in `buildPageMetadata()` in `src/lib/seo.ts`. Each page passes what is actually unique — title, description, keywords, route path, and OG image alt text — and the helper derives the canonical URL, `og:url`, and the default OG image path (`/og{route}.png`) from the route. The emitted tags are exactly what the acceptance criteria describe; the helper only removes the copy-paste.

Two findings worth calling out, since they change what the issue described:

**`/use-cases` already had metadata**, in `src/app/use-cases/layout.tsx` rather than in the page — the issue lists it as having none. Its existing title/description/keywords were kept and extended in place. Moving them into the page would have been a behavioral no-op with an extra override to reason about.

**`/accessibility` is a client component** (`"use client"`), so it cannot export a `metadata` object — Next.js only reads metadata from server components. Its metadata goes in a new `src/app/accessibility/layout.tsx`, mirroring the pattern `use-cases` already uses in this codebase. The page itself is untouched.

Also fixed in passing: `/contact` had `title: "Contact Sales | OFFER-HUB"`, which the root layout's `"%s | OFFER-HUB"` template rendered as **"Contact Sales | OFFER-HUB | OFFER-HUB"**. The title is now just `"Contact Sales"`.

## ✅ Changes applied

**Added**

- `src/lib/seo.ts` — `buildPageMetadata()` plus `SITE_URL` / `SITE_NAME` constants. Builds canonical, Open Graph, and Twitter card blocks from a per-page input.
- `src/app/accessibility/layout.tsx` — metadata holder for the client-component page.
- `public/og/README.md` — documents the 10 expected OG image paths and the follow-up needed to create them.

**Metadata added (previously had none) — 4 pages**

- `src/app/privacy/page.tsx`
- `src/app/terms/page.tsx`
- `src/app/use-cases/layout.tsx` — existing metadata extended (see above)
- `src/app/accessibility/layout.tsx` — new file (see above)

**Metadata extended with openGraph / twitter / canonical — 6 pages**

- `src/app/changelog/page.tsx`
- `src/app/architecture/page.tsx`
- `src/app/community/page.tsx`
- `src/app/blueprint/page.tsx`
- `src/app/pricing/page.tsx` — also gained `keywords`, which it lacked
- `src/app/contact/page.tsx` — also gained `keywords`; title template bug fixed

**Not changed**

- `src/app/layout.tsx` — root metadata untouched; `metadataBase` was already set, which is what resolves the new relative image paths to absolute URLs.
- `src/app/page.tsx` — the homepage correctly keeps `/og-image.png` and a canonical of `/`.
- `/docs` and `/docs/[...slug]` still inherit the root OG image. They were not in the issue's scope, and `/docs/[...slug]` needs `generateMetadata` per document rather than a static export — worth a separate issue.

## 🔍 Evidence/Media (screenshots/videos)

- `npx tsc --noEmit` — clean, no errors.
- `npm run lint` — `✔ No ESLint warnings or errors`.
- `npm run build` — succeeds; all 10 routes prerender.

Verified against the prerendered HTML in `.next/server/app/*.html` rather than by reading the source. Every one of the 10 routes emits its own image, canonical, and card:

| Route | `og:image` | `<link rel="canonical">` | `twitter:card` | `<title>` |
| --- | --- | --- | --- | --- |
| `/privacy` | `…/og/privacy.png` | `…/privacy` | `summary_large_image` | Privacy Policy \| OFFER-HUB |
| `/terms` | `…/og/terms.png` | `…/terms` | `summary_large_image` | Terms of Service \| OFFER-HUB |
| `/use-cases` | `…/og/use-cases.png` | `…/use-cases` | `summary_large_image` | Industry Use Cases \| OFFER-HUB |
| `/accessibility` | `…/og/accessibility.png` | `…/accessibility` | `summary_large_image` | Accessibility \| OFFER-HUB |
| `/changelog` | `…/og/changelog.png` | `…/changelog` | `summary_large_image` | Changelog \| OFFER-HUB |
| `/architecture` | `…/og/architecture.png` | `…/architecture` | `summary_large_image` | Technical Architecture \| OFFER-HUB |
| `/community` | `…/og/community.png` | `…/community` | `summary_large_image` | Community \| OFFER-HUB |
| `/blueprint` | `…/og/blueprint.png` | `…/blueprint` | `summary_large_image` | Blueprint \| OFFER-HUB |
| `/pricing` | `…/og/pricing.png` | `…/pricing` | `summary_large_image` | Pricing \| OFFER-HUB |
| `/contact` | `…/og/contact.png` | `…/contact` | `summary_large_image` | Contact Sales \| OFFER-HUB |

Grepping the prerendered output for the generic `og-image.png` now matches only `/`, `/docs`, and `/_not-found` — the homepage intentionally, and `/docs` as noted above. No page in scope falls back to the root image.

> ⚠️ **The OG image files do not exist yet.** Per the issue's notes, this PR declares the paths and leaves the assets to a follow-up. The tradeoff is real and worth a conscious decision before deploy: until those files land, a shared link resolves to a **404 image** instead of the generic-but-working `/og-image.png`. The 10 required files are listed in `public/og/README.md`. Copying `og-image.png` into place was rejected as a stopgap — it is 470 KB, so 10 copies would add ~4.7 MB to the repo for images meant to be replaced. A per-route `opengraph-image.tsx` using the `ImageResponse` API is the cleaner follow-up: it generates real cards at build time with no binary assets.
