### PR TITLE
feat: add and wire skeleton into routes

### DIFF
--- a/src/app/architecture/loading.tsx
+++ b/src/app/architecture/loading.tsx
@@ -1,60 +1,36 @@
 import { Navbar } from "@/components/layout/Navbar";
 import { Footer } from "@/components/layout/Footer";
-
-function HeroSkeleton() {
-  return (
-    <section className="relative pt-44 md:pt-48 pb-20 bg-transparent">
-      <div className="max-w-7xl mx-auto px-6 lg:px-8 text-center flex flex-col items-center">
-        <div className="h-[clamp(3rem,10vw,7.75rem)] w-2/3 rounded-2xl bg-[#e5e7eb] dark:bg-[#1e2a4a] animate-pulse mb-6" />
-        <div className="h-8 w-48 rounded-full bg-[#e5e7eb] dark:bg-[#1e2a4a] animate-pulse mb-8" />
-        <div className="h-16 w-3/4 rounded-xl bg-[#e5e7eb] dark:bg-[#1e2a4a] animate-pulse mb-3" />
-        <div className="h-16 w-2/3 rounded-xl bg-[#e5e7eb] dark:bg-[#1e2a4a] animate-pulse mb-8" />
-        <div className="h-5 w-2/3 bg-[#e5e7eb] dark:bg-[#1e2a4a] rounded animate-pulse mb-2" />
-        <div className="h-5 w-1/2 bg-[#e5e7eb] dark:bg-[#1e2a4a] rounded animate-pulse mb-12" />
-        <div className="w-full max-w-3xl rounded-[2rem] bg-[#e5e7eb] dark:bg-[#1e2a4a] animate-pulse h-48" />
-      </div>
-    </section>
-  );
-}
-
-function NavSkeleton() {
-  return (
-    <div className="sticky top-[80px] z-40 py-6 pointer-events-none">
-      <div className="max-w-3xl mx-auto px-6 flex justify-center">
-        <div className="pointer-events-auto flex items-center gap-1.5 p-2 rounded-2xl bg-[#e5e7eb] dark:bg-[#1e2a4a] animate-pulse">
-          {["Overview", "System", "Payment Flow", "Integrations", "Roadmap"].map((label) => (
-            <div key={label} className="h-10 w-24 sm:w-28 rounded-xl bg-[#d1d5db] dark:bg-[#3d3d5c]" />
-          ))}
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function SectionSkeleton({ tall = false }: { tall?: boolean }) {
-  return (
-    <section className="px-6 py-24 bg-transparent">
-      <div className="mx-auto max-w-7xl">
-        <div
-          className={`rounded-[2.5rem] bg-[#e5e7eb] dark:bg-[#1e2a4a] animate-pulse p-10 ${tall ? "h-[600px]" : "h-96"}`}
-        />
-      </div>
-    </section>
-  );
-}
+import LoadingBar from "@/components/ui/LoadingBar";
+import { Skeleton } from "@/components/ui/Skeleton";
 
 export default function ArchitectureLoading() {
   return (
     <div className="min-h-screen flex flex-col bg-transparent">
+      <LoadingBar />
       <Navbar />
+
       <main className="flex-grow">
-        <HeroSkeleton />
-        <NavSkeleton />
-        <SectionSkeleton tall />
-        <SectionSkeleton tall />
-        <SectionSkeleton />
-        <SectionSkeleton />
+        <section className="relative pt-44 md:pt-48 pb-20 bg-transparent">
+          <div className="max-w-7xl mx-auto px-6 lg:px-8 text-center flex flex-col items-center">
+            <Skeleton className="h-[clamp(3rem,10vw,7.75rem)] w-2/3 rounded-2xl mb-6" />
+            <Skeleton className="h-8 w-48 rounded-full mb-8" />
+            <Skeleton className="h-16 w-3/4 rounded-xl mb-3" />
+            <Skeleton className="h-16 w-2/3 rounded-xl mb-8" />
+            <Skeleton className="h-5 w-2/3 mb-2" />
+            <Skeleton className="h-5 w-1/2 mb-12" />
+            <Skeleton className="w-full max-w-3xl rounded-[2rem] h-64" />
+          </div>
+        </section>
+
+        <section className="px-6 py-24 bg-transparent">
+          <div className="mx-auto max-w-7xl grid md:grid-cols-2 gap-8">
+            {[1, 2, 3, 4].map((i) => (
+              <Skeleton key={i} className="rounded-[2.5rem] h-96" />
+            ))}
+          </div>
+        </section>
       </main>
+
       <Footer />
     </div>
   );

--- a/src/app/blueprint/loading.tsx
+++ b/src/app/blueprint/loading.tsx
@@ -1,280 +1,36 @@
 import { Navbar } from "@/components/layout/Navbar";
 import { Footer } from "@/components/layout/Footer";
-
-/* ── Vision / Hero ─────────────────────────────────────────────────────────── */
-function VisionSkeleton() {
-  return (
-    <section className="relative pt-44 md:pt-48 pb-20 bg-transparent">
-      <div className="max-w-7xl mx-auto px-6 lg:px-8 text-center flex flex-col items-center">
-        {/* Brand name — large gradient text */}
-        <div className="h-[clamp(3rem,10vw,7.75rem)] w-2/3 rounded-2xl bg-[#e5e7eb] dark:bg-[#1e2a4a] shadow-raised animate-pulse mb-6" />
-        {/* Eyebrow badge */}
-        <div className="h-8 w-40 rounded-full bg-[#e5e7eb] dark:bg-[#1e2a4a] shadow-raised animate-pulse mb-8" />
-        {/* h1 */}
-        <div className="h-16 w-3/4 rounded-xl bg-[#e5e7eb] dark:bg-[#1e2a4a] shadow-raised animate-pulse mb-3" />
-        <div className="h-16 w-2/3 rounded-xl bg-[#e5e7eb] dark:bg-[#1e2a4a] shadow-raised animate-pulse mb-8" />
-        {/* Description */}
-        <div className="h-5 w-2/3 bg-[#e5e7eb] dark:bg-[#1e2a4a] rounded shadow-raised animate-pulse mb-2" />
-        <div className="h-5 w-1/2 bg-[#e5e7eb] dark:bg-[#1e2a4a] rounded shadow-raised animate-pulse mb-12" />
-        {/* Preview card — 3-column diagram */}
-        <div className="w-full max-w-3xl rounded-[2rem] bg-[#e5e7eb] dark:bg-[#1e2a4a] shadow-raised animate-pulse p-8 md:p-10">
-          <div className="grid grid-cols-3 gap-4 md:gap-6">
-            {[1, 2, 3].map((i) => (
-              <div key={i} className="flex flex-col items-center gap-3">
-                <div className="w-full aspect-[4/3] rounded-2xl bg-[#d1d5db] dark:bg-[#3d3d5c]" />
-                <div className="h-2 w-14 bg-[#d1d5db] dark:bg-[#3d3d5c] rounded" />
-              </div>
-            ))}
-          </div>
-          <div className="mt-8 h-3 w-40 bg-[#d1d5db] dark:bg-[#3d3d5c] rounded mx-auto" />
-        </div>
-      </div>
-    </section>
-  );
-}
-
-/* ── Section Navigation pill ────────────────────────────────────────────────── */
-function SectionNavSkeleton() {
-  return (
-    <div className="sticky top-[80px] z-40 py-6 pointer-events-none">
-      <div className="max-w-3xl mx-auto px-6 flex justify-center">
-        <div className="pointer-events-auto flex items-center gap-1 sm:gap-1.5 p-2 rounded-2xl bg-[#e5e7eb] dark:bg-[#1e2a4a] shadow-raised animate-pulse">
-          {["Vision", "Orchestrator", "Templates", "Evolution"].map((label) => (
-            <div key={label} className="h-10 w-24 sm:w-28 rounded-xl bg-[#d1d5db] dark:bg-[#3d3d5c]" />
-          ))}
-        </div>
-      </div>
-    </div>
-  );
-}
-
-/* ── Orchestrator Showcase ──────────────────────────────────────────────────── */
-function OrchestratorSkeleton() {
-  return (
-    <section className="px-6 py-24 bg-transparent">
-      <div className="mx-auto max-w-7xl">
-        {/* Outer raised card */}
-        <div className="rounded-[2.5rem] bg-[#e5e7eb] dark:bg-[#1e2a4a] shadow-raised animate-pulse p-10">
-          {/* 2-col: text left, flow diagram right */}
-          <div className="grid gap-12 lg:grid-cols-2 lg:items-center">
-            <div>
-              {/* Eyebrow */}
-              <div className="h-8 w-44 rounded-full bg-[#d1d5db] dark:bg-[#3d3d5c] mb-6" />
-              {/* h2 */}
-              <div className="h-10 w-full bg-[#d1d5db] dark:bg-[#3d3d5c] rounded mb-2" />
-              <div className="h-10 w-5/6 bg-[#d1d5db] dark:bg-[#3d3d5c] rounded mb-5" />
-              {/* p */}
-              <div className="space-y-2 mb-8">
-                <div className="h-4 w-full bg-[#d1d5db] dark:bg-[#3d3d5c] rounded" />
-                <div className="h-4 w-5/6 bg-[#d1d5db] dark:bg-[#3d3d5c] rounded" />
-                <div className="h-4 w-4/6 bg-[#d1d5db] dark:bg-[#3d3d5c] rounded" />
-              </div>
-              {/* 3 stat mini-cards */}
-              <div className="grid gap-4 sm:grid-cols-3">
-                {[1, 2, 3].map((i) => (
-                  <div key={i} className="rounded-[1.5rem] bg-[#d1d5db] dark:bg-[#3d3d5c] p-4 h-16" />
-                ))}
-              </div>
-            </div>
-            {/* Flow diagram placeholder */}
-            <div className="rounded-[2rem] bg-[#d1d5db] dark:bg-[#3d3d5c] h-64 w-full" />
-          </div>
-
-          {/* Flow legend row */}
-          <div className="mt-10 flex gap-4">
-            {[1, 2, 3].map((i) => (
-              <div key={i} className="h-6 w-28 rounded-full bg-[#d1d5db] dark:bg-[#3d3d5c]" />
-            ))}
-          </div>
-
-          {/* 3 detail cards — dark outer, light inner (inverted neumorphic layer) */}
-          <div className="mt-12 grid gap-6 xl:grid-cols-3">
-            {[1, 2, 3].map((i) => (
-              <div key={i} className="rounded-[2rem] bg-[#d1d5db] dark:bg-[#3d3d5c] p-8">
-                <div className="flex items-start justify-between gap-4 mb-4">
-                  <div className="flex items-start gap-4 flex-1">
-                    <div className="w-12 h-12 rounded-[1.25rem] bg-[#f3f4f6] dark:bg-[#0d1525]" />
-                    <div className="flex-1 space-y-2">
-                      <div className="h-3 w-20 bg-[#f3f4f6] dark:bg-[#0d1525] rounded" />
-                      <div className="h-6 w-36 bg-[#f3f4f6] dark:bg-[#0d1525] rounded" />
-                    </div>
-                  </div>
-                  <div className="w-11 h-11 rounded-full bg-[#f3f4f6] dark:bg-[#0d1525]" />
-                </div>
-                <div className="space-y-1.5 mb-4">
-                  <div className="h-4 w-full bg-[#f3f4f6] dark:bg-[#0d1525] rounded" />
-                  <div className="h-4 w-5/6 bg-[#f3f4f6] dark:bg-[#0d1525] rounded" />
-                </div>
-                <div className="flex gap-2">
-                  <div className="h-6 w-20 rounded-full bg-[#f3f4f6] dark:bg-[#0d1525]" />
-                  <div className="h-6 w-24 rounded-full bg-[#f3f4f6] dark:bg-[#0d1525]" />
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-      </div>
-    </section>
-  );
-}
-
-/* ── Marketplace Templates ──────────────────────────────────────────────────── */
-function TemplatesSkeleton() {
-  return (
-    <section className="py-24 px-6 bg-transparent">
-      <div className="max-w-6xl mx-auto">
-        {/* Section header */}
-        <div className="text-center mb-16">
-          <div className="h-8 w-44 rounded-full bg-[#e5e7eb] dark:bg-[#1e2a4a] shadow-raised animate-pulse mx-auto mb-4" />
-          <div className="h-9 w-72 bg-[#e5e7eb] dark:bg-[#1e2a4a] rounded-xl shadow-raised animate-pulse mx-auto mb-4" />
-          <div className="h-4 w-96 bg-[#e5e7eb] dark:bg-[#1e2a4a] rounded shadow-raised animate-pulse mx-auto mb-2" />
-          <div className="h-4 w-80 bg-[#e5e7eb] dark:bg-[#1e2a4a] rounded shadow-raised animate-pulse mx-auto" />
-        </div>
-
-        <div className="grid md:grid-cols-2 gap-12 items-start">
-          {/* Left — view toggle + dashboard preview */}
-          <div className="flex flex-col items-center gap-6 animate-pulse">
-            {/* Toggle pill */}
-            <div className="h-11 w-80 rounded-full bg-[#e5e7eb] dark:bg-[#1e2a4a] shadow-raised" />
-            {/* Dashboard card */}
-            <div className="w-full rounded-3xl bg-[#e5e7eb] dark:bg-[#1e2a4a] shadow-raised p-4">
-              {/* Browser chrome bar */}
-              <div className="flex items-center gap-2 px-3 py-2 rounded-xl mb-3 bg-[#d1d5db] dark:bg-[#3d3d5c]">
-                <div className="flex gap-1.5">
-                  {[1, 2, 3].map((i) => (
-                    <span key={i} className="w-2.5 h-2.5 rounded-full bg-[#f3f4f6] dark:bg-[#0d1525]" />
-                  ))}
-                </div>
-                <div className="flex-1 h-4 bg-[#f3f4f6] dark:bg-[#0d1525] rounded-full mx-2" />
-              </div>
-              {/* Dashboard content */}
-              <div className="rounded-2xl bg-[#d1d5db] dark:bg-[#3d3d5c] min-h-[280px] p-4 space-y-3">
-                <div className="h-4 w-40 bg-[#f3f4f6] dark:bg-[#0d1525] rounded" />
-                <div className="rounded-xl bg-[#f3f4f6] dark:bg-[#0d1525] p-4 space-y-2">
-                  <div className="h-3 w-32 bg-[#d1d5db] dark:bg-[#3d3d5c] rounded" />
-                  {[1, 2, 3].map((i) => (
-                    <div key={i} className="h-8 w-full bg-[#d1d5db] dark:bg-[#3d3d5c] rounded" />
-                  ))}
-                </div>
-                <div className="rounded-xl bg-[#f3f4f6] dark:bg-[#0d1525] p-4">
-                  <div className="h-3 w-24 bg-[#d1d5db] dark:bg-[#3d3d5c] rounded mb-2" />
-                  <div className="h-8 w-28 bg-[#d1d5db] dark:bg-[#3d3d5c] rounded" />
-                </div>
-              </div>
-            </div>
-          </div>
-
-          {/* Right — quick start + feature list */}
-          <div className="flex flex-col gap-6 animate-pulse">
-            <div>
-              <div className="h-4 w-24 bg-[#e5e7eb] dark:bg-[#1e2a4a] rounded mb-3 shadow-raised" />
-              <div className="rounded-2xl bg-[#e5e7eb] dark:bg-[#1e2a4a] shadow-raised p-6 space-y-2">
-                {[1, 2, 3].map((i) => (
-                  <div key={i} className="h-4 bg-[#d1d5db] dark:bg-[#3d3d5c] rounded" style={{ width: `${70 + i * 8}%` }} />
-                ))}
-              </div>
-            </div>
-            <div className="space-y-3">
-              {[1, 2, 3].map((i) => (
-                <div key={i} className="flex items-start gap-3">
-                  <div className="w-5 h-5 rounded bg-[#d1d5db] dark:bg-[#3d3d5c] mt-0.5 shrink-0" />
-                  <div className="flex-1 space-y-1">
-                    <div className="h-4 w-3/4 bg-[#e5e7eb] dark:bg-[#1e2a4a] rounded shadow-raised" />
-                    <div className="h-3 w-full bg-[#d1d5db] dark:bg-[#3d3d5c] rounded" />
-                  </div>
-                </div>
-              ))}
-            </div>
-            <div className="h-10 w-40 rounded-xl bg-[#d1d5db] dark:bg-[#3d3d5c]" />
-          </div>
-        </div>
-      </div>
-    </section>
-  );
-}
-
-/* ── Evolution Timeline ─────────────────────────────────────────────────────── */
-function EvolutionSkeleton() {
-  return (
-    <section className="py-24 bg-[#e5e7eb] dark:bg-[#0d1525]">
-      <div className="relative mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
-        {/* Header */}
-        <div className="mb-4 text-center">
-          <div className="h-8 w-36 rounded-full bg-[#d1d5db] dark:bg-[#3d3d5c] shadow-raised animate-pulse mx-auto mb-4" />
-          <div className="h-11 w-80 bg-[#d1d5db] dark:bg-[#3d3d5c] rounded-xl shadow-raised animate-pulse mx-auto mb-3" />
-          <div className="h-4 w-96 bg-[#d1d5db] dark:bg-[#3d3d5c] rounded shadow-raised animate-pulse mx-auto" />
-        </div>
-
-        {/* Stats row */}
-        <div className="mb-10 mt-6 grid grid-cols-2 sm:grid-cols-4 gap-4 rounded-2xl bg-[#d1d5db] dark:bg-[#3d3d5c] shadow-raised animate-pulse p-5">
-          {[1, 2, 3, 4].map((i) => (
-            <div key={i} className="rounded-xl bg-[#f3f4f6] dark:bg-[#0d1525] p-3 text-center">
-              <div className="h-8 w-12 bg-[#d1d5db] dark:bg-[#3d3d5c] rounded mx-auto mb-1" />
-              <div className="h-3 w-20 bg-[#d1d5db] dark:bg-[#3d3d5c] rounded mx-auto" />
-            </div>
-          ))}
-        </div>
-
-        {/* Domain filter tabs */}
-        <div className="mb-14 flex gap-2 overflow-x-auto rounded-2xl bg-[#d1d5db] dark:bg-[#3d3d5c] shadow-raised animate-pulse p-3">
-          {[1, 2, 3, 4, 5].map((i) => (
-            <div key={i} className="h-9 w-24 shrink-0 rounded-xl bg-[#f3f4f6] dark:bg-[#0d1525]" />
-          ))}
-        </div>
-
-        {/* Timeline cards */}
-        <div className="relative flex flex-col gap-10">
-          {/* Vertical connector line */}
-          <div className="absolute left-4 sm:left-1/2 top-0 bottom-0 w-0.5 bg-[#d1d5db] dark:bg-[#3d3d5c]" />
-          {[1, 2, 3, 4].map((i) => (
-            <div key={i} className="relative pl-12 sm:pl-0">
-              {/* Connector dot */}
-              <div className="absolute left-3 sm:left-1/2 top-5 w-4 h-4 rounded-full bg-[#d1d5db] dark:bg-[#3d3d5c] -translate-x-1.5 sm:-translate-x-2 z-10" />
-              {/* Phase card — alternating sides on large screens */}
-              <div
-                className={`rounded-[2rem] bg-[#d1d5db] dark:bg-[#3d3d5c] shadow-raised animate-pulse p-6 sm:w-[46%] ${
-                  i % 2 === 0 ? "sm:ml-auto" : ""
-                }`}
-              >
-                <div className="flex items-center gap-3 mb-4">
-                  <div className="h-6 w-6 rounded bg-[#f3f4f6] dark:bg-[#0d1525]" />
-                  <div className="h-3 w-20 bg-[#f3f4f6] dark:bg-[#0d1525] rounded" />
-                  <div className="h-5 w-16 rounded-full bg-[#f3f4f6] dark:bg-[#0d1525] ml-auto" />
-                </div>
-                <div className="h-6 w-3/4 bg-[#f3f4f6] dark:bg-[#0d1525] rounded mb-3" />
-                <div className="space-y-1.5 mb-4">
-                  <div className="h-3 w-full bg-[#f3f4f6] dark:bg-[#0d1525] rounded" />
-                  <div className="h-3 w-5/6 bg-[#f3f4f6] dark:bg-[#0d1525] rounded" />
-                </div>
-                {/* Progress bar */}
-                <div className="h-1.5 w-full rounded-full bg-[#f3f4f6] dark:bg-[#0d1525]">
-                  <div className="h-full rounded-full bg-gray-400" style={{ width: `${40 + i * 12}%` }} />
-                </div>
-                <div className="flex gap-2 mt-3">
-                  {[1, 2].map((j) => (
-                    <div key={j} className="h-5 w-16 rounded-full bg-[#f3f4f6] dark:bg-[#0d1525]" />
-                  ))}
-                </div>
-              </div>
-            </div>
-          ))}
-        </div>
-      </div>
-    </section>
-  );
-}
+import LoadingBar from "@/components/ui/LoadingBar";
+import { Skeleton } from "@/components/ui/Skeleton";
 
 export default function BlueprintLoading() {
   return (
     <div className="min-h-screen flex flex-col bg-transparent">
+      <LoadingBar />
       <Navbar />
 
       <main className="flex-grow">
-        <VisionSkeleton />
-        <SectionNavSkeleton />
-        <OrchestratorSkeleton />
-        <TemplatesSkeleton />
-        <EvolutionSkeleton />
+        <section className="relative pt-44 md:pt-48 pb-20 bg-transparent">
+          <div className="max-w-7xl mx-auto px-6 lg:px-8 text-center flex flex-col items-center">
+            <Skeleton className="h-[clamp(3rem,10vw,7.75rem)] w-2/3 rounded-2xl mb-6" />
+            <Skeleton className="h-8 w-40 rounded-full mb-8" />
+            <Skeleton className="h-16 w-3/4 rounded-xl mb-3" />
+            <Skeleton className="h-16 w-2/3 rounded-xl mb-8" />
+            <Skeleton className="h-5 w-2/3 mb-2" />
+            <Skeleton className="h-5 w-1/2 mb-12" />
+            <Skeleton className="w-full max-w-3xl rounded-[2rem] h-64" />
+          </div>
+        </section>
+
+        <section className="px-6 py-24 bg-transparent">
+          <div className="mx-auto max-w-6xl">
+            <div className="flex flex-wrap justify-center gap-3">
+              {[120, 140, 128, 152, 136].map((w, i) => (
+                <Skeleton key={i} className="h-10 rounded-2xl" style={{ width: w }} />
+              ))}
+            </div>
+          </div>
+        </section>
       </main>
 
       <Footer />

--- a/src/app/changelog/loading.tsx
+++ b/src/app/changelog/loading.tsx
@@ -1,70 +1,35 @@
 import { Navbar } from "@/components/layout/Navbar";
 import { Footer } from "@/components/layout/Footer";
-
-function TimelineEntrySkeleton({ reverse = false }: { reverse?: boolean }) {
-  return (
-    <div
-      className={`relative flex flex-col md:flex-row items-start md:items-center md:justify-between ${reverse ? "md:flex-row-reverse" : ""}`}
-    >
-      <div className="absolute left-6 md:left-1/2 transform -translate-x-1/2 w-6 h-6 rounded-full bg-bg-base shadow-neu-raised-sm z-10 flex items-center justify-center">
-        <div className="w-2 h-2 rounded-full bg-theme-primary/40" />
-      </div>
-
-      <div className={`hidden md:block w-5/12 ${reverse ? "text-left" : "text-right"}`}>
-        <div className="h-3 w-28 bg-bg-elevated rounded-full shadow-neu-raised-sm animate-pulse inline-block" />
-      </div>
-
-      <div className="w-full md:w-5/12 pl-12 md:pl-0">
-        <div className="bg-bg-elevated rounded-[2.5rem] p-8 md:p-10 shadow-neu-raised animate-pulse">
-          <div className="flex items-center justify-between mb-6 gap-3">
-            <div className="flex items-center gap-3">
-              <div className="h-8 w-20 rounded bg-bg-base" />
-              <div className="h-5 w-16 rounded-full bg-bg-base" />
-            </div>
-            <div className="h-4 w-20 rounded bg-bg-base md:hidden" />
-          </div>
-
-          <div className="h-6 w-2/3 rounded bg-bg-base mb-4" />
-          <div className="h-4 w-full rounded bg-bg-base mb-2" />
-          <div className="h-4 w-5/6 rounded bg-bg-base mb-6" />
-
-          <div className="space-y-3">
-            {[1, 2, 3].map((item) => (
-              <div key={item} className="flex items-start gap-3">
-                <span className="mt-2 h-1 w-1 rounded-full bg-theme-primary/40 shrink-0" />
-                <div className="h-4 w-4/5 rounded bg-bg-base" />
-              </div>
-            ))}
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-}
+import LoadingBar from "@/components/ui/LoadingBar";
+import { Skeleton } from "@/components/ui/Skeleton";
 
 export default function ChangelogLoading() {
   return (
     <div className="min-h-screen flex flex-col bg-transparent">
+      <LoadingBar />
       <Navbar />
+
       <main className="flex-grow pt-32 pb-24 px-6 md:px-8">
         <div className="max-w-4xl mx-auto">
-          <header className="text-center mb-24">
-            <div className="h-3 w-24 rounded mx-auto bg-bg-elevated shadow-neu-raised-sm mb-4 animate-pulse" />
-            <div className="h-12 md:h-14 w-2/3 mx-auto rounded bg-bg-elevated shadow-neu-raised mb-6 animate-pulse" />
-            <div className="h-5 w-5/6 md:w-2/3 mx-auto rounded bg-bg-elevated shadow-neu-raised-sm animate-pulse" />
+          <header className="text-center mb-16 space-y-4">
+            <Skeleton className="h-3 w-24 mx-auto" />
+            <Skeleton className="h-12 md:h-14 w-2/3 mx-auto" />
+            <Skeleton className="h-5 w-1/2 mx-auto" />
           </header>
 
-          <div className="relative">
-            <div className="absolute left-6 md:left-1/2 top-4 bottom-4 w-1 transform md:-translate-x-1/2 bg-theme-primary/10 dark:bg-theme-primary/30 rounded-full" />
-
-            <div className="space-y-16 md:space-y-24">
-              <TimelineEntrySkeleton reverse />
-              <TimelineEntrySkeleton />
-              <TimelineEntrySkeleton reverse />
-            </div>
+          <div className="space-y-8">
+            {[1, 2, 3, 4].map((i) => (
+              <div key={i} className="rounded-[2.5rem] p-8 space-y-3">
+                <Skeleton className="h-6 w-1/3" />
+                <Skeleton className="h-4 w-full" />
+                <Skeleton className="h-4 w-5/6" />
+                <Skeleton className="h-4 w-4/6" />
+              </div>
+            ))}
           </div>
         </div>
       </main>
+
       <Footer />
     </div>
   );

--- a/src/app/community/loading.tsx
+++ b/src/app/community/loading.tsx
@@ -1,137 +1,87 @@
 import { Footer } from "@/components/layout/Footer";
 import { Navbar } from "@/components/layout/Navbar";
-
-function HeroRepoStatsSkeleton() {
-  return (
-    <section id="hero-repo-stats" className="py-24">
-      <div className="mx-auto max-w-7xl px-6 lg:px-8">
-        <div className="grid grid-cols-1 gap-8 lg:grid-cols-12 lg:gap-10">
-          <div className="rounded-3xl bg-[#e5e7eb] p-8 shadow-raised md:p-10 lg:col-span-7 animate-pulse">
-            <div className="mb-4 h-3 w-32 bg-gray-300 rounded"></div>
-            <div className="h-12 w-3/4 bg-gray-300 rounded mb-4"></div>
-            <div className="h-4 w-full bg-gray-300 rounded mb-2"></div>
-            <div className="h-4 w-5/6 bg-gray-300 rounded"></div>
-          </div>
-
-          <div className="grid grid-cols-2 gap-4 lg:col-span-5">
-            {[1, 2, 3, 4].map((i) => (
-              <div
-                key={i}
-                className="rounded-2xl bg-[#e5e7eb] p-6 shadow-raised animate-pulse"
-              >
-                <div className="h-3 w-16 bg-gray-300 rounded mb-3"></div>
-                <div className="h-8 w-20 bg-gray-300 rounded"></div>
-              </div>
-            ))}
-          </div>
-        </div>
-      </div>
-    </section>
-  );
-}
-
-function ContributorsSkeleton() {
-  return (
-    <section id="contributors" className="py-24">
-      <div className="mx-auto max-w-7xl px-6 lg:px-8">
-        <div className="text-center mb-16">
-          <div className="h-3 w-24 bg-[#e5e7eb] rounded mx-auto mb-4 animate-pulse"></div>
-          <div className="h-10 w-64 bg-[#e5e7eb] rounded mx-auto mb-4 animate-pulse"></div>
-          <div className="h-4 w-96 bg-[#e5e7eb] rounded mx-auto animate-pulse"></div>
-        </div>
-
-        <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
-          {[1, 2, 3, 4, 5, 6].map((i) => (
-            <div
-              key={i}
-              className="rounded-2xl bg-[#e5e7eb] p-6 shadow-raised animate-pulse"
-            >
-              <div className="w-12 h-12 rounded-full bg-gray-300"></div>
-              <div className="mt-4 h-5 w-32 bg-gray-300 rounded"></div>
-              <div className="mt-2 h-3 w-24 bg-gray-300 rounded"></div>
-              <div className="mt-4 h-4 w-20 bg-gray-300 rounded"></div>
-            </div>
-          ))}
-        </div>
-      </div>
-    </section>
-  );
-}
-
-function RecentPRsSkeleton() {
-  return (
-    <section id="recent-prs" className="py-24">
-      <div className="mx-auto max-w-7xl px-6 lg:px-8">
-        <div className="text-center mb-16">
-          <div className="h-3 w-32 bg-[#e5e7eb] rounded mx-auto mb-4 animate-pulse"></div>
-          <div className="h-10 w-80 bg-[#e5e7eb] rounded mx-auto mb-4 animate-pulse"></div>
-          <div className="h-4 w-96 bg-[#e5e7eb] rounded mx-auto animate-pulse"></div>
-        </div>
-
-        <div className="space-y-4">
-          {[1, 2, 3, 4, 5, 6].map((i) => (
-            <div
-              key={i}
-              className="flex flex-col gap-4 rounded-2xl bg-[#e5e7eb] p-6 shadow-raised sm:flex-row sm:items-center sm:justify-between animate-pulse"
-            >
-              <div className="flex items-start gap-3 flex-1">
-                <div className="w-5 h-5 bg-gray-300 rounded mt-1"></div>
-                <div className="flex-1">
-                  <div className="h-5 w-3/4 bg-gray-300 rounded mb-2"></div>
-                  <div className="h-3 w-24 bg-gray-300 rounded"></div>
-                </div>
-              </div>
-              <div className="h-4 w-16 bg-gray-300 rounded"></div>
-            </div>
-          ))}
-        </div>
-      </div>
-    </section>
-  );
-}
-
-function OpenIssuesSkeleton() {
-  return (
-    <section id="open-issues" className="py-24">
-      <div className="mx-auto max-w-7xl px-6 lg:px-8">
-        <div className="text-center mb-16">
-          <div className="h-3 w-24 bg-[#e5e7eb] rounded mx-auto mb-4 animate-pulse"></div>
-          <div className="h-10 w-96 bg-[#e5e7eb] rounded mx-auto mb-4 animate-pulse"></div>
-          <div className="h-4 w-80 bg-[#e5e7eb] rounded mx-auto animate-pulse"></div>
-        </div>
-
-        <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-          {[1, 2, 3, 4].map((i) => (
-            <div
-              key={i}
-              className="rounded-2xl bg-[#e5e7eb] p-6 shadow-raised animate-pulse"
-            >
-              <div className="flex items-start justify-between gap-4">
-                <div className="h-5 w-3/4 bg-gray-300 rounded"></div>
-                <div className="w-5 h-5 bg-gray-300 rounded"></div>
-              </div>
-              <div className="mt-4 flex items-center justify-between">
-                <div className="h-3 w-20 bg-gray-300 rounded"></div>
-                <div className="h-3 w-16 bg-gray-300 rounded"></div>
-              </div>
-            </div>
-          ))}
-        </div>
-      </div>
-    </section>
-  );
-}
+import LoadingBar from "@/components/ui/LoadingBar";
+import { Skeleton } from "@/components/ui/Skeleton";
 
 export default function CommunityLoading() {
   return (
     <>
+      <LoadingBar />
       <Navbar />
+
       <main className="pt-16">
-        <HeroRepoStatsSkeleton />
-        <ContributorsSkeleton />
-        <RecentPRsSkeleton />
-        <OpenIssuesSkeleton />
+        <section className="py-24">
+          <div className="mx-auto max-w-7xl px-6 lg:px-8">
+            <div className="grid grid-cols-1 gap-8 lg:grid-cols-12 lg:gap-10">
+              <div className="rounded-3xl p-8 md:p-10 lg:col-span-7 space-y-4">
+                <Skeleton className="h-3 w-32" />
+                <Skeleton className="h-12 w-3/4" />
+                <Skeleton className="h-4 w-full" />
+                <Skeleton className="h-4 w-5/6" />
+              </div>
+
+              <div className="grid grid-cols-2 gap-4 lg:col-span-5">
+                {[1, 2, 3, 4].map((i) => (
+                  <div key={i} className="rounded-2xl p-6 space-y-3">
+                    <Skeleton className="h-3 w-16" />
+                    <Skeleton className="h-8 w-20" />
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="py-24">
+          <div className="mx-auto max-w-7xl px-6 lg:px-8">
+            <div className="text-center mb-16 space-y-4">
+              <Skeleton className="h-3 w-24 mx-auto" />
+              <Skeleton className="h-10 w-64 mx-auto" />
+              <Skeleton className="h-4 w-96 mx-auto" />
+            </div>
+
+            <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+              {[1, 2, 3, 4, 5, 6].map((i) => (
+                <div key={i} className="rounded-2xl p-6 space-y-4">
+                  <Skeleton className="w-12 h-12 rounded-full" />
+                  <Skeleton className="h-5 w-32" />
+                  <Skeleton className="h-3 w-24" />
+                  <Skeleton className="h-4 w-20" />
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="py-24">
+          <div className="mx-auto max-w-7xl px-6 lg:px-8">
+            <div className="text-center mb-16 space-y-4">
+              <Skeleton className="h-3 w-32 mx-auto" />
+              <Skeleton className="h-10 w-80 mx-auto" />
+              <Skeleton className="h-4 w-96 mx-auto" />
+            </div>
+
+            <div className="space-y-4">
+              {[1, 2, 3, 4, 5].map((i) => (
+                <div
+                  key={i}
+                  className="flex flex-col gap-4 rounded-2xl p-6 sm:flex-row sm:items-center sm:justify-between"
+                >
+                  <div className="flex items-start gap-3 flex-1">
+                    <Skeleton className="w-5 h-5 mt-1" />
+                    <div className="flex-1 space-y-2">
+                      <Skeleton className="h-5 w-3/4" />
+                      <Skeleton className="h-3 w-24" />
+                    </div>
+                  </div>
+                  <Skeleton className="h-4 w-16" />
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
       </main>
+
       <Footer />
     </>
   );

--- a/src/app/pricing/loading.tsx
+++ b/src/app/pricing/loading.tsx
@@ -1,48 +1,28 @@
 import { Footer } from "@/components/layout/Footer";
 import { Navbar } from "@/components/layout/Navbar";
-
-function PricingHeroSkeleton() {
-  return (
-    <div className="text-center max-w-3xl mx-auto flex flex-col items-center">
-      {/* Badge pill */}
-      <div className="h-8 w-28 rounded-full bg-[#e5e7eb] dark:bg-[#1e2a4a] shadow-raised animate-pulse mb-8" />
-      {/* h1 – two lines */}
-      <div className="h-14 w-3/4 bg-[#e5e7eb] dark:bg-[#1e2a4a] rounded-xl shadow-raised animate-pulse mb-3" />
-      <div className="h-14 w-2/3 bg-[#e5e7eb] dark:bg-[#1e2a4a] rounded-xl shadow-raised animate-pulse mb-8" />
-      {/* Subtitle paragraph */}
-      <div className="h-5 w-full bg-[#e5e7eb] dark:bg-[#1e2a4a] rounded shadow-raised animate-pulse mb-2" />
-      <div className="h-5 w-5/6 bg-[#e5e7eb] dark:bg-[#1e2a4a] rounded shadow-raised animate-pulse mb-2" />
-      <div className="h-5 w-4/6 bg-[#e5e7eb] dark:bg-[#1e2a4a] rounded shadow-raised animate-pulse" />
-    </div>
-  );
-}
+import LoadingBar from "@/components/ui/LoadingBar";
+import { Skeleton } from "@/components/ui/Skeleton";
 
 function PricingCardSkeleton() {
   return (
-    <div className="rounded-[2.5rem] bg-[#e5e7eb] dark:bg-[#1e2a4a] shadow-raised animate-pulse p-10 flex flex-col">
-      {/* Icon */}
-      <div className="w-16 h-16 rounded-2xl bg-[#d1d5db] dark:bg-[#3d3d5c]" />
-      {/* Name */}
-      <div className="mt-5 h-7 w-36 bg-[#d1d5db] dark:bg-[#3d3d5c] rounded" />
-      {/* Price label */}
-      <div className="mt-2 h-3 w-24 bg-[#d1d5db] dark:bg-[#3d3d5c] rounded" />
-      {/* Description */}
-      <div className="mt-4 space-y-1.5">
-        <div className="h-4 w-full bg-[#d1d5db] dark:bg-[#3d3d5c] rounded" />
-        <div className="h-4 w-5/6 bg-[#d1d5db] dark:bg-[#3d3d5c] rounded" />
-        <div className="h-4 w-4/6 bg-[#d1d5db] dark:bg-[#3d3d5c] rounded" />
+    <div className="rounded-[2.5rem] p-10 flex flex-col space-y-5">
+      <Skeleton className="w-16 h-16 rounded-2xl" />
+      <Skeleton className="h-7 w-36" />
+      <Skeleton className="h-3 w-24" />
+      <div className="space-y-1.5">
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-5/6" />
+        <Skeleton className="h-4 w-4/6" />
       </div>
-      {/* Features list */}
-      <ul className="mt-6 space-y-3 flex-grow">
+      <ul className="space-y-3 flex-grow">
         {[1, 2, 3, 4].map((i) => (
           <li key={i} className="flex items-start gap-2">
-            <div className="mt-1.5 h-1.5 w-1.5 rounded-full bg-[#d1d5db] dark:bg-[#3d3d5c] shrink-0" />
-            <div className="h-4 w-full bg-[#d1d5db] dark:bg-[#3d3d5c] rounded" />
+            <Skeleton className="mt-1.5 h-1.5 w-1.5 rounded-full shrink-0" />
+            <Skeleton className="h-4 w-full" />
           </li>
         ))}
       </ul>
-      {/* CTA button */}
-      <div className="mt-8 h-12 w-full rounded-xl bg-[#d1d5db] dark:bg-[#3d3d5c]" />
+      <Skeleton className="h-12 w-full rounded-xl" />
     </div>
   );
 }
@@ -50,11 +30,19 @@ function PricingCardSkeleton() {
 export default function PricingLoading() {
   return (
     <div className="min-h-screen flex flex-col bg-transparent">
+      <LoadingBar />
       <Navbar />
 
       <main className="flex-grow pt-28 pb-20">
         <section className="max-w-7xl mx-auto px-6 lg:px-8">
-          <PricingHeroSkeleton />
+          <div className="text-center max-w-3xl mx-auto flex flex-col items-center space-y-3">
+            <Skeleton className="h-8 w-28 rounded-full mb-5" />
+            <Skeleton className="h-14 w-3/4 rounded-xl" />
+            <Skeleton className="h-14 w-2/3 rounded-xl" />
+            <Skeleton className="h-5 w-full" />
+            <Skeleton className="h-5 w-5/6" />
+            <Skeleton className="h-5 w-4/6" />
+          </div>
 
           <div className="mt-14 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             {[1, 2, 3].map((i) => (
@@ -62,9 +50,8 @@ export default function PricingLoading() {
             ))}
           </div>
 
-          {/* Footer note */}
           <div className="mt-10 flex justify-center">
-            <div className="h-4 w-80 bg-[#e5e7eb] dark:bg-[#1e2a4a] rounded shadow-raised animate-pulse" />
+            <Skeleton className="h-4 w-80" />
           </div>
         </section>
       </main>

--- a/src/app/privacy/loading.tsx
+++ b/src/app/privacy/loading.tsx
@@ -1,151 +1,44 @@
 import { Footer } from "@/components/layout/Footer";
 import { Navbar } from "@/components/layout/Navbar";
+import LoadingBar from "@/components/ui/LoadingBar";
+import { Skeleton } from "@/components/ui/Skeleton";
 
-function HeaderSkeleton() {
+function LegalSectionSkeleton() {
   return (
-    <div className="text-center mb-20">
-      <div className="h-3 w-24 bg-[#e5e7eb] rounded mx-auto mb-4 animate-pulse"></div>
-      <div className="h-10 w-60 bg-[#e5e7eb] rounded mx-auto mb-6 animate-pulse"></div>
-      <div className="h-4 w-full bg-[#e5e7eb] rounded mx-auto mb-4 animate-pulse"></div>
-      <div className="mt-8 inline-flex items-center gap-2 px-4 py-2 rounded-full bg-[#e5e7eb] text-xs font-bold text-content-secondary animate-pulse">
-        <div className="h-3 w-16 bg-gray-300 rounded"></div>
-      </div>
-    </div>
-  );
-}
-
-function FeatureSkeleton() {
-  return (
-    <div className="p-10 rounded-[2.5rem] bg-[#e5e7eb] shadow-raised flex flex-col gap-6 animate-pulse">
-      <div className="w-14 h-14 rounded-2xl shadow-raised flex items-center justify-center shrink-0 bg-[#e5e7eb]"></div>
-      <div>
-        <h3 className="h-6 w-24 bg-gray-300 rounded mb-4"></h3>
-        <p className="h-3 w-full bg-gray-300 rounded"></p>
-      </div>
-    </div>
-  );
-}
-
-function ProcessorSkeleton() {
-  return (
-    <div className="p-8 rounded-[2rem] bg-[#e5e7eb] shadow-raised flex flex-col gap-4 border animate-pulse">
-      <div className="flex items-center justify-between">
-        <h3 className="h-5 w-20 bg-gray-300 rounded"></h3>
-        <a className="text-xs font-bold text-theme-primary hover:underline flex items-center gap-1">
-          <div className="h-3 w-16 bg-gray-300 rounded"></div>
-        </a>
-      </div>
-      <div className="space-y-4">
-        <div>
-          <span className="text-[10px] font-black uppercase tracking-widest text-content-secondary block mb-1"></span>
-          <p className="h-3 w-full bg-gray-300 rounded"></p>
-        </div>
-        <div>
-          <span className="text-[10px] font-black uppercase tracking-widest text-content-secondary block mb-1"></span>
-          <p className="h-3 w-full bg-gray-300 rounded"></p>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function ContactCardSkeleton() {
-  return (
-    <div className="p-8 sm:p-12 md:p-14 rounded-[3rem] shadow-raised flex flex-col md:flex-row md:items-center md:justify-between gap-10 md:gap-14 mt-16 bg-[#e5e7eb]">
-      <div className="flex flex-col gap-6 md:max-w-md">
-        <div className="w-14 h-14 rounded-2xl shadow-raised flex items-center justify-center shrink-0 bg-[#e5e7eb]"></div>
-        <div>
-          <h2 className="h-8 w-32 bg-gray-300 rounded mb-4 animate-pulse"></h2>
-          <p className="h-3 w-full bg-gray-300 rounded animate-pulse"></p>
-        </div>
-      </div>
-      <div className="flex flex-col gap-5 w-full md:w-auto md:shrink-0 md:min-w-[280px]">
-        <a className="flex flex-col gap-1 rounded-2xl px-6 py-5 transition-all duration-300 shadow-raised bg-[#e5e7eb] hover:shadow-raised group">
-          <span className="text-[10px] font-black uppercase tracking-widest text-content-secondary"></span>
-          <span className="text-base font-bold text-theme-primary group-hover:text-content-primary transition-colors"></span>
-        </a>
-        <a className="flex flex-col gap-1 rounded-2xl px-6 py-5 transition-all duration-300 shadow-raised bg-[#e5e7eb] hover:shadow-raised group">
-          <span className="text-[10px] font-black uppercase tracking-widest text-content-secondary"></span>
-          <span className="text-base font-bold text-theme-primary group-hover:text-content-primary transition-colors"></span>
-        </a>
-        <div className="rounded-2xl px-6 py-5 shadow-raised bg-[#e5e7eb]">
-          <p className="text-xs leading-relaxed font-medium text-content-secondary">
-            Offer Hub Inc.
-            <br />
-            123 Market Street, Suite 400
-            <br />
-            San Francisco, CA 94105, USA
-          </p>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function DataRightsSkeleton() {
-  return (
-    <div className="mt-16">
-      <div className="text-center mb-10">
-        <div className="h-3 w-16 bg-[#e5e7eb] rounded mx-auto mb-3 animate-pulse"></div>
-        <h2 className="h-8 w-32 bg-[#e5e7eb] rounded mx-auto mb-4 animate-pulse"></h2>
-        <p className="h-3 w-full bg-gray-300 rounded mx-auto max-w-xl animate-pulse"></p>
-      </div>
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-        <div className="p-8 sm:p-10 rounded-[2.5rem] bg-[#e5e7eb] shadow-raised flex flex-col gap-6 animate-pulse">
-          <div className="w-14 h-14 rounded-2xl shadow-raised flex items-center justify-center shrink-0 bg-[#e5e7eb]"></div>
-          <div>
-            <h3 className="h-5 w-24 bg-gray-300 rounded mb-2"></h3>
-            <p className="h-3 w-full bg-gray-300 rounded"></p>
-          </div>
-          <div className="h-10 w-full bg-gray-300 rounded"></div>
-          <div className="h-10 w-full bg-gray-300 rounded"></div>
-        </div>
-        <div className="p-8 sm:p-10 rounded-[2.5rem] bg-[#e5e7eb] shadow-raised flex flex-col gap-6 animate-pulse">
-          <div className="w-14 h-14 rounded-2xl shadow-raised flex items-center justify-center shrink-0 bg-[#e5e7eb]"></div>
-          <div>
-            <h3 className="h-5 w-24 bg-gray-300 rounded mb-2"></h3>
-            <p className="h-3 w-full bg-gray-300 rounded"></p>
-          </div>
-          <div className="h-10 w-full bg-gray-300 rounded"></div>
-          <div className="h-10 w-full bg-gray-300 rounded"></div>
-        </div>
-      </div>
+    <div className="p-8 md:p-12 rounded-[2.5rem] space-y-4">
+      <Skeleton className="h-8 w-48" />
+      <Skeleton className="h-4 w-full" />
+      <Skeleton className="h-4 w-5/6" />
+      <Skeleton className="h-4 w-4/5" />
+      <Skeleton className="h-4 w-full" />
+      <Skeleton className="h-4 w-3/4" />
     </div>
   );
 }
 
 export default function PrivacyLoading() {
   return (
-    <>
+    <div className="min-h-screen flex flex-col">
+      <LoadingBar />
       <Navbar />
+
       <main className="flex-grow pt-24 sm:pt-28 md:pt-32 pb-16 sm:pb-20 px-4 sm:px-8 md:px-12 lg:px-24">
-        <HeaderSkeleton />
-
-        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6 sm:gap-8 lg:gap-10 mb-5">
-          <FeatureSkeleton />
-          <FeatureSkeleton />
-          <FeatureSkeleton />
+        <div className="text-center mb-20 md:mb-28 space-y-4">
+          <Skeleton className="h-3 w-24 mx-auto" />
+          <Skeleton className="h-12 md:h-16 w-2/3 mx-auto" />
+          <Skeleton className="h-5 w-full max-w-2xl mx-auto" />
+          <Skeleton className="h-5 w-4/5 max-w-xl mx-auto" />
+          <Skeleton className="h-8 w-48 rounded-full mx-auto mt-4" />
         </div>
 
-        <div className="mt-24 mb-24">
-          <div className="flex flex-col gap-6 mb-12">
-            <h2 className="h-6 w-40 bg-gray-300 rounded mb-4 animate-pulse"></h2>
-            <p className="h-3 w-full bg-gray-300 rounded animate-pulse"></p>
-          </div>
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-            <ProcessorSkeleton />
-            <ProcessorSkeleton />
-            <ProcessorSkeleton />
-            <ProcessorSkeleton />
-            <ProcessorSkeleton />
-          </div>
+        <div className="max-w-4xl mx-auto space-y-12">
+          {[1, 2, 3, 4, 5].map((i) => (
+            <LegalSectionSkeleton key={i} />
+          ))}
         </div>
-
-        <ContactCardSkeleton />
-
-        <DataRightsSkeleton />
       </main>
+
       <Footer />
-    </>
+    </div>
   );
 }

--- a/src/app/terms/loading.tsx
+++ b/src/app/terms/loading.tsx
@@ -1,65 +1,51 @@
 import { Footer } from "@/components/layout/Footer";
 import { Navbar } from "@/components/layout/Navbar";
+import LoadingBar from "@/components/ui/LoadingBar";
+import { Skeleton } from "@/components/ui/Skeleton";
 
-function HeaderSkeleton() {
+function LegalSectionSkeleton() {
   return (
-    <header className="text-center mb-20">
-      <div className="h-3 w-24 bg-[#e5e7eb] rounded mx-auto mb-4 animate-pulse"></div>
-      <div className="h-10 w-60 bg-[#e5e7eb] rounded mx-auto mb-6 animate-pulse"></div>
-      <div className="h-4 w-full bg-[#e5e7eb] rounded mx-auto mb-8 animate-pulse"></div>
-      <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-[#e5e7eb] text-xs font-bold text-content-secondary animate-pulse">
-        <div className="h-3 w-16 bg-gray-300 rounded"></div>
-      </div>
-    </header>
-  );
-}
-
-function SectionSkeleton() {
-  return (
-    <div className="p-8 md:p-12 rounded-[2.5rem] bg-[#e5e7eb] shadow-raised animate-pulse">
-      <div className="flex items-center gap-5 mb-8">
-        <div className="w-12 h-12 rounded-xl flex items-center justify-center bg-[#e5e7eb] shadow-raised"></div>
-        <div className="h-8 w-48 bg-gray-300 rounded"></div>
-      </div>
-      <div className="space-y-4">
-        <div className="h-4 w-full bg-gray-300 rounded"></div>
-        <div className="h-4 w-5/6 bg-gray-300 rounded"></div>
-        <div className="h-4 w-4/5 bg-gray-300 rounded"></div>
-        <div className="h-4 w-full bg-gray-300 rounded"></div>
-        <div className="h-4 w-3/4 bg-gray-300 rounded"></div>
-      </div>
-    </div>
-  );
-}
-
-function DisclaimerSkeleton() {
-  return (
-    <div className="p-8 md:p-10 rounded-[2.5rem] bg-[#e5e7eb] shadow-raised animate-pulse">
-      <div className="h-3 w-full bg-gray-300 rounded mb-4"></div>
-      <div className="h-3 w-3/4 bg-gray-300 rounded mb-2"></div>
-      <div className="h-3 w-full bg-gray-300 rounded"></div>
+    <div className="p-8 md:p-12 rounded-[2.5rem] space-y-4">
+      <Skeleton className="h-8 w-48" />
+      <Skeleton className="h-4 w-full" />
+      <Skeleton className="h-4 w-5/6" />
+      <Skeleton className="h-4 w-4/5" />
+      <Skeleton className="h-4 w-full" />
+      <Skeleton className="h-4 w-3/4" />
     </div>
   );
 }
 
 export default function TermsLoading() {
   return (
-    <>
+    <div className="min-h-screen flex flex-col bg-bg-base">
+      <LoadingBar />
       <Navbar />
-      <main className="pt-32 pb-24 px-6 lg:px-8">
+
+      <main className="flex-grow pt-32 pb-24 px-6 lg:px-8">
         <div className="max-w-4xl mx-auto">
-          <HeaderSkeleton />
+          <header className="text-center mb-20 space-y-4">
+            <Skeleton className="h-3 w-24 mx-auto" />
+            <Skeleton className="h-12 w-2/3 mx-auto" />
+            <Skeleton className="h-5 w-full max-w-2xl mx-auto" />
+            <Skeleton className="h-8 w-48 rounded-full mx-auto mt-4" />
+          </header>
+
           <div className="space-y-12">
-            <SectionSkeleton />
-            <SectionSkeleton />
-            <SectionSkeleton />
-            <SectionSkeleton />
-            <SectionSkeleton />
-            <DisclaimerSkeleton />
+            {[1, 2, 3, 4, 5].map((i) => (
+              <LegalSectionSkeleton key={i} />
+            ))}
+
+            <div className="p-8 md:p-10 rounded-[2.5rem] space-y-3">
+              <Skeleton className="h-3 w-full" />
+              <Skeleton className="h-3 w-3/4" />
+              <Skeleton className="h-3 w-full" />
+            </div>
           </div>
         </div>
       </main>
+
       <Footer />
-    </>
+    </div>
   );
 }

--- a/src/app/use-cases/loading.tsx
+++ b/src/app/use-cases/loading.tsx
@@ -1,200 +1,58 @@
 import { Navbar } from "@/components/layout/Navbar";
 import { Footer } from "@/components/layout/Footer";
-
-/* ── Use-Case Switcher (top tab row) ────────────────────────────────────────── */
-function UseCaseSwitcherSkeleton() {
-  return (
-    <section className="pt-28 pb-0 bg-transparent">
-      <div className="max-w-5xl mx-auto px-4 sm:px-6 flex flex-wrap justify-center gap-3">
-        {[148, 128, 132, 148, 176].map((w, i) => (
-          <div
-            key={i}
-            className="h-10 rounded-2xl bg-[#e5e7eb] dark:bg-[#1e2a4a] shadow-raised animate-pulse"
-            style={{ width: w }}
-          />
-        ))}
-      </div>
-    </section>
-  );
-}
-
-/* ── Hero (per-use-case — approximated with standard 2-col hero) ─────────────── */
-function HeroSkeleton() {
-  return (
-    <section className="py-24 bg-transparent">
-      <div className="max-w-7xl mx-auto px-6 lg:px-8">
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
-          {/* Text column */}
-          <div className="animate-pulse">
-            <div className="h-3 w-24 bg-[#e5e7eb] dark:bg-[#1e2a4a] rounded mb-6" />
-            <div className="h-14 w-full bg-[#e5e7eb] dark:bg-[#1e2a4a] shadow-raised rounded-xl mb-3" />
-            <div className="h-14 w-4/5 bg-[#e5e7eb] dark:bg-[#1e2a4a] shadow-raised rounded-xl mb-6" />
-            <div className="space-y-2 mb-8">
-              <div className="h-5 w-full bg-[#e5e7eb] dark:bg-[#1e2a4a] rounded" />
-              <div className="h-5 w-5/6 bg-[#e5e7eb] dark:bg-[#1e2a4a] rounded" />
-              <div className="h-5 w-4/6 bg-[#e5e7eb] dark:bg-[#1e2a4a] rounded" />
-            </div>
-            <div className="flex gap-4">
-              <div className="h-12 w-40 rounded-xl bg-[#e5e7eb] dark:bg-[#1e2a4a] shadow-raised" />
-              <div className="h-12 w-36 rounded-xl bg-[#e5e7eb] dark:bg-[#1e2a4a] shadow-raised" />
-            </div>
-          </div>
-          {/* Visual column */}
-          <div className="rounded-[2rem] bg-[#e5e7eb] dark:bg-[#1e2a4a] shadow-raised animate-pulse p-8">
-            <div className="h-56 w-full rounded-2xl bg-[#d1d5db] dark:bg-[#3d3d5c]" />
-          </div>
-        </div>
-      </div>
-    </section>
-  );
-}
-
-/* ── Sticky Section Navigation (5 tabs) ────────────────────────────────────── */
-function SectionNavSkeleton() {
-  return (
-    <div className="sticky top-[80px] z-40 py-6 pointer-events-none">
-      <div className="max-w-3xl mx-auto px-4 sm:px-6 flex justify-center">
-        <div className="pointer-events-auto flex items-center gap-1 sm:gap-2 p-1.5 sm:p-2 rounded-2xl bg-[#e5e7eb] dark:bg-[#1e2a4a] shadow-raised animate-pulse">
-          {/* Overview, Features, Metrics, Architecture, SDK */}
-          {[96, 88, 80, 112, 64].map((w, i) => (
-            <div key={i} className="h-10 rounded-xl bg-[#d1d5db] dark:bg-[#3d3d5c]" style={{ width: w }} />
-          ))}
-        </div>
-      </div>
-    </div>
-  );
-}
-
-/* ── Features Section (3 cards) ────────────────────────────────────────────── */
-function FeaturesSkeleton() {
-  return (
-    <section className="py-24 relative bg-transparent">
-      <div className="max-w-7xl mx-auto px-6 lg:px-8">
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
-          {[1, 2, 3].map((i) => (
-            <div
-              key={i}
-              className="flex flex-col items-center text-center p-10 rounded-[2rem] bg-[#e5e7eb] dark:bg-[#1e2a4a] shadow-raised animate-pulse"
-            >
-              <div className="w-16 h-16 rounded-2xl bg-[#d1d5db] dark:bg-[#3d3d5c] mb-8" />
-              <div className="h-6 w-36 bg-[#d1d5db] dark:bg-[#3d3d5c] rounded mb-4" />
-              <div className="space-y-2 w-full">
-                <div className="h-4 w-full bg-[#d1d5db] dark:bg-[#3d3d5c] rounded" />
-                <div className="h-4 w-5/6 bg-[#d1d5db] dark:bg-[#3d3d5c] rounded mx-auto" />
-                <div className="h-4 w-4/6 bg-[#d1d5db] dark:bg-[#3d3d5c] rounded mx-auto" />
-              </div>
-            </div>
-          ))}
-        </div>
-      </div>
-    </section>
-  );
-}
-
-/* ── Metrics Section (StellarImpactCards — 4 stat cards) ───────────────────── */
-function MetricsSkeleton() {
-  return (
-    <section className="py-24 relative bg-transparent">
-      <div className="max-w-7xl mx-auto px-6 lg:px-8">
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-6">
-          {[1, 2, 3, 4].map((i) => (
-            <div
-              key={i}
-              className="rounded-[2rem] bg-[#e5e7eb] dark:bg-[#1e2a4a] shadow-raised animate-pulse p-8 text-center"
-            >
-              <div className="h-10 w-20 bg-[#d1d5db] dark:bg-[#3d3d5c] rounded mx-auto mb-3" />
-              <div className="h-4 w-24 bg-[#d1d5db] dark:bg-[#3d3d5c] rounded mx-auto mb-2" />
-              <div className="h-3 w-16 bg-[#d1d5db] dark:bg-[#3d3d5c] rounded mx-auto" />
-            </div>
-          ))}
-        </div>
-      </div>
-    </section>
-  );
-}
-
-/* ── Architecture Section (EscrowFlowDiagram centered) ─────────────────────── */
-function ArchitectureSkeleton() {
-  return (
-    <section className="py-24 relative bg-transparent">
-      <div className="max-w-7xl mx-auto px-6 lg:px-8 text-center animate-pulse">
-        <div className="w-16 h-16 rounded-2xl bg-[#e5e7eb] dark:bg-[#1e2a4a] shadow-raised mx-auto mb-8" />
-        <div className="h-12 w-96 bg-[#e5e7eb] dark:bg-[#1e2a4a] rounded-xl shadow-raised mx-auto mb-6" />
-        <div className="space-y-2 mb-16">
-          <div className="h-5 w-2/3 bg-[#e5e7eb] dark:bg-[#1e2a4a] rounded shadow-raised mx-auto" />
-          <div className="h-5 w-1/2 bg-[#e5e7eb] dark:bg-[#1e2a4a] rounded shadow-raised mx-auto" />
-        </div>
-        {/* Flow diagram box */}
-        <div className="rounded-[2rem] bg-[#e5e7eb] dark:bg-[#1e2a4a] shadow-raised mx-auto max-w-3xl p-6">
-          <div className="h-64 w-full rounded-2xl bg-[#d1d5db] dark:bg-[#3d3d5c]" />
-        </div>
-      </div>
-    </section>
-  );
-}
-
-/* ── SDK / Code Integration Section (CodeIntegrationShowcase) ──────────────── */
-function SdkSkeleton() {
-  return (
-    <section className="relative bg-transparent py-24">
-      <div className="max-w-7xl mx-auto px-6 lg:px-8">
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-10 items-start">
-          {/* Text column */}
-          <div className="animate-pulse">
-            <div className="h-3 w-16 bg-[#e5e7eb] dark:bg-[#1e2a4a] rounded mb-6" />
-            <div className="h-10 w-80 bg-[#e5e7eb] dark:bg-[#1e2a4a] shadow-raised rounded-xl mb-4" />
-            <div className="space-y-2 mb-8">
-              <div className="h-4 w-full bg-[#e5e7eb] dark:bg-[#1e2a4a] rounded" />
-              <div className="h-4 w-5/6 bg-[#e5e7eb] dark:bg-[#1e2a4a] rounded" />
-            </div>
-            <div className="space-y-4">
-              {[1, 2, 3].map((i) => (
-                <div key={i} className="flex items-start gap-3">
-                  <div className="w-5 h-5 mt-0.5 shrink-0 bg-[#d1d5db] dark:bg-[#3d3d5c] rounded" />
-                  <div className="flex-1 space-y-1">
-                    <div className="h-4 w-3/4 bg-[#e5e7eb] dark:bg-[#1e2a4a] rounded shadow-raised" />
-                    <div className="h-3 w-full bg-[#d1d5db] dark:bg-[#3d3d5c] rounded" />
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
-          {/* Code panel */}
-          <div className="rounded-[2rem] bg-[#e5e7eb] dark:bg-[#1e2a4a] shadow-raised animate-pulse p-6">
-            <div className="flex gap-2 mb-4">
-              {[80, 72, 88].map((w, i) => (
-                <div key={i} className="h-7 rounded-lg bg-[#d1d5db] dark:bg-[#3d3d5c]" style={{ width: w }} />
-              ))}
-            </div>
-            <div className="space-y-2">
-              {[90, 70, 55, 80, 65, 75, 50, 85].map((pct, i) => (
-                <div
-                  key={i}
-                  className="h-4 bg-[#d1d5db] dark:bg-[#3d3d5c] rounded"
-                  style={{ width: `${pct}%` }}
-                />
-              ))}
-            </div>
-          </div>
-        </div>
-      </div>
-    </section>
-  );
-}
+import LoadingBar from "@/components/ui/LoadingBar";
+import { Skeleton } from "@/components/ui/Skeleton";
 
 export default function UseCasesLoading() {
   return (
     <div className="bg-transparent min-h-[100dvh]">
+      <LoadingBar />
       <Navbar />
 
       <main>
-        <UseCaseSwitcherSkeleton />
-        <HeroSkeleton />
-        <SectionNavSkeleton />
-        <FeaturesSkeleton />
-        <MetricsSkeleton />
-        <ArchitectureSkeleton />
-        <SdkSkeleton />
+        <section className="pt-28 pb-0 bg-transparent">
+          <div className="max-w-5xl mx-auto px-4 sm:px-6 flex flex-wrap justify-center gap-3">
+            {[148, 128, 132, 148, 176].map((w, i) => (
+              <Skeleton key={i} className="h-10 rounded-2xl" style={{ width: w }} />
+            ))}
+          </div>
+        </section>
+
+        <section className="py-24 bg-transparent">
+          <div className="max-w-7xl mx-auto px-6 lg:px-8">
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
+              <div className="space-y-4">
+                <Skeleton className="h-3 w-24" />
+                <Skeleton className="h-14 w-full rounded-xl" />
+                <Skeleton className="h-14 w-4/5 rounded-xl" />
+                <Skeleton className="h-5 w-full" />
+                <Skeleton className="h-5 w-5/6" />
+                <Skeleton className="h-5 w-4/6" />
+                <div className="flex gap-4 pt-4">
+                  <Skeleton className="h-12 w-40 rounded-xl" />
+                  <Skeleton className="h-12 w-36 rounded-xl" />
+                </div>
+              </div>
+              <Skeleton className="rounded-[2rem] h-64 w-full" />
+            </div>
+          </div>
+        </section>
+
+        <section className="py-24 relative bg-transparent">
+          <div className="max-w-7xl mx-auto px-6 lg:px-8">
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+              {[1, 2, 3].map((i) => (
+                <div key={i} className="flex flex-col items-center text-center p-10 rounded-[2rem] space-y-4">
+                  <Skeleton className="w-16 h-16 rounded-2xl" />
+                  <Skeleton className="h-6 w-36" />
+                  <Skeleton className="h-4 w-full" />
+                  <Skeleton className="h-4 w-5/6" />
+                  <Skeleton className="h-4 w-4/6" />
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
       </main>
 
       <Footer />

--- a/src/components/ui/Skeleton.tsx
+++ b/src/components/ui/Skeleton.tsx
@@ -1,0 +1,22 @@
+import { cn } from "@/lib/cn";
+
+interface SkeletonProps extends React.HTMLAttributes<HTMLDivElement> {
+  className?: string;
+}
+
+export function Skeleton({ className, ...props }: SkeletonProps) {
+  return (
+    <div
+      aria-hidden="true"
+      className={cn(
+        "rounded-lg bg-[#F3F4F6] dark:bg-bg-sunken shadow-neu-raised",
+        "relative overflow-hidden",
+        "before:absolute before:inset-0 before:-translate-x-full",
+        "before:bg-gradient-to-r before:from-transparent before:via-white/50 before:to-transparent",
+        "before:animate-shimmer motion-reduce:before:hidden",
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -54,10 +54,14 @@ const config: Config = {
           from: { opacity: "0" },
           to: { opacity: "1" },
         },
+        shimmer: {
+          "100%": { transform: "translateX(100%)" },
+        },
       },
       animation: {
         fadeInUp: "fadeInUp 400ms ease-out both",
         fadeIn: "fadeIn 300ms ease-out both",
+        shimmer: "shimmer 1.5s ease-in-out infinite",
       },
       boxShadow: {
         // Legacy shadows (kept for backwards compatibility)


### PR DESCRIPTION
# 📝 Pull Request 

## 🔧 Title: Replace generic LoadingBar

## 🛠️ Issue

- Closes #1454

## 📚 Description

- This PR replaces the route-level ad hoc loading placeholders with a reusable Skeleton primitive and updates every loading.tsx to provide consistent, contextual loading states while preserving the existing route transition experience.

During implementation, I found that the codebase had already evolved beyond the original issue description. Instead of rendering only <LoadingBar />, every route already contained page-specific skeleton layouts built with raw div elements and animate-pulse. This PR standardizes those implementations rather than introducing skeletons from scratch.


## ✅ Changes applied

- Added a reusable Skeleton component (src/components/ui/Skeleton.tsx) with:
 Consistent neumorphic styling
 Shimmer animation
 prefers-reduced-motion support
 Flexible sizing through className
 Added shimmer animation tokens to tailwind.config.ts.
 Added <LoadingBar /> to every route-level loading.tsx so route transition progress is always visible.
- Replaced ad hoc animate-pulse placeholder blocks with the shared Skeleton component across:
 Architecture
 Blueprint
 Changelog
 Community
 Pricing
 Privacy
 Terms
 Use Cases
- Simplified several loading layouts to better match the actual page structure while reducing duplicated placeholder components.
- Updated the legal page skeletons (privacy and terms) to more accurately reflect their MDX document layouts.
