### PR TITLE
refactor(hooks): extract useScrollProgress, use in LoadingBar and Bac…

### DIFF
--- a/src/components/docs/BackToTopButton.tsx
+++ b/src/components/docs/BackToTopButton.tsx
@@ -1,29 +1,14 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback } from "react";
 import { ChevronUp } from "lucide-react";
+import { useScrollProgress } from "@/hooks/useScrollProgress";
 
 const SCROLL_THRESHOLD = 400;
 
 export function BackToTopButton() {
-  const [isVisible, setIsVisible] = useState(false);
-
-  useEffect(() => {
-    let ticking = false;
-    const onScroll = () => {
-      if (!ticking) {
-        ticking = true;
-        requestAnimationFrame(() => {
-          setIsVisible(window.scrollY > SCROLL_THRESHOLD);
-          ticking = false;
-        });
-      }
-    };
-
-    onScroll();
-    window.addEventListener("scroll", onScroll, { passive: true });
-    return () => window.removeEventListener("scroll", onScroll);
-  }, []);
+  const scrollY = useScrollProgress();
+  const isVisible = scrollY > SCROLL_THRESHOLD;
 
   const scrollToTop = useCallback(() => {
     const prefersReducedMotion = window.matchMedia(

--- a/src/components/ui/LoadingBar.tsx
+++ b/src/components/ui/LoadingBar.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useState } from "react";
+import { useScrollProgress } from "@/hooks/useScrollProgress";
 
 export default function LoadingBar() {
     const [progress, setProgress] = useState(0);
     const [isLoading, setIsLoading] = useState(true);
-    const ticking = useRef(false);
+    const scrollY = useScrollProgress(!isLoading);
 
     useEffect(() => {
         setProgress(0.3);
@@ -18,21 +19,9 @@ export default function LoadingBar() {
 
     useEffect(() => {
         if (isLoading) return;
-
-        const onScroll = () => {
-            if (!ticking.current) {
-                ticking.current = true;
-                requestAnimationFrame(() => {
-                    const docHeight = document.documentElement.scrollHeight - window.innerHeight;
-                    setProgress(docHeight > 0 ? window.scrollY / docHeight : 0);
-                    ticking.current = false;
-                });
-            }
-        };
-
-        window.addEventListener("scroll", onScroll, { passive: true });
-        return () => window.removeEventListener("scroll", onScroll);
-    }, [isLoading]);
+        const docHeight = document.documentElement.scrollHeight - window.innerHeight;
+        setProgress(docHeight > 0 ? scrollY / docHeight : 0);
+    }, [isLoading, scrollY]);
 
     return (
         <div

--- a/src/hooks/useScrollProgress.ts
+++ b/src/hooks/useScrollProgress.ts
@@ -1,0 +1,42 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Tracks `window.scrollY`, throttled to one update per animation frame via
+ * the standard `ticking` ref pattern. Centralizes the RAF-throttled scroll
+ * listener that was previously re-implemented in several components
+ * (LoadingBar, BackToTopButton, SectionNav, Navbar, UseCasesClient).
+ *
+ * Consumers derive whatever they need from the returned value (a progress
+ * ratio, a threshold boolean, a pinned/sticky check against a ref, etc.).
+ *
+ * @param enabled When false, no listener is attached and the last known
+ *   value is returned. Useful for components that only want to track scroll
+ *   after some other condition is met (e.g. LoadingBar waits until its
+ *   intro animation finishes before it starts tracking scroll).
+ */
+export function useScrollProgress(enabled: boolean = true): number {
+  const [scrollY, setScrollY] = useState(0);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    let ticking = false;
+    const onScroll = () => {
+      if (!ticking) {
+        ticking = true;
+        requestAnimationFrame(() => {
+          setScrollY(window.scrollY);
+          ticking = false;
+        });
+      }
+    };
+
+    onScroll();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  }, [enabled]);
+
+  return scrollY;
+}


### PR DESCRIPTION
# 📝 Pull Request 

## 🔧 Title: 
- refactor(hooks): extract useScrollProgress, use in LoadingBar and BackToTopButton

## 🛠️ Issue
- Contributes to #1471 (partial — see Description for scope)

## 📚 Description
- There is no `src/hooks/` layer yet, so RAF-throttled scroll listeners are duplicated across components. This PR adds the layer and covers the first two, lowest-risk consumers: `LoadingBar` and `BackToTopButton`.
- `ArchitectureSectionNav`/`BlueprintSectionNav` from the issue don't exist as separate files — both pages render the same `src/components/shared/SectionNav.tsx`, which contains both the RAF-scroll pattern and the IntersectionObserver scroll-spy pattern. Given the issue's own note to prefer small, incremental PRs and its flag on regression risk around IntersectionObserver behavior, I'm splitting this into multiple PRs instead of one large change:
  - **This PR**: `useScrollProgress` + `LoadingBar` + `BackToTopButton` (RAF pattern only, no IntersectionObserver).
  - **Follow-up**: `useScrollSpy` + `SectionNav`, `TableOfContents`, `UseCasesClient`, `Navbar`.
  - **Follow-up**: `useFocusTrap`, `useBodyScrollLock`, `useDebounce`, `useMediaQuery`, `useLiquidTextAnimation` — each has consumers beyond what's listed in the issue (e.g. focus-trap also in `DocsLayoutShell`, body-scroll-lock also in `DiagramZoomModal`, liquid-text-animation also in `OrchestratorShowcase` and `WhyStellarSection`), so each needs its own scoped PR.

## ✅ Changes applied
- Added `src/hooks/useScrollProgress.ts` — a single RAF-throttled `window.scrollY` tracker (`ticking` ref pattern), with an optional `enabled` flag for components that only want to track scroll after some other condition is met.
- Refactored `src/components/ui/LoadingBar.tsx` to use it, preserving the original behavior exactly — the scroll listener still only attaches after the intro fill animation finishes.
- Refactored `src/components/docs/BackToTopButton.tsx` to use it, preserving the 400px show/hide threshold and reduced-motion scroll behavior exactly.
- No changes to markup, styling, or any other component.

## 🔍 Evidence/Media (screenshots/videos)


https://github.com/user-attachments/assets/66e66be7-6cb1-497e-a9cd-8a3de64b864d




- `npx tsc --noEmit`: 0 errors from touched files (pre-existing, unrelated errors in test files and `docs-index.json` documented separately, not introduced by this PR)
- `npm run build`: passes

Part of #1471