### PR TITLE
refactor: centralize scattered types and constants (#1472)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,16 +1,17 @@
 import type { NextConfig } from "next";
 import { getSecurityHeaders } from "./config/security-headers";
 import { logger } from "./src/utils/logger";
+import { SITE_URL_FALLBACK } from "./src/constants/site";
 
 if (process.env.NODE_ENV === "production" && !process.env.NEXT_PUBLIC_SITE_URL) {
   logger.warn(
     "\x1b[33m%s\x1b[0m",
-    "⚠️ WARNING: NEXT_PUBLIC_SITE_URL is not set in the production environment. " +
-    "CORS will fall back to 'https://offer-hub.tech' which may cause client-side issues if the site is hosted elsewhere."
+    `⚠️ WARNING: NEXT_PUBLIC_SITE_URL is not set in the production environment. ` +
+    `CORS will fall back to '${SITE_URL_FALLBACK}' which may cause client-side issues if the site is hosted elsewhere.`
   );
 }
 
-const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://offer-hub.tech";
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || SITE_URL_FALLBACK;
 
 const corsHeaders = [
   { key: "Access-Control-Allow-Credentials", value: "true" },

--- a/src/app/accessibility/page.tsx
+++ b/src/app/accessibility/page.tsx
@@ -4,6 +4,8 @@ import { Navbar } from "@/components/layout/Navbar";
 import { Footer } from "@/components/layout/Footer";
 import { LoadingBar } from "@/components/ui/LoadingBar";
 import { Mail, AlertCircle, CheckCircle, ExternalLink, Headphones, Eye, Hand, Brain, MessageSquare } from "lucide-react";
+import { SOCIAL_TELEGRAM, SOCIAL_DISCORD } from "@/constants/social";
+import { GITHUB_REPO_URL } from "@/constants/github";
 
 const features = [
      {
@@ -63,21 +65,21 @@ const contactMethods = [
           method: "Telegram",
           description: "For users who cannot use email",
           value: "@offer_hub_contributors",
-          href: "https://t.me/offer_hub_contributors",
+           href: SOCIAL_TELEGRAM,
           external: true,
      },
      {
           method: "Discord",
           description: "Community support in #support channel",
           value: "OFFER-HUB Community Server",
-          href: "https://discord.gg/yH4vBNWwc",
+           href: SOCIAL_DISCORD,
           external: true,
      },
      {
           method: "GitHub Issues",
           description: "For technical accessibility problems",
           value: "Label with 'accessibility' tag",
-          href: "https://github.com/OFFER-HUB/offer-hub-monorepo/issues",
+           href: `${GITHUB_REPO_URL}/issues`,
           external: true,
      },
 ];

--- a/src/app/changelog/page.tsx
+++ b/src/app/changelog/page.tsx
@@ -2,7 +2,8 @@ import type { Metadata } from "next";
 import { Navbar } from "@/components/layout/Navbar";
 import { Footer } from "@/components/layout/Footer";
 import { buildPageMetadata } from "@/lib/seo";
-import { fetchChangelogEntries } from "@/services/github";
+import type { GitHubRelease } from "@/types/github";
+import { GITHUB_RELEASES_API_URL } from "@/constants/github";
 
 export const metadata: Metadata = buildPageMetadata({
   title: "Changelog",
@@ -18,6 +19,128 @@ export const metadata: Metadata = buildPageMetadata({
   path: "/changelog",
   ogImageAlt: "OFFER-HUB Changelog — releases, improvements, and fixes",
 });
+
+interface ChangelogEntry {
+  version: string;
+  date: string;
+  title: string;
+  badge: string;
+  badgeColor: string;
+  description: string;
+  changes: string[];
+}
+
+const RELEASES_API_URL = GITHUB_RELEASES_API_URL;
+
+function formatReleaseDate(dateString: string): string {
+  return new Intl.DateTimeFormat("en-US", {
+    month: "long",
+    year: "numeric",
+  }).format(new Date(dateString));
+}
+
+function removeMarkdownInlineSyntax(text: string): string {
+  return text
+    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, "$1")
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/\*\*([^*]+)\*\*/g, "$1")
+    .replace(/\*([^*]+)\*/g, "$1")
+    .replace(/__([^_]+)__/g, "$1")
+    .replace(/_([^_]+)_/g, "$1")
+    .trim();
+}
+
+function parseReleaseBody(body: string | null): Pick<ChangelogEntry, "description" | "changes"> {
+  const rawBody = body?.trim();
+
+  if (!rawBody) {
+    return {
+      description: "No release notes were provided for this version.",
+      changes: ["See full release details on GitHub."],
+    };
+  }
+
+  const lines = rawBody
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  const changes = lines
+    .map((line) => line.match(/^[-*+]\s+(.+)$/)?.[1] ?? line.match(/^\d+\.\s+(.+)$/)?.[1] ?? null)
+    .filter((line): line is string => Boolean(line))
+    .map(removeMarkdownInlineSyntax);
+
+  const firstMeaningfulLine = lines.find(
+    (line) => !/^[-*+]\s+/.test(line) && !/^\d+\.\s+/.test(line) && !/^#+\s+/.test(line),
+  );
+
+  return {
+    description: firstMeaningfulLine
+      ? removeMarkdownInlineSyntax(firstMeaningfulLine)
+      : "Release notes are available in the full GitHub release details.",
+    changes: changes.length > 0 ? changes : ["See full release details on GitHub."],
+  };
+}
+
+function getReleaseBadge(release: Pick<GitHubRelease, "draft" | "prerelease">): Pick<ChangelogEntry, "badge" | "badgeColor"> {
+  if (release.draft) {
+    return {
+      badge: "Draft",
+      badgeColor: "bg-content-secondary/10 text-content-secondary",
+    };
+  }
+
+  if (release.prerelease) {
+    return {
+      badge: "Pre-release",
+      badgeColor: "bg-theme-warning/10 text-theme-warning",
+    };
+  }
+
+  return {
+    badge: "Release",
+    badgeColor: "bg-theme-success/10 text-theme-success",
+  };
+}
+
+function mapReleaseToEntry(release: GitHubRelease): ChangelogEntry {
+  const { description, changes } = parseReleaseBody(release.body);
+  const badge = getReleaseBadge(release);
+
+  return {
+    version: release.tag_name,
+    date: formatReleaseDate(release.published_at ?? release.created_at),
+    title: release.name?.trim() || `Release ${release.tag_name}`,
+    description,
+    changes,
+    ...badge,
+  };
+}
+
+async function fetchChangelogEntries(): Promise<{ entries: ChangelogEntry[]; hasError: boolean }> {
+  try {
+    const response = await fetch(RELEASES_API_URL, {
+      next: { revalidate: 3600 },
+      headers: {
+        Accept: "application/vnd.github+json",
+      },
+    });
+
+    if (!response.ok) {
+      return { entries: [], hasError: true };
+    }
+
+    const releases = (await response.json()) as GitHubRelease[];
+
+    return {
+      entries: releases.map(mapReleaseToEntry),
+      hasError: false,
+    };
+  } catch (error) {
+    console.error("Failed to fetch GitHub releases:", error);
+    return { entries: [], hasError: true };
+  }
+}
 
 export default async function ChangelogPage() {
   const { entries: changelogEntries, hasError } = await fetchChangelogEntries();

--- a/src/app/community/page.tsx
+++ b/src/app/community/page.tsx
@@ -11,7 +11,9 @@ import { LoadingBar } from "@/components/ui/LoadingBar";
 import { Footer } from "@/components/layout/Footer";
 import { Navbar } from "@/components/layout/Navbar";
 import { buildPageMetadata } from "@/lib/seo";
-import { fetchCommunityData } from "@/services/github";
+import type { PullRequestData } from "@/types/community";
+import type { RepoStats, ContributorData, IssueData, CommunityData } from "@/types/community";
+import type { Contributor, GitHubRepo, GitHubPullRequest, GitHubIssue } from "@/types/github";
 
 export const revalidate = 600;
 
@@ -31,8 +33,138 @@ export const metadata: Metadata = buildPageMetadata({
   ogImageAlt: "OFFER-HUB Community — contributors, issues, and pull requests",
 });
 
+const formatNumber = (num: number): string => {
+  if (num >= 1000) {
+    return `${(num / 1000).toFixed(1)}k`;
+  }
+  return num.toString();
+};
+
+function formatTimeAgo(dateString: string): string {
+  const date = new Date(dateString);
+  const now = new Date();
+  const diffInMs = now.getTime() - date.getTime();
+  const diffInDays = Math.floor(diffInMs / (1000 * 60 * 60 * 24));
+
+  if (diffInDays === 0) return "today";
+  if (diffInDays === 1) return "1 day ago";
+  if (diffInDays < 7) return `${diffInDays} days ago`;
+  if (diffInDays < 14) return "1 week ago";
+  if (diffInDays < 30) return `${Math.floor(diffInDays / 7)} weeks ago`;
+  if (diffInDays < 60) return "1 month ago";
+  return `${Math.floor(diffInDays / 30)} months ago`;
+}
+
+const REPOS = [
+  'OFFER-HUB/offer-hub-monorepo',
+  'OFFER-HUB/OFFER-HUB',
+  'OFFER-HUB/OFFER-HUB-Frontend',
+];
+
+function processGitHubData(validData: NonNullable<Awaited<ReturnType<typeof fetchRepoData>>>[]): CommunityData {
+  const totalStars = validData.reduce((acc, d) => acc + d.repo.stargazers_count, 0);
+  const totalForks = validData.reduce((acc, d) => acc + d.repo.forks_count, 0);
+  const totalOpenIssues = validData.reduce((acc, d) => acc + d.repo.open_issues_count, 0);
+
+  const contribMap = new Map<string, ContributorData>();
+  validData.forEach(d => {
+    d.contributors.forEach(c => {
+      const existing = contribMap.get(c.login);
+      if (existing) {
+        existing.commits += c.contributions;
+      } else {
+        contribMap.set(c.login, {
+          name: c.login, username: c.login, avatar: c.avatar_url,
+          commits: c.contributions, profileUrl: c.html_url
+        });
+      }
+    });
+  });
+  const contributors = Array.from(contribMap.values()).sort((a, b) => b.commits - a.commits);
+
+  const stats: RepoStats = {
+    stars: formatNumber(totalStars), forks: formatNumber(totalForks),
+    contributors: formatNumber(contributors.length), openIssues: formatNumber(totalOpenIssues),
+  };
+
+  const allPRs = validData.flatMap(d => d.pullRequests)
+    .map(pr => ({
+      number: pr.number,
+      title: pr.title,
+      author: pr.user?.login || "Unknown",
+      timestamp: pr.state === 'open' ? pr.created_at : pr.merged_at || pr.created_at,
+      url: pr.html_url,
+      status: (pr.state === 'open' ? 'Open' : 'Merged') as 'Open' | 'Merged' | 'Closed'
+    }))
+    .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
+
+  const pullRequests: PullRequestData[] = allPRs.slice(0, 30).map(pr => ({ ...pr, timestamp: formatTimeAgo(pr.timestamp) }));
+
+  const allIssues = validData.flatMap(d => d.issues)
+    .filter(issue => !issue.pull_request)
+    .map(issue => {
+      const priorityLabel = issue.labels.find(label => label.name.toLowerCase().includes('priority'));
+      let priority = "Medium";
+      if (priorityLabel) {
+        const labelName = priorityLabel.name.toLowerCase();
+        if (labelName.includes('high') || labelName.includes('critical')) priority = "High";
+        else if (labelName.includes('low')) priority = "Low";
+      }
+      return { number: issue.number, title: issue.title, priority, url: issue.html_url, labels: issue.labels.map(l => l.name), createdAt: issue.created_at || "" };
+    })
+    .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+  const issues: IssueData[] = allIssues.slice(0, 50).map(({ number, title, priority, url, labels }) => ({
+    number,
+    title,
+    priority,
+    url,
+    labels,
+  }));
+
+  return { stats, contributors, pullRequests, issues };
+}
+
+async function fetchRepoData(repo: string) {
+  const cacheOpts = { next: { revalidate: 600 } };
+  const [repoRes, contribRes, prRes, issueRes] = await Promise.all([
+    fetch(`https://api.github.com/repos/${repo}`, cacheOpts),
+    fetch(`https://api.github.com/repos/${repo}/contributors?per_page=100`, cacheOpts),
+    fetch(`https://api.github.com/repos/${repo}/pulls?state=all&sort=updated&direction=desc&per_page=20`, cacheOpts),
+    fetch(`https://api.github.com/repos/${repo}/issues?state=open&sort=created&direction=desc&per_page=20`, cacheOpts),
+  ]);
+
+  if (!repoRes.ok || !contribRes.ok || !prRes.ok || !issueRes.ok) return null;
+
+  return {
+    repo: await repoRes.json() as GitHubRepo,
+    contributors: await contribRes.json() as Contributor[],
+    pullRequests: await prRes.json() as GitHubPullRequest[],
+    issues: await issueRes.json() as GitHubIssue[],
+  };
+}
+
+async function fetchGitHubData() {
+  try {
+    const allPills = await Promise.all(REPOS.map(fetchRepoData));
+
+    const validData = allPills.filter((d): d is NonNullable<typeof d> => d !== null);
+
+    if (validData.length === 0) throw new Error('Failed to fetch any repo data');
+
+    return processGitHubData(validData);
+  } catch (error) {
+    console.error('Error fetching GitHub data:', error);
+    return {
+      stats: null,
+      contributors: [],
+      pullRequests: [],
+      issues: [],
+    } as CommunityData;
+  }
+}
+
 export default async function CommunityPage() {
-  const { stats, contributors, pullRequests, issues } = await fetchCommunityData();
+  const { stats, contributors, pullRequests, issues } = await fetchGitHubData();
 
   return (
     <>

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -5,6 +5,7 @@ import { DocsSearchBar } from "@/components/docs/DocsSearchBar";
 import { Book, Code, Shield, LifeBuoy, Terminal, Zap, ChevronRight, Lock } from "lucide-react";
 import Link from "next/link";
 import { cn } from "@/lib/cn";
+import { GITHUB_REPO_URL } from "@/constants/github";
 
 const docSections = [
   {
@@ -202,7 +203,7 @@ export default function DocsPage() {
           <div className="flex justify-center items-center gap-8">
             <Link href="/community" className="text-theme-primary font-black uppercase tracking-widest text-xs hover:tracking-[0.2em] transition-all">Help Center</Link>
             <span className="w-1.5 h-1.5 rounded-full bg-theme-border/40" />
-            <Link href="https://github.com/OFFER-HUB/offer-hub-monorepo/issues" className="text-theme-primary font-black uppercase tracking-widest text-xs hover:tracking-[0.2em] transition-all">GitHub Issues</Link>
+            <Link href={`${GITHUB_REPO_URL}/issues`} className="text-theme-primary font-black uppercase tracking-widest text-xs hover:tracking-[0.2em] transition-all">GitHub Issues</Link>
           </div>
         </div>
       </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,7 @@ import { NavigationProgress } from "@/components/ui/NavigationProgress";
 import { FloatingCTA } from "@/components/ui/FloatingCTA";
 import { ThemeProvider } from "@/components/providers/ThemeProvider";
 import { CookieConsentBanner } from "@/components/CookieConsentBanner";
+import { SITE_URL_FALLBACK, SITE_NAME } from "@/constants/site";
 
 const inter = Inter({
   subsets: ["latin"],
@@ -30,8 +31,8 @@ export const viewport = {
 
 export const metadata: Metadata = {
   title: {
-    default: "OFFER-HUB",
-    template: "%s | OFFER-HUB",
+    default: SITE_NAME,
+    template: `%s | ${SITE_NAME}`,
   },
   description:
     "OFFER-HUB empowers marketplaces to provide secure, non-custodial escrow payments without building complex payment infrastructure.",
@@ -42,7 +43,7 @@ export const metadata: Metadata = {
   // Eliminates the "metadataBase property in metadata export is not set" build
   // warning and prevents search engines from indexing duplicate versions of the
   // site (e.g. www subdomain, Vercel preview URLs).
-  metadataBase: new URL("https://offer-hub.tech"),
+  metadataBase: new URL(SITE_URL_FALLBACK),
 
   // ── Canonical URL ─────────────────────────────────────────────────────────
   // Next.js resolves '/' against metadataBase and injects
@@ -87,8 +88,8 @@ export const metadata: Metadata = {
     title: "OFFER-HUB | The Future of On-Chain Bounties",
     description:
       "OFFER-HUB empowers marketplaces to provide secure, non-custodial escrow payments without building complex payment infrastructure.",
-    url: "https://offer-hub.tech",
-    siteName: "OFFER-HUB",
+    url: SITE_URL_FALLBACK,
+    siteName: SITE_NAME,
     images: [
       {
         url: "/og-image.png",

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -7,6 +7,7 @@ import { Footer } from "@/components/layout/Footer";
 import { Navbar } from "@/components/layout/Navbar";
 import { LoadingBar } from "@/components/ui/LoadingBar";
 import { buildPageMetadata } from "@/lib/seo";
+import { GITHUB_REPO_URL } from "@/constants/github";
 
 export const metadata: Metadata = buildPageMetadata({
   title: "Pricing",
@@ -49,7 +50,7 @@ const tiers: PricingTier[] = [
       "Ideal for prototypes, pilots, and technical evaluation",
     ],
     ctaLabel: "View on GitHub",
-    ctaHref: "https://github.com/OFFER-HUB/offer-hub-monorepo",
+    ctaHref: GITHUB_REPO_URL,
     ctaStyle: "secondary",
     external: true,
     icon: Code2,

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,8 +1,9 @@
 import { MetadataRoute } from 'next';
 import docsIndex from '@/data/docs-index.json';
+import { SITE_URL_FALLBACK } from '@/constants/site';
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const baseUrl = 'https://offer-hub.tech';
+  const baseUrl = SITE_URL_FALLBACK;
 
   const staticRoutes = [
     '',
@@ -14,6 +15,8 @@ export default function sitemap(): MetadataRoute.Sitemap {
     '/docs',
     '/terms',
     '/privacy',
+    '/contact',
+    '/accessibility',
   ];
 
   const sitemapEntries: MetadataRoute.Sitemap = staticRoutes.map((route) => ({

--- a/src/components/Analytics.tsx
+++ b/src/components/Analytics.tsx
@@ -3,12 +3,13 @@
 import { useEffect } from 'react';
 import { usePathname } from 'next/navigation';
 import { trackPageView } from '@/services/analytics';
+import { COOKIE_CONSENT_KEY } from '@/constants/storage';
 
 export function Analytics() {
   const pathname = usePathname();
 
   useEffect(() => {
-    if (localStorage.getItem("cookie_consent") === "accepted") {
+    if (localStorage.getItem(COOKIE_CONSENT_KEY) === "accepted") {
       trackPageView(pathname);
     }
   }, [pathname]);

--- a/src/components/CookieConsentBanner.tsx
+++ b/src/components/CookieConsentBanner.tsx
@@ -2,15 +2,14 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
-
-const CONSENT_KEY = "cookie_consent";
-const COOKIE_PREFERENCES_EVENT = "cookie-preferences-open";
+import { COOKIE_CONSENT_KEY } from "@/constants/storage";
+import { COOKIE_PREFERENCES_EVENT } from "@/constants/events";
 
 export function CookieConsentBanner() {
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
-    if (!localStorage.getItem(CONSENT_KEY)) {
+    if (!localStorage.getItem(COOKIE_CONSENT_KEY)) {
       setVisible(true);
     }
 
@@ -29,12 +28,12 @@ export function CookieConsentBanner() {
   }, []);
 
   const accept = () => {
-    localStorage.setItem(CONSENT_KEY, "accepted");
+    localStorage.setItem(COOKIE_CONSENT_KEY, "accepted");
     setVisible(false);
   };
 
   const reject = () => {
-    localStorage.setItem(CONSENT_KEY, "rejected");
+    localStorage.setItem(COOKIE_CONSENT_KEY, "rejected");
     setVisible(false);
   };
 

--- a/src/components/blueprint/OrchestratorShowcase.data.ts
+++ b/src/components/blueprint/OrchestratorShowcase.data.ts
@@ -1,5 +1,6 @@
 import { Shield, Cpu, Workflow } from "lucide-react";
 import { FlowNode, DetailCard } from "./OrchestratorShowcase.types";
+import { DOCS_REPO_BLOB_BASE } from "@/constants/github";
 
 export const flowNodes: FlowNode[] = [
   { id: "input", label: "Input", sublabel: "Fiat / Crypto", x: 120, y: 168 },
@@ -23,7 +24,7 @@ export const detailCards: DetailCard[] = [
     callout: "The first gate guarantees the orchestrator never mixes custody states across counterparties.",
     method: "prepare()",
     docHref:
-      "https://github.com/OFFER-HUB/offer-hub-monorepo/blob/main/docs/architecture/overview.md",
+      `${DOCS_REPO_BLOB_BASE}/docs/architecture/overview.md`,
     docLabel: "Architecture overview",
   },
   {
@@ -41,7 +42,7 @@ export const detailCards: DetailCard[] = [
     callout: "Liquidity is reserved before release, so the visible seller payout is backed by an available trustline path.",
     method: "authorize()",
     docHref:
-      "https://github.com/OFFER-HUB/offer-hub-monorepo/blob/main/docs/architecture/payment-flows.md",
+      `${DOCS_REPO_BLOB_BASE}/docs/architecture/payment-flows.md`,
     docLabel: "Payment flows",
   },
   {
@@ -59,7 +60,7 @@ export const detailCards: DetailCard[] = [
     callout: "The SDK turns complex backend choreography into a small set of explicit method calls and irreversible checkpoints.",
     method: "finalize()",
     docHref:
-      "https://github.com/OFFER-HUB/offer-hub-monorepo/blob/main/docs/architecture/data-model.md",
+      `${DOCS_REPO_BLOB_BASE}/docs/architecture/data-model.md`,
     docLabel: "Data model",
   },
 ];

--- a/src/components/community/CommunityChannelsSection.tsx
+++ b/src/components/community/CommunityChannelsSection.tsx
@@ -3,30 +3,32 @@
 import { ArrowUpRight, Disc3, Github, Send, Twitter } from "lucide-react";
 import { motion } from "framer-motion";
 import { SectionHeading } from "@/components/community/SectionHeading";
+import { SOCIAL_DISCORD, SOCIAL_TELEGRAM, SOCIAL_X } from "@/constants/social";
+import { GITHUB_ORG_URL } from "@/constants/github";
 
 const channels = [
   {
     name: "Discord",
     description: "Real-time discussions, pairing, and contributor office hours.",
-    href: "https://discord.gg/yH4vBNWwc",
+    href: SOCIAL_DISCORD,
     icon: Disc3,
   },
   {
     name: "Telegram",
     description: "Fast async updates for announcements and roadmap drops.",
-    href: "https://t.me/offer_hub_contributors",
+    href: SOCIAL_TELEGRAM,
     icon: Send,
   },
   {
     name: "X",
     description: "Community highlights, release threads, and ecosystem news.",
-    href: "https://x.com/offerhub_",
+    href: SOCIAL_X,
     icon: Twitter,
   },
   {
     name: "GitHub",
     description: "Open source repositories, pull requests, and roadmap items.",
-    href: "https://github.com/OFFER-HUB",
+    href: GITHUB_ORG_URL,
     icon: Github,
   },
 ];

--- a/src/components/community/ContributorGrid.tsx
+++ b/src/components/community/ContributorGrid.tsx
@@ -1,4 +1,5 @@
 import { SectionHeading } from "@/components/community/SectionHeading";
+import { GITHUB_REPO_URL } from "@/constants/github";
 
 interface Contributor {
   name: string;
@@ -69,7 +70,7 @@ export function ContributorGrid({ contributors }: ContributorGridProps) {
 
         <div className="mt-12 text-center">
           <a
-            href="https://github.com/OFFER-HUB/offer-hub-monorepo/graphs/contributors"
+                        href={`${GITHUB_REPO_URL}/graphs/contributors`}
             target="_blank"
             rel="noopener noreferrer"
             className="inline-block px-6 py-3 rounded-xl text-sm font-semibold transition-all duration-[400ms] ease-out border border-theme-primary text-theme-primary hover:shadow-neu-raised-hover"

--- a/src/components/community/ContributorsSection.tsx
+++ b/src/components/community/ContributorsSection.tsx
@@ -4,14 +4,7 @@ import { useState, memo } from "react";
 import { Users, GitCommit, ChevronDown } from "lucide-react";
 import { SectionHeading } from "@/components/community/SectionHeading";
 import Image from "next/image";
-
-interface ContributorData {
-  name: string;
-  username: string;
-  avatar: string;
-  commits: number;
-  profileUrl: string;
-}
+import type { ContributorData } from "@/types/community";
 
 interface ContributorsSectionProps {
   contributors: ContributorData[];

--- a/src/components/community/HeroRepoStatsSection.tsx
+++ b/src/components/community/HeroRepoStatsSection.tsx
@@ -1,11 +1,6 @@
 import { Star, GitFork, Users, AlertCircle } from "lucide-react";
-
-interface RepoStats {
-  stars: string;
-  forks: string;
-  contributors: string;
-  openIssues: string;
-}
+import type { RepoStats } from "@/types/community";
+import { GITHUB_REPO_URL } from "@/constants/github";
 
 interface HeroRepoStatsSectionProps {
   stats: RepoStats | null;
@@ -40,7 +35,7 @@ export const HeroRepoStatsSection = ({ stats }: HeroRepoStatsSectionProps) => {
 
             <div className="mt-10 flex flex-wrap gap-4">
               <a
-                href="https://github.com/OFFER-HUB/offer-hub-monorepo"
+                href={GITHUB_REPO_URL}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="px-8 py-4 rounded-xl bg-content-primary text-white text-xs font-black uppercase tracking-widest shadow-xl shadow-content-primary/20 hover:bg-black transition-all"

--- a/src/components/community/HowToContribute.tsx
+++ b/src/components/community/HowToContribute.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { Code, BookOpen, PenTool, Bug } from "lucide-react";
+import { GITHUB_REPO_URL } from "@/constants/github";
 
 const steps = [
     { number: "01", title: "Fork", description: "Fork the repository to your own GitHub account." },
@@ -85,7 +86,7 @@ export function HowToContribute() {
                 {/* CTAs */}
                 <div className="flex flex-col sm:flex-row items-center justify-center gap-6">
                     <Link
-                        href="https://github.com/OFFER-HUB/offer-hub-monorepo/issues"
+                        href={`${GITHUB_REPO_URL}/issues`}
                         target="_blank"
                         rel="noopener noreferrer"
                         className="btn-neumorphic-primary px-8 py-4 rounded-xl font-medium flex items-center gap-2"

--- a/src/components/community/OpenIssuesSection.tsx
+++ b/src/components/community/OpenIssuesSection.tsx
@@ -4,14 +4,7 @@ import { useState, memo, useMemo } from "react";
 import { Tag, ArrowUpRight, ChevronDown } from "lucide-react";
 import { SectionHeading } from "@/components/community/SectionHeading";
 import { cn } from "@/lib/cn";
-
-interface IssueData {
-  number: number;
-  title: string;
-  priority: string;
-  url: string;
-  labels: string[];
-}
+import type { IssueData } from "@/types/community";
 
 interface OpenIssuesSectionProps {
   issues: IssueData[];

--- a/src/components/community/RecentPRsSection.tsx
+++ b/src/components/community/RecentPRsSection.tsx
@@ -3,17 +3,9 @@
 import { memo } from "react";
 import { GitPullRequest, Timer, User, ArrowUpRight } from "lucide-react";
 import { SectionHeading } from "@/components/community/SectionHeading";
+import type { PullRequestData } from "@/types/community";
 
-export interface PullRequestData {
-  number: number;
-  title: string;
-  author: string;
-  timestamp: string;
-  url: string;
-  status: 'Open' | 'Merged' | 'Closed';
-}
-
-export interface RecentPRsSectionProps {
+interface RecentPRsSectionProps {
   pullRequests: PullRequestData[];
 }
 

--- a/src/components/community/RepoLinksSection.tsx
+++ b/src/components/community/RepoLinksSection.tsx
@@ -1,19 +1,20 @@
 import { Github, FolderGit2 } from "lucide-react";
+import { GITHUB_CORE_URL, GITHUB_UI_URL, GITHUB_REPO_URL } from "@/constants/github";
 
 const repos = [
     {
         name: "OFFER-HUB Core",
-        url: "https://github.com/OFFER-HUB/OFFER-HUB",
+        url: GITHUB_CORE_URL,
         description: "The decentralized payment engine",
     },
     {
         name: "OFFER-HUB UI",
-        url: "https://github.com/OFFER-HUB/OFFER-HUB-Frontend",
+        url: GITHUB_UI_URL,
         description: "The primary workspace portal",
     },
     {
         name: "OFFER-HUB Mono",
-        url: "https://github.com/OFFER-HUB/offer-hub-monorepo",
+        url: GITHUB_REPO_URL,
         description: "Modern marketplace orchestrator",
     },
 ];

--- a/src/components/docs/Breadcrumb.tsx
+++ b/src/components/docs/Breadcrumb.tsx
@@ -4,8 +4,9 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useMemo } from "react";
 import { ChevronRight, Home } from "lucide-react";
+import { SITE_URL_FALLBACK } from "@/constants/site";
 
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://offer-hub.tech";
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || SITE_URL_FALLBACK;
 
 function formatSegment(segment: string): string {
   return decodeURIComponent(segment)

--- a/src/components/docs/DocPageActions.tsx
+++ b/src/components/docs/DocPageActions.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from "react";
 import { Download, FileCode2, FileText, Github } from "lucide-react";
 
 import { ExportJSON } from "@/components/docs/ExportJSON";
+import { DOCS_REPO_BASE } from "@/constants/github";
 import { logger } from "@/utils/logger";
 
 interface DocPageActionsProps {
@@ -12,8 +13,6 @@ interface DocPageActionsProps {
   description?: string;
   markdownContent: string;
 }
-
-const DOCS_REPO_BASE = "https://github.com/OFFER-HUB/offer-hub-monorepo/blob/main/content/docs";
 
 function dateStamp() {
   return new Date().toISOString().split("T")[0];

--- a/src/components/docs/DocsLayoutShell.tsx
+++ b/src/components/docs/DocsLayoutShell.tsx
@@ -13,6 +13,7 @@ import { Breadcrumb } from "@/components/docs/Breadcrumb";
 import { FileCode2, FileText, Github } from "lucide-react";
 import { useFocusTrap } from "@/hooks/useFocusTrap";
 import { SITE_URL_FALLBACK } from "@/constants/site";
+import { DOCS_REPO_BASE } from "@/constants/github";
 
 // Use production URL for AI assistant links
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || SITE_URL_FALLBACK;
@@ -64,7 +65,7 @@ export function DocsLayoutShell({ nav, children }: DocsLayoutShellProps) {
   // Inline DocActionsMenu to avoid missing import error
   function DocActionsMenu({ slug }: { slug: string }) {
     const viewUrl = `${SITE_URL}/docs/${slug}`;
-    const githubUrl = `https://github.com/offer-hub/offer-hub-monorepo/blob/main/apps/www/src/content/docs/${slug}.mdx`;
+    const githubUrl = `${DOCS_REPO_BASE}/${slug}.mdx`;
 
     return (
       <div className="flex items-center gap-3">

--- a/src/components/docs/DocsLayoutShell.tsx
+++ b/src/components/docs/DocsLayoutShell.tsx
@@ -12,9 +12,10 @@ import { Navbar } from "@/components/layout/Navbar";
 import { Breadcrumb } from "@/components/docs/Breadcrumb";
 import { FileCode2, FileText, Github } from "lucide-react";
 import { useFocusTrap } from "@/hooks/useFocusTrap";
+import { SITE_URL_FALLBACK } from "@/constants/site";
 
 // Use production URL for AI assistant links
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://offer-hub.tech";
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || SITE_URL_FALLBACK;
 
 interface DocsLayoutShellProps {
   nav: SidebarSection[];
@@ -237,4 +238,3 @@ export function DocsLayoutShell({ nav, children }: DocsLayoutShellProps) {
     </div>
   );
 }
-

--- a/src/components/docs/EditOnGitHub.tsx
+++ b/src/components/docs/EditOnGitHub.tsx
@@ -1,11 +1,12 @@
 import { Pencil } from 'lucide-react';
+import { DOCS_EDIT_BASE } from '@/constants/github';
 
 interface EditOnGitHubProps {
   filePath: string;
 }
 
 export function EditOnGitHub({ filePath }: EditOnGitHubProps) {
-  const githubEditUrl = `https://github.com/OFFER-HUB/offer-hub-monorepo/edit/main/${filePath}`;
+  const githubEditUrl = `${DOCS_EDIT_BASE}/${filePath}`;
 
   return (
     <a

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -5,8 +5,9 @@ import Image from "next/image";
 import Link from "next/link";
 import { Twitter, Send, Github, Disc3 } from "lucide-react";
 import { useTheme } from "@/components/providers/ThemeProvider";
-
-const COOKIE_PREFERENCES_EVENT = "cookie-preferences-open";
+import { COOKIE_PREFERENCES_EVENT } from "@/constants/events";
+import { SOCIAL_X, SOCIAL_TELEGRAM, SOCIAL_DISCORD } from "@/constants/social";
+import { GITHUB_ORG_URL } from "@/constants/github";
 
 const navColumns = [
   {
@@ -38,10 +39,10 @@ const navColumns = [
 ];
 
 const socialLinks = [
-  { href: "https://x.com/offerhub_", icon: Twitter, label: "X" },
-  { href: "https://t.me/offer_hub_contributors", icon: Send, label: "Telegram" },
-  { href: "https://discord.gg/yH4vBNWwc", icon: Disc3, label: "Discord" },
-  { href: "https://github.com/OFFER-HUB", icon: Github, label: "GitHub" },
+  { href: SOCIAL_X, icon: Twitter, label: "X" },
+  { href: SOCIAL_TELEGRAM, icon: Send, label: "Telegram" },
+  { href: SOCIAL_DISCORD, icon: Disc3, label: "Discord" },
+  { href: GITHUB_ORG_URL, icon: Github, label: "GitHub" },
 ];
 
 export function Footer() {

--- a/src/components/mdx/PrivacyComponents.tsx
+++ b/src/components/mdx/PrivacyComponents.tsx
@@ -5,7 +5,7 @@ import { getIcon, type IconName } from "@/lib/icon-registry";
 import { COMPANY_INFO } from "@/data/company-info";
 export { DataRightsForm };
 
-export function FeatureCard({
+export function PrivacyFeatureCard({
   title,
   description,
   iconName,
@@ -38,7 +38,7 @@ export function FeatureCard({
   );
 }
 
-export function FeaturesGrid({ children }: { children: React.ReactNode }): React.ReactElement {
+export function PrivacyFeaturesGrid({ children }: { children: React.ReactNode }): React.ReactElement {
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6 sm:gap-8 lg:gap-10 mb-5">
       {children}
@@ -148,8 +148,8 @@ export function ContactSection(): React.ReactElement {
 }
 
 export const MDX_PRIVACY_COMPONENTS = {
-  FeaturesGrid,
-  FeatureCard,
+  FeaturesGrid: PrivacyFeaturesGrid,
+  FeatureCard: PrivacyFeatureCard,
   ProcessorsGrid,
   ProcessorCard,
   ContactSection,

--- a/src/components/providers/ThemeProvider.tsx
+++ b/src/components/providers/ThemeProvider.tsx
@@ -3,6 +3,7 @@
 import { createContext, useContext, useEffect, useState, useCallback } from "react";
 import { flushSync } from "react-dom";
 import { MotionConfig } from "framer-motion";
+import { THEME_STORAGE_KEY } from "@/constants/storage";
 
 type Theme = "light" | "dark" | "system";
 type ResolvedTheme = "light" | "dark";
@@ -16,8 +17,6 @@ interface ThemeContextType {
 
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
-const STORAGE_KEY = "offer-hub-theme";
-
 function getSystemTheme(): ResolvedTheme {
   if (typeof window === "undefined") return "light";
   return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
@@ -30,7 +29,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
 
   // Initialize theme from localStorage
   useEffect(() => {
-    const stored = localStorage.getItem(STORAGE_KEY) as Theme | null;
+    const stored = localStorage.getItem(THEME_STORAGE_KEY) as Theme | null;
     if (stored && ["light", "dark", "system"].includes(stored)) {
       setThemeState(stored);
     }
@@ -63,7 +62,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
 
   const setTheme = useCallback((newTheme: Theme) => {
     setThemeState(newTheme);
-    localStorage.setItem(STORAGE_KEY, newTheme);
+    localStorage.setItem(THEME_STORAGE_KEY, newTheme);
   }, []);
 
   const toggleTheme = useCallback((event?: React.MouseEvent) => {

--- a/src/components/ui/FloatingCTA.tsx
+++ b/src/components/ui/FloatingCTA.tsx
@@ -3,8 +3,8 @@
 import { useState, useEffect } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import { X, ArrowRight } from "lucide-react";
+import { CTA_DISMISSED_KEY } from "@/constants/storage";
 
-const STORAGE_KEY = "offer-hub-cta-dismissed";
 const DISMISS_DURATION = 7 * 24 * 60 * 60 * 1000; // 7 days
 
 export function FloatingCTA() {
@@ -18,17 +18,17 @@ export function FloatingCTA() {
 
   useEffect(() => {
     // Check if dismissed recently
-    const dismissedAt = localStorage.getItem(STORAGE_KEY);
+    const dismissedAt = localStorage.getItem(CTA_DISMISSED_KEY);
     if (dismissedAt) {
       const parsed = parseInt(dismissedAt, 10);
       if (!Number.isFinite(parsed) || parsed < 0) {
-        localStorage.removeItem(STORAGE_KEY);
+        localStorage.removeItem(CTA_DISMISSED_KEY);
       } else {
         const elapsed = Date.now() - parsed;
         if (elapsed < DISMISS_DURATION) {
           return;
         }
-        localStorage.removeItem(STORAGE_KEY);
+        localStorage.removeItem(CTA_DISMISSED_KEY);
       }
     }
 
@@ -49,7 +49,7 @@ export function FloatingCTA() {
       setIsVisible(false);
       setTimeout(() => setIsAnimating(false), 300);
     } else if (!isExcludedPage && !isVisible) {
-      const dismissedAt = localStorage.getItem(STORAGE_KEY);
+      const dismissedAt = localStorage.getItem(CTA_DISMISSED_KEY);
       if (!dismissedAt) {
         setIsAnimating(true);
         setTimeout(() => setIsVisible(true), 50);
@@ -61,7 +61,7 @@ export function FloatingCTA() {
     setIsVisible(false);
     setTimeout(() => {
       setIsAnimating(false);
-      localStorage.setItem(STORAGE_KEY, Date.now().toString());
+      localStorage.setItem(CTA_DISMISSED_KEY, Date.now().toString());
     }, 300);
   };
 

--- a/src/components/ui/__tests__/FloatingCTA.test.tsx
+++ b/src/components/ui/__tests__/FloatingCTA.test.tsx
@@ -10,7 +10,7 @@ vi.mock("next/navigation", () => ({
   useRouter: () => ({ push }),
 }));
 
-const STORAGE_KEY = "offer-hub-cta-dismissed";
+import { CTA_DISMISSED_KEY } from "@/constants/storage";
 const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
 
 describe("FloatingCTA", () => {
@@ -26,7 +26,7 @@ describe("FloatingCTA", () => {
   });
 
   it("stays hidden while the dismiss flag is within its TTL", async () => {
-    localStorage.setItem(STORAGE_KEY, Date.now().toString());
+    localStorage.setItem(CTA_DISMISSED_KEY, Date.now().toString());
     render(<FloatingCTA />);
 
     await act(async () => {
@@ -37,7 +37,7 @@ describe("FloatingCTA", () => {
   });
 
   it("becomes visible again once the dismiss TTL has expired", async () => {
-    localStorage.setItem(STORAGE_KEY, (Date.now() - SEVEN_DAYS_MS - 1000).toString());
+    localStorage.setItem(CTA_DISMISSED_KEY, (Date.now() - SEVEN_DAYS_MS - 1000).toString());
     render(<FloatingCTA />);
 
     await act(async () => {
@@ -45,7 +45,7 @@ describe("FloatingCTA", () => {
     });
 
     expect(screen.getByText(/join the waitlist/i)).toBeInTheDocument();
-    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+    expect(localStorage.getItem(CTA_DISMISSED_KEY)).toBeNull();
   });
 
   it("shows the CTA when the page loads with no dismiss flag set", async () => {
@@ -72,6 +72,6 @@ describe("FloatingCTA", () => {
       await vi.advanceTimersByTimeAsync(350);
     });
 
-    expect(localStorage.getItem(STORAGE_KEY)).not.toBeNull();
+    expect(localStorage.getItem(CTA_DISMISSED_KEY)).not.toBeNull();
   });
 });

--- a/src/components/use-cases/dao-payroll/code-tabs.ts
+++ b/src/components/use-cases/dao-payroll/code-tabs.ts
@@ -4,6 +4,7 @@ import type {
   CodeTab,
   SdkCard,
 } from "@/components/use-cases/shared/CodeIntegrationShowcase";
+import { DOCS_REPO_BLOB_BASE } from "@/constants/github";
 
 export const description: CodeIntegrationShowcaseProps["description"] =
   "handles DAO payroll creation, treasury funding, and atomic contributor distribution in three explicit calls — no manual payroll management required.";
@@ -17,7 +18,7 @@ export const tabs: CodeTab[] = [
     description:
       "Payroll epoch creation and treasury escrow funding on the server side.",
     docHref:
-      "https://github.com/OFFER-HUB/offer-hub-monorepo/blob/main/docs/api/overview.md",
+      `${DOCS_REPO_BLOB_BASE}/docs/api/overview.md`,
     docLabel: "API Reference",
     code: `import { OfferHub } from "@offerhub/sdk";
 
@@ -49,7 +50,7 @@ await oh.escrows.fund(payroll.id, {
     description:
       "Milestone verification and payroll distribution — triggers on-chain settlement.",
     docHref:
-      "https://github.com/OFFER-HUB/offer-hub-monorepo/blob/main/docs/sdk/integration-guide.md",
+      `${DOCS_REPO_BLOB_BASE}/docs/sdk/integration-guide.md`,
     docLabel: "SDK Guide",
     code: `import { OfferHub } from "@offerhub/sdk";
 

--- a/src/components/use-cases/ecommerce/code-tabs.ts
+++ b/src/components/use-cases/ecommerce/code-tabs.ts
@@ -4,6 +4,7 @@ import type {
   CodeTab,
   SdkCard,
 } from "@/components/use-cases/shared/CodeIntegrationShowcase";
+import { DOCS_REPO_BLOB_BASE } from "@/constants/github";
 
 export const description: CodeIntegrationShowcaseProps["description"] =
   "handles order creation, escrow funding, and delivery confirmation in three explicit calls — no manual fund management required.";
@@ -16,7 +17,7 @@ export const tabs: CodeTab[] = [
     icon: Server,
     description: "Order creation and escrow funding on the server side.",
     docHref:
-      "https://github.com/OFFER-HUB/offer-hub-monorepo/blob/main/docs/api/overview.md",
+      `${DOCS_REPO_BLOB_BASE}/docs/api/overview.md`,
     docLabel: "API Reference",
     code: `import { OfferHub } from "@offerhub/sdk";
 
@@ -45,7 +46,7 @@ await oh.escrows.fund(order.id, {
     description:
       "Delivery confirmation from the buyer — triggers on-chain fund release.",
     docHref:
-      "https://github.com/OFFER-HUB/offer-hub-monorepo/blob/main/docs/sdk/integration-guide.md",
+      `${DOCS_REPO_BLOB_BASE}/docs/sdk/integration-guide.md`,
     docLabel: "SDK Guide",
     code: `import { OfferHub } from "@offerhub/sdk";
 

--- a/src/components/use-cases/freelance/code-tabs.ts
+++ b/src/components/use-cases/freelance/code-tabs.ts
@@ -4,6 +4,7 @@ import type {
   CodeTab,
   SdkCard,
 } from "@/components/use-cases/shared/CodeIntegrationShowcase";
+import { DOCS_REPO_BLOB_BASE } from "@/constants/github";
 
 export const description: CodeIntegrationShowcaseProps["description"] =
   "mirrors your orchestrator state with a small set of explicit method calls — escrow creation, vault funding, and milestone release in three lines.";
@@ -16,7 +17,7 @@ export const tabs: CodeTab[] = [
     icon: Server,
     description: "Order creation and escrow funding on the server side.",
     docHref:
-      "https://github.com/OFFER-HUB/offer-hub-monorepo/blob/main/docs/api/overview.md",
+      `${DOCS_REPO_BLOB_BASE}/docs/api/overview.md`,
     docLabel: "API Reference",
     code: `import { OfferHub } from "@offerhub/sdk";
 
@@ -48,7 +49,7 @@ await oh.escrows.fund(order.id, {
     description:
       "Milestone approval from the client side — triggers on-chain settlement.",
     docHref:
-      "https://github.com/OFFER-HUB/offer-hub-monorepo/blob/main/docs/sdk/integration-guide.md",
+      `${DOCS_REPO_BLOB_BASE}/docs/sdk/integration-guide.md`,
     docLabel: "SDK Guide",
     code: `import { OfferHub } from "@offerhub/sdk";
 

--- a/src/components/use-cases/real-estate/code-tabs.ts
+++ b/src/components/use-cases/real-estate/code-tabs.ts
@@ -4,6 +4,7 @@ import type {
   CodeTab,
   SdkCard,
 } from "@/components/use-cases/shared/CodeIntegrationShowcase";
+import { DOCS_REPO_BLOB_BASE } from "@/constants/github";
 
 export const description: CodeIntegrationShowcaseProps["description"] =
   "handles deposit initialization, vault funding, and inspection-gated release in three explicit calls — no escrow agent required.";
@@ -17,7 +18,7 @@ export const tabs: CodeTab[] = [
     description:
       "Deposit escrow initialization and vault funding on the server side.",
     docHref:
-      "https://github.com/OFFER-HUB/offer-hub-monorepo/blob/main/docs/api/overview.md",
+      `${DOCS_REPO_BLOB_BASE}/docs/api/overview.md`,
     docLabel: "API Reference",
     code: `import { OfferHub } from "@offerhub/sdk";
 
@@ -49,7 +50,7 @@ await oh.escrows.fund(deposit.id, {
     description:
       "Inspection verification and deposit settlement at lease end.",
     docHref:
-      "https://github.com/OFFER-HUB/offer-hub-monorepo/blob/main/docs/sdk/integration-guide.md",
+      `${DOCS_REPO_BLOB_BASE}/docs/sdk/integration-guide.md`,
     docLabel: "SDK Guide",
     code: `import { OfferHub } from "@offerhub/sdk";
 

--- a/src/components/use-cases/service-platforms/code-tabs.ts
+++ b/src/components/use-cases/service-platforms/code-tabs.ts
@@ -1,4 +1,5 @@
 import { Server, Monitor } from "lucide-react";
+import { DOCS_REPO_BLOB_BASE } from "@/constants/github";
 import type {
   CodeIntegrationShowcaseProps,
   CodeTab,
@@ -17,7 +18,7 @@ export const tabs: CodeTab[] = [
     description:
       "Service contract creation and budget funding on the server side.",
     docHref:
-      "https://github.com/OFFER-HUB/offer-hub-monorepo/blob/main/docs/api/overview.md",
+      `${DOCS_REPO_BLOB_BASE}/docs/api/overview.md`,
     docLabel: "API Reference",
     code: `import { OfferHub } from "@offerhub/sdk";
 
@@ -53,7 +54,7 @@ console.log("Contract funded:", escrow.status);
     description:
       "Milestone approval from the client side — releases the matching payment.",
     docHref:
-      "https://github.com/OFFER-HUB/offer-hub-monorepo/blob/main/docs/sdk/integration-guide.md",
+      `${DOCS_REPO_BLOB_BASE}/docs/sdk/integration-guide.md`,
     docLabel: "SDK Guide",
     code: `import { OfferHub } from "@offerhub/sdk";
 

--- a/src/constants/events.ts
+++ b/src/constants/events.ts
@@ -1,0 +1,1 @@
+export const COOKIE_PREFERENCES_EVENT = "cookie-preferences-open";

--- a/src/constants/github.ts
+++ b/src/constants/github.ts
@@ -1,0 +1,8 @@
+export const GITHUB_ORG_URL = "https://github.com/OFFER-HUB";
+export const GITHUB_REPO_URL = "https://github.com/OFFER-HUB/offer-hub-monorepo";
+export const GITHUB_CORE_URL = "https://github.com/OFFER-HUB/OFFER-HUB";
+export const GITHUB_UI_URL = "https://github.com/OFFER-HUB/OFFER-HUB-Frontend";
+export const GITHUB_RELEASES_API_URL = "https://api.github.com/repos/OFFER-HUB/offer-hub-monorepo/releases";
+export const DOCS_REPO_BASE = "https://github.com/OFFER-HUB/offer-hub-monorepo/blob/main/content/docs";
+export const DOCS_EDIT_BASE = "https://github.com/OFFER-HUB/offer-hub-monorepo/edit/main";
+export const DOCS_REPO_BLOB_BASE = "https://github.com/OFFER-HUB/offer-hub-monorepo/blob/main";

--- a/src/constants/site.ts
+++ b/src/constants/site.ts
@@ -1,0 +1,2 @@
+export const SITE_URL_FALLBACK = "https://offer-hub.tech";
+export const SITE_NAME = "OFFER-HUB";

--- a/src/constants/social.ts
+++ b/src/constants/social.ts
@@ -1,0 +1,3 @@
+export const SOCIAL_X = "https://x.com/offerhub_";
+export const SOCIAL_TELEGRAM = "https://t.me/offer_hub_contributors";
+export const SOCIAL_DISCORD = "https://discord.gg/yH4vBNWwc";

--- a/src/constants/storage.ts
+++ b/src/constants/storage.ts
@@ -1,0 +1,6 @@
+export const COOKIE_CONSENT_KEY = "cookie_consent";
+export const VISITOR_ID_KEY = "visitor_id";
+export const SESSION_ID_KEY = "session_id";
+export const GEO_CACHE_KEY = "geo_cache";
+export const THEME_STORAGE_KEY = "offer-hub-theme";
+export const CTA_DISMISSED_KEY = "offer-hub-cta-dismissed";

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
+import { SITE_URL_FALLBACK, SITE_NAME } from "@/constants/site";
 
-export const SITE_URL = "https://offer-hub.tech";
-export const SITE_NAME = "OFFER-HUB";
+export const SITE_URL = SITE_URL_FALLBACK;
 
 type PageSeoInput = {
   /** Feeds `metadata.title`, so the root layout's "%s | OFFER-HUB" template applies */

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -2,25 +2,26 @@ import { supabase, isSupabaseConfigured } from '@/lib/supabase';
 import { getBrowserName, getDeviceType, getOSName } from '@/utils/device';
 import { getGeolocation } from './geolocation';
 import { logger } from '@/utils/logger';
+import { COOKIE_CONSENT_KEY, VISITOR_ID_KEY, SESSION_ID_KEY } from '@/constants/storage';
 
 // Generate a unique visitor ID
 export function generateVisitorId(): string {
-  if (localStorage.getItem('cookie_consent') !== 'accepted') return '';
-  const stored = localStorage.getItem('visitor_id');
+  if (localStorage.getItem(COOKIE_CONSENT_KEY) !== 'accepted') return '';
+  const stored = localStorage.getItem(VISITOR_ID_KEY);
   if (stored) return stored;
 
   const visitorId = `visitor_${crypto.randomUUID()}`;
-  localStorage.setItem('visitor_id', visitorId);
+  localStorage.setItem(VISITOR_ID_KEY, visitorId);
   return visitorId;
 }
 
 // Get session ID
 export function getSessionId(): string {
-  const stored = sessionStorage.getItem('session_id');
+  const stored = sessionStorage.getItem(SESSION_ID_KEY);
   if (stored) return stored;
 
   const sessionId = `session_${crypto.randomUUID()}`;
-  sessionStorage.setItem('session_id', sessionId);
+  sessionStorage.setItem(SESSION_ID_KEY, sessionId);
   return sessionId;
 }
 
@@ -38,7 +39,7 @@ export function getUTMParams(): { utm_source?: string; utm_medium?: string; utm_
 
 // Track page view
 export async function trackPageView(pagePath: string, pageTitle?: string): Promise<void> {
-  if (typeof window !== 'undefined' && localStorage.getItem('cookie_consent') !== 'accepted') {
+  if (typeof window !== 'undefined' && localStorage.getItem(COOKIE_CONSENT_KEY) !== 'accepted') {
     return;
   }
   // Skip tracking if Supabase is not properly configured
@@ -98,7 +99,7 @@ export async function trackPageView(pagePath: string, pageTitle?: string): Promi
           browser: getBrowserName(),
           device: getDeviceType(),
           os: getOSName(),
-        }], { onConflict: 'visitor_id' })
+        }], { onConflict: VISITOR_ID_KEY })
         .then(({ error }) => {
           if (error) {
             const msg = (error as { message?: string })?.message ?? JSON.stringify(error);

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -1,39 +1,7 @@
-import type { PullRequestData } from "@/types/community";
+import type { RepoStats, ContributorData, IssueData, PullRequestData, CommunityData } from "@/types/community";
+import type { Contributor, GitHubRepo, GitHubPullRequest, GitHubIssue, GitHubRelease } from "@/types/github";
+import { GITHUB_RELEASES_API_URL } from "@/constants/github";
 import { logger } from '@/utils/logger';
-
-/* -------------------------------------------------------------------------- */
-/*                              Public data shapes                             */
-/* -------------------------------------------------------------------------- */
-
-export interface RepoStats {
-  stars: string;
-  forks: string;
-  contributors: string;
-  openIssues: string;
-}
-
-export interface ContributorData {
-  name: string;
-  username: string;
-  avatar: string;
-  commits: number;
-  profileUrl: string;
-}
-
-export interface IssueData {
-  number: number;
-  title: string;
-  priority: string;
-  url: string;
-  labels: string[];
-}
-
-export interface CommunityData {
-  stats: RepoStats | null;
-  contributors: ContributorData[];
-  pullRequests: PullRequestData[];
-  issues: IssueData[];
-}
 
 export interface ChangelogEntry {
   version: string;
@@ -43,56 +11,6 @@ export interface ChangelogEntry {
   badgeColor: string;
   description: string;
   changes: string[];
-}
-
-/* -------------------------------------------------------------------------- */
-/*                            Raw GitHub API shapes                            */
-/* -------------------------------------------------------------------------- */
-
-interface Contributor {
-  login: string;
-  avatar_url: string;
-  contributions: number;
-  html_url: string;
-}
-
-interface GitHubRepo {
-  stargazers_count: number;
-  forks_count: number;
-  open_issues_count: number;
-}
-
-interface GitHubPullRequest {
-  number: number;
-  title: string;
-  html_url: string;
-  state: string;
-  created_at: string;
-  merged_at: string | null;
-  user: {
-    login: string;
-  } | null;
-}
-
-interface GitHubIssue {
-  number: number;
-  title: string;
-  html_url: string;
-  pull_request?: object;
-  created_at?: string;
-  labels: Array<{
-    name: string;
-  }>;
-}
-
-interface GitHubRelease {
-  tag_name: string;
-  name: string | null;
-  body: string | null;
-  draft: boolean;
-  prerelease: boolean;
-  published_at: string | null;
-  created_at: string;
 }
 
 /* -------------------------------------------------------------------------- */
@@ -233,7 +151,7 @@ export async function fetchCommunityData() {
 /*                                  Changelog                                  */
 /* -------------------------------------------------------------------------- */
 
-const RELEASES_API_URL = "https://api.github.com/repos/OFFER-HUB/offer-hub-monorepo/releases";
+const RELEASES_API_URL = GITHUB_RELEASES_API_URL;
 
 function formatReleaseDate(dateString: string): string {
   return new Intl.DateTimeFormat("en-US", {

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -1,4 +1,4 @@
-import type { PullRequestData } from "@/components/community/RecentPRsSection";
+import type { PullRequestData } from "@/types/community";
 import { logger } from '@/utils/logger';
 
 /* -------------------------------------------------------------------------- */

--- a/src/types/community.ts
+++ b/src/types/community.ts
@@ -1,0 +1,38 @@
+export interface RepoStats {
+  stars: string;
+  forks: string;
+  contributors: string;
+  openIssues: string;
+}
+
+export interface ContributorData {
+  name: string;
+  username: string;
+  avatar: string;
+  commits: number;
+  profileUrl: string;
+}
+
+export interface IssueData {
+  number: number;
+  title: string;
+  priority: string;
+  url: string;
+  labels: string[];
+}
+
+export interface PullRequestData {
+  number: number;
+  title: string;
+  author: string;
+  timestamp: string;
+  url: string;
+  status: 'Open' | 'Merged' | 'Closed';
+}
+
+export interface CommunityData {
+  stats: RepoStats | null;
+  contributors: ContributorData[];
+  pullRequests: PullRequestData[];
+  issues: IssueData[];
+}

--- a/src/types/github.ts
+++ b/src/types/github.ts
@@ -1,0 +1,45 @@
+export interface Contributor {
+  login: string;
+  avatar_url: string;
+  contributions: number;
+  html_url: string;
+}
+
+export interface GitHubRepo {
+  stargazers_count: number;
+  forks_count: number;
+  open_issues_count: number;
+}
+
+export interface GitHubPullRequest {
+  number: number;
+  title: string;
+  html_url: string;
+  state: string;
+  created_at: string;
+  merged_at: string | null;
+  user: {
+    login: string;
+  } | null;
+}
+
+export interface GitHubIssue {
+  number: number;
+  title: string;
+  html_url: string;
+  pull_request?: object;
+  created_at?: string;
+  labels: Array<{
+    name: string;
+  }>;
+}
+
+export interface GitHubRelease {
+  tag_name: string;
+  name: string | null;
+  body: string | null;
+  draft: boolean;
+  prerelease: boolean;
+  published_at: string | null;
+  created_at: string;
+}


### PR DESCRIPTION
## Summary

Closes #1472

Centralizes duplicated domain types and repeated constants into `src/types/` and `src/constants/`.

This is a move/reorganization only — no intended logic or behavioral changes.

## Changes

### Types

Added centralized type definitions:

- `src/types/community.ts`
  - `RepoStats`
  - `ContributorData`
  - `IssueData`
  - `PullRequestData`
  - `CommunityData`
- `src/types/github.ts`
  - `Contributor`
  - `GitHubRepo`
  - `GitHubPullRequest`
  - `GitHubIssue`
  - `GitHubRelease`

Removed duplicate/local definitions from the community components, community page, and changelog page.

### Constants

Added `src/constants/` as the single source of truth for:

- Site URL fallback and site name
- GitHub repository URLs and docs/release URLs
- Social links
- `localStorage` / `sessionStorage` keys
- `cookie-preferences-open` event name

Updated existing consumers to use the centralized constants instead of repeated literals.

### Additional fixes

- Added `/contact` and `/accessibility` to the static sitemap routes.
- Resolved the `FeatureCard` / `FeaturesGrid` naming collision by renaming the privacy-specific implementations to `PrivacyFeatureCard` and `PrivacyFeaturesGrid`.
- Preserved the existing MDX API through `MDX_PRIVACY_COMPONENTS`.

## Verification

```text
npm run build
PASS

npm run lint
PASS : 0 warnings/errors

npx vitest run
PASS : 5 test files, 20 tests
```