### PR TITLE
refactor: introduce a services layer, isolate data-fetching and IO out of pages and components

### DIFF
--- a/src/app/changelog/page.tsx
+++ b/src/app/changelog/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Navbar } from "@/components/layout/Navbar";
 import { Footer } from "@/components/layout/Footer";
 import { buildPageMetadata } from "@/lib/seo";
+import { fetchChangelogEntries } from "@/services/github";
 
 export const metadata: Metadata = buildPageMetadata({
   title: "Changelog",
@@ -17,138 +18,6 @@ export const metadata: Metadata = buildPageMetadata({
   path: "/changelog",
   ogImageAlt: "OFFER-HUB Changelog — releases, improvements, and fixes",
 });
-
-interface GitHubRelease {
-  tag_name: string;
-  name: string | null;
-  body: string | null;
-  draft: boolean;
-  prerelease: boolean;
-  published_at: string | null;
-  created_at: string;
-}
-
-interface ChangelogEntry {
-  version: string;
-  date: string;
-  title: string;
-  badge: string;
-  badgeColor: string;
-  description: string;
-  changes: string[];
-}
-
-const RELEASES_API_URL = "https://api.github.com/repos/OFFER-HUB/offer-hub-monorepo/releases";
-
-function formatReleaseDate(dateString: string): string {
-  return new Intl.DateTimeFormat("en-US", {
-    month: "long",
-    year: "numeric",
-  }).format(new Date(dateString));
-}
-
-function removeMarkdownInlineSyntax(text: string): string {
-  return text
-    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, "$1")
-    .replace(/`([^`]+)`/g, "$1")
-    .replace(/\*\*([^*]+)\*\*/g, "$1")
-    .replace(/\*([^*]+)\*/g, "$1")
-    .replace(/__([^_]+)__/g, "$1")
-    .replace(/_([^_]+)_/g, "$1")
-    .trim();
-}
-
-function parseReleaseBody(body: string | null): Pick<ChangelogEntry, "description" | "changes"> {
-  const rawBody = body?.trim();
-
-  if (!rawBody) {
-    return {
-      description: "No release notes were provided for this version.",
-      changes: ["See full release details on GitHub."],
-    };
-  }
-
-  const lines = rawBody
-    .split("\n")
-    .map((line) => line.trim())
-    .filter(Boolean);
-
-  const changes = lines
-    .map((line) => line.match(/^[-*+]\s+(.+)$/)?.[1] ?? line.match(/^\d+\.\s+(.+)$/)?.[1] ?? null)
-    .filter((line): line is string => Boolean(line))
-    .map(removeMarkdownInlineSyntax);
-
-  const firstMeaningfulLine = lines.find(
-    (line) => !/^[-*+]\s+/.test(line) && !/^\d+\.\s+/.test(line) && !/^#+\s+/.test(line),
-  );
-
-  return {
-    description: firstMeaningfulLine
-      ? removeMarkdownInlineSyntax(firstMeaningfulLine)
-      : "Release notes are available in the full GitHub release details.",
-    changes: changes.length > 0 ? changes : ["See full release details on GitHub."],
-  };
-}
-
-function getReleaseBadge(release: Pick<GitHubRelease, "draft" | "prerelease">): Pick<ChangelogEntry, "badge" | "badgeColor"> {
-  if (release.draft) {
-    return {
-      badge: "Draft",
-      badgeColor: "bg-content-secondary/10 text-content-secondary",
-    };
-  }
-
-  if (release.prerelease) {
-    return {
-      badge: "Pre-release",
-      badgeColor: "bg-theme-warning/10 text-theme-warning",
-    };
-  }
-
-  return {
-    badge: "Release",
-    badgeColor: "bg-theme-success/10 text-theme-success",
-  };
-}
-
-function mapReleaseToEntry(release: GitHubRelease): ChangelogEntry {
-  const { description, changes } = parseReleaseBody(release.body);
-  const badge = getReleaseBadge(release);
-
-  return {
-    version: release.tag_name,
-    date: formatReleaseDate(release.published_at ?? release.created_at),
-    title: release.name?.trim() || `Release ${release.tag_name}`,
-    description,
-    changes,
-    ...badge,
-  };
-}
-
-async function fetchChangelogEntries(): Promise<{ entries: ChangelogEntry[]; hasError: boolean }> {
-  try {
-    const response = await fetch(RELEASES_API_URL, {
-      next: { revalidate: 3600 },
-      headers: {
-        Accept: "application/vnd.github+json",
-      },
-    });
-
-    if (!response.ok) {
-      return { entries: [], hasError: true };
-    }
-
-    const releases = (await response.json()) as GitHubRelease[];
-
-    return {
-      entries: releases.map(mapReleaseToEntry),
-      hasError: false,
-    };
-  } catch (error) {
-    console.error("Failed to fetch GitHub releases:", error);
-    return { entries: [], hasError: true };
-  }
-}
 
 export default async function ChangelogPage() {
   const { entries: changelogEntries, hasError } = await fetchChangelogEntries();

--- a/src/app/community/page.tsx
+++ b/src/app/community/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import HeroRepoStatsSection from "@/components/community/HeroRepoStatsSection";
 import ContributorsSection from "@/components/community/ContributorsSection";
 import HowToContribute from "@/components/community/HowToContribute";
-import RecentPRsSection, { PullRequestData } from "@/components/community/RecentPRsSection";
+import RecentPRsSection from "@/components/community/RecentPRsSection";
 import OpenIssuesSection from "@/components/community/OpenIssuesSection";
 import RepoLinksSection from "@/components/community/RepoLinksSection";
 import CommunityChannelsSection from "@/components/community/CommunityChannelsSection";
@@ -11,6 +11,7 @@ import LoadingBar from "@/components/ui/LoadingBar";
 import { Footer } from "@/components/layout/Footer";
 import { Navbar } from "@/components/layout/Navbar";
 import { buildPageMetadata } from "@/lib/seo";
+import { fetchCommunityData } from "@/services/github";
 
 export const revalidate = 600;
 
@@ -30,204 +31,8 @@ export const metadata: Metadata = buildPageMetadata({
   ogImageAlt: "OFFER-HUB Community — contributors, issues, and pull requests",
 });
 
-interface RepoStats {
-  stars: string;
-  forks: string;
-  contributors: string;
-  openIssues: string;
-}
-
-interface CommunityData {
-  stats: RepoStats | null;
-  contributors: ContributorData[];
-  pullRequests: PullRequestData[];
-  issues: IssueData[];
-}
-
-interface Contributor {
-  login: string;
-  avatar_url: string;
-  contributions: number;
-  html_url: string;
-}
-
-interface ContributorData {
-  name: string;
-  username: string;
-  avatar: string;
-  commits: number;
-  profileUrl: string;
-}
-
-interface IssueData {
-  number: number;
-  title: string;
-  priority: string;
-  url: string;
-  labels: string[];
-}
-
-interface GitHubRepo {
-  stargazers_count: number;
-  forks_count: number;
-  open_issues_count: number;
-}
-
-interface GitHubPullRequest {
-  number: number;
-  title: string;
-  html_url: string;
-  state: string;
-  created_at: string;
-  merged_at: string | null;
-  user: {
-    login: string;
-  } | null;
-}
-
-interface GitHubIssue {
-  number: number;
-  title: string;
-  html_url: string;
-  pull_request?: object;
-  created_at?: string;
-  labels: Array<{
-    name: string;
-  }>;
-}
-
-const formatNumber = (num: number): string => {
-  if (num >= 1000) {
-    return `${(num / 1000).toFixed(1)}k`;
-  }
-  return num.toString();
-};
-
-function formatTimeAgo(dateString: string): string {
-  const date = new Date(dateString);
-  const now = new Date();
-  const diffInMs = now.getTime() - date.getTime();
-  const diffInDays = Math.floor(diffInMs / (1000 * 60 * 60 * 24));
-
-  if (diffInDays === 0) return "today";
-  if (diffInDays === 1) return "1 day ago";
-  if (diffInDays < 7) return `${diffInDays} days ago`;
-  if (diffInDays < 14) return "1 week ago";
-  if (diffInDays < 30) return `${Math.floor(diffInDays / 7)} weeks ago`;
-  if (diffInDays < 60) return "1 month ago";
-  return `${Math.floor(diffInDays / 30)} months ago`;
-}
-
-const REPOS = [
-  'OFFER-HUB/offer-hub-monorepo',
-  'OFFER-HUB/OFFER-HUB',
-  'OFFER-HUB/OFFER-HUB-Frontend'
-];
-
-function processGitHubData(validData: NonNullable<Awaited<ReturnType<typeof fetchRepoData>>>[]): CommunityData {
-  const totalStars = validData.reduce((acc, d) => acc + d.repo.stargazers_count, 0);
-  const totalForks = validData.reduce((acc, d) => acc + d.repo.forks_count, 0);
-  const totalOpenIssues = validData.reduce((acc, d) => acc + d.repo.open_issues_count, 0);
-
-  const contribMap = new Map<string, ContributorData>();
-  validData.forEach(d => {
-    d.contributors.forEach(c => {
-      const existing = contribMap.get(c.login);
-      if (existing) {
-        existing.commits += c.contributions;
-      } else {
-        contribMap.set(c.login, {
-          name: c.login, username: c.login, avatar: c.avatar_url,
-          commits: c.contributions, profileUrl: c.html_url
-        });
-      }
-    });
-  });
-  const contributors = Array.from(contribMap.values()).sort((a, b) => b.commits - a.commits);
-
-  const stats: RepoStats = {
-    stars: formatNumber(totalStars), forks: formatNumber(totalForks),
-    contributors: formatNumber(contributors.length), openIssues: formatNumber(totalOpenIssues),
-  };
-
-  const allPRs = validData.flatMap(d => d.pullRequests)
-    .map(pr => ({
-      number: pr.number,
-      title: pr.title,
-      author: pr.user?.login || "Unknown",
-      timestamp: pr.state === 'open' ? pr.created_at : pr.merged_at || pr.created_at,
-      url: pr.html_url,
-      status: (pr.state === 'open' ? 'Open' : 'Merged') as 'Open' | 'Merged' | 'Closed'
-    }))
-    .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
-
-  const pullRequests: PullRequestData[] = allPRs.slice(0, 30).map(pr => ({ ...pr, timestamp: formatTimeAgo(pr.timestamp) }));
-
-  const allIssues = validData.flatMap(d => d.issues)
-    .filter(issue => !issue.pull_request)
-    .map(issue => {
-      const priorityLabel = issue.labels.find(label => label.name.toLowerCase().includes('priority'));
-      let priority = "Medium";
-      if (priorityLabel) {
-        const labelName = priorityLabel.name.toLowerCase();
-        if (labelName.includes('high') || labelName.includes('critical')) priority = "High";
-        else if (labelName.includes('low')) priority = "Low";
-      }
-      return { number: issue.number, title: issue.title, priority, url: issue.html_url, labels: issue.labels.map(l => l.name), createdAt: issue.created_at || "" };
-    })
-    .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
-  const issues: IssueData[] = allIssues.slice(0, 50).map(({ number, title, priority, url, labels }) => ({
-    number,
-    title,
-    priority,
-    url,
-    labels,
-  }));
-
-  return { stats, contributors, pullRequests, issues };
-}
-
-async function fetchRepoData(repo: string) {
-  const cacheOpts = { next: { revalidate: 600 } };
-  const [repoRes, contribRes, prRes, issueRes] = await Promise.all([
-    fetch(`https://api.github.com/repos/${repo}`, cacheOpts),
-    fetch(`https://api.github.com/repos/${repo}/contributors?per_page=100`, cacheOpts),
-    fetch(`https://api.github.com/repos/${repo}/pulls?state=all&sort=updated&direction=desc&per_page=20`, cacheOpts),
-    fetch(`https://api.github.com/repos/${repo}/issues?state=open&sort=created&direction=desc&per_page=20`, cacheOpts),
-  ]);
-
-  if (!repoRes.ok || !contribRes.ok || !prRes.ok || !issueRes.ok) return null;
-
-  return {
-    repo: await repoRes.json() as GitHubRepo,
-    contributors: await contribRes.json() as Contributor[],
-    pullRequests: await prRes.json() as GitHubPullRequest[],
-    issues: await issueRes.json() as GitHubIssue[],
-  };
-}
-
-async function fetchGitHubData() {
-  try {
-    const allPills = await Promise.all(REPOS.map(fetchRepoData));
-
-    const validData = allPills.filter((d): d is NonNullable<typeof d> => d !== null);
-
-    if (validData.length === 0) throw new Error('Failed to fetch any repo data');
-
-    return processGitHubData(validData);
-  } catch (error) {
-    console.error('Error fetching GitHub data:', error);
-    return {
-      stats: null,
-      contributors: [],
-      pullRequests: [],
-      issues: [],
-    } as CommunityData;
-  }
-}
-
 export default async function CommunityPage() {
-  const { stats, contributors, pullRequests, issues } = await fetchGitHubData();
+  const { stats, contributors, pullRequests, issues } = await fetchCommunityData();
 
   return (
     <>

--- a/src/app/contact/ContactForm.client.tsx
+++ b/src/app/contact/ContactForm.client.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { Send, User, Mail, MessageSquare, Building2, CheckCircle2, AlertCircle } from "lucide-react";
-import { supabase } from "@/lib/supabase";
+import { submitContactInquiry } from "@/services/contact";
 
 interface ContactFormData {
   company: string;
@@ -53,33 +53,26 @@ export default function ContactForm() {
 
     setIsLoading(true);
 
-    try {
-      if (!supabase) {
-        setSubmitError("Contact is not configured. Please try again later.");
-        setIsLoading(false);
-        return;
-      }
+    const result = await submitContactInquiry({
+      company: formData.company,
+      name: formData.name,
+      email: formData.email,
+      message: formData.message,
+    });
 
-      const { error: sbError } = await supabase.from("contact_inquiries").insert([
-        {
-          company: formData.company,
-          contact_name: formData.name,
-          email: formData.email,
-          message: formData.message,
-        },
-      ]);
-
-      if (sbError) {
-        setSubmitError("Something went wrong. Please try again.");
-        setIsLoading(false);
-        return;
-      }
-
+    if (result.ok) {
       setIsSubmitted(true);
-    } catch {
-      setSubmitError("Network error. Please check your connection and try again.");
-      setIsLoading(false);
+      return;
     }
+
+    if (result.reason === "not_configured") {
+      setSubmitError("Contact is not configured. Please try again later.");
+    } else if (result.reason === "error") {
+      setSubmitError("Something went wrong. Please try again.");
+    } else {
+      setSubmitError("Network error. Please check your connection and try again.");
+    }
+    setIsLoading(false);
   };
 
   if (isSubmitted) {

--- a/src/app/contact/__tests__/ContactForm.client.test.tsx
+++ b/src/app/contact/__tests__/ContactForm.client.test.tsx
@@ -1,14 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import ContactForm from "../ContactForm.client";
+import { submitContactInquiry } from "@/services/contact";
 
-const insert = vi.fn();
-
-vi.mock("@/lib/supabase", () => ({
-  supabase: {
-    from: vi.fn(() => ({ insert })),
-  },
+vi.mock("@/services/contact", () => ({
+  submitContactInquiry: vi.fn(),
 }));
+
+const submitContactInquiryMock = vi.mocked(submitContactInquiry);
 
 function fillField(container: HTMLElement, id: string, value: string) {
   const field = container.querySelector<HTMLInputElement | HTMLTextAreaElement>(`#${id}`)!;
@@ -17,7 +16,7 @@ function fillField(container: HTMLElement, id: string, value: string) {
 
 describe("ContactForm", () => {
   beforeEach(() => {
-    insert.mockReset();
+    submitContactInquiryMock.mockReset();
   });
 
   it("shows required-field errors and does not submit when fields are empty", () => {
@@ -29,7 +28,7 @@ describe("ContactForm", () => {
     expect(screen.getByText(/company name is required/i)).toBeInTheDocument();
     expect(screen.getByText(/contact name is required/i)).toBeInTheDocument();
     expect(screen.getByText(/work email is required/i)).toBeInTheDocument();
-    expect(insert).not.toHaveBeenCalled();
+    expect(submitContactInquiry).not.toHaveBeenCalled();
   });
 
   it("shows a format error for an invalid work email", () => {
@@ -43,32 +42,32 @@ describe("ContactForm", () => {
     fireEvent.submit(form);
 
     expect(screen.getByText(/enter a valid work email/i)).toBeInTheDocument();
-    expect(insert).not.toHaveBeenCalled();
+    expect(submitContactInquiry).not.toHaveBeenCalled();
   });
 
-  it("submits to Supabase and shows the success state with valid data", async () => {
-    insert.mockResolvedValueOnce({ error: null });
+  it("submits the inquiry and shows the success state with valid data", async () => {
+    submitContactInquiryMock.mockResolvedValueOnce({ ok: true });
     const { container } = render(<ContactForm />);
     const form = container.querySelector("form")!;
 
     fillField(container, "company", "Acme Inc");
     fillField(container, "name", "Jane Doe");
     fillField(container, "email", "jane@acme.com");
+    fillField(container, "message", "We need escrow for 200 sellers");
 
     fireEvent.submit(form);
 
     expect(await screen.findByText(/thanks — we'll be in touch/i)).toBeInTheDocument();
-    expect(insert).toHaveBeenCalledWith([
-      expect.objectContaining({
-        company: "Acme Inc",
-        contact_name: "Jane Doe",
-        email: "jane@acme.com",
-      }),
-    ]);
+    expect(submitContactInquiry).toHaveBeenCalledWith({
+      company: "Acme Inc",
+      name: "Jane Doe",
+      email: "jane@acme.com",
+      message: "We need escrow for 200 sellers",
+    });
   });
 
-  it("renders the submit error with role=alert when Supabase returns an error", async () => {
-    insert.mockResolvedValueOnce({ error: { message: "boom" } });
+  it("renders the submit error with role=alert when the service reports an error", async () => {
+    submitContactInquiryMock.mockResolvedValueOnce({ ok: false, reason: "error" });
     const { container } = render(<ContactForm />);
     const form = container.querySelector("form")!;
 

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,5 +1,3 @@
-import fs from "fs";
-import path from "path";
 import type { Metadata } from "next";
 import { Navbar } from "@/components/layout/Navbar";
 import { Footer } from "@/components/layout/Footer";
@@ -7,6 +5,7 @@ import LoadingBar from "@/components/ui/LoadingBar";
 import { MDXRemote } from "next-mdx-remote/rsc";
 import { MDX_PRIVACY_COMPONENTS } from "@/components/mdx/PrivacyComponents";
 import { buildPageMetadata } from "@/lib/seo";
+import { getStaticMdxContent } from "@/lib/mdx";
 
 export const metadata: Metadata = buildPageMetadata({
   title: "Privacy Policy",
@@ -25,7 +24,7 @@ export const metadata: Metadata = buildPageMetadata({
 });
 
 export default async function PrivacyPage() {
-  const content = fs.readFileSync(path.join(process.cwd(), "src/content/privacy.mdx"), "utf-8");
+  const content = getStaticMdxContent("src/content/privacy.mdx");
 
   return (
     <div className="min-h-screen flex flex-col">

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,5 +1,3 @@
-import fs from "fs";
-import path from "path";
 import type { Metadata } from "next";
 import { MDXRemote } from "next-mdx-remote/rsc";
 import remarkGfm from "remark-gfm";
@@ -9,6 +7,7 @@ import LoadingBar from "@/components/ui/LoadingBar";
 import { TERMS_MDX_COMPONENTS } from "@/components/terms/terms-mdx-components";
 import { TermsPageHeader } from "@/components/terms/TermsPageHeader";
 import { buildPageMetadata } from "@/lib/seo";
+import { getStaticMdxContent } from "@/lib/mdx";
 
 export const metadata: Metadata = buildPageMetadata({
   title: "Terms of Service",
@@ -27,10 +26,7 @@ export const metadata: Metadata = buildPageMetadata({
 });
 
 export default async function TermsOfServicePage() {
-  const source = fs.readFileSync(
-    path.join(process.cwd(), "src/content/terms.mdx"),
-    "utf-8"
-  );
+  const source = getStaticMdxContent("src/content/terms.mdx");
 
   return (
     <div className="min-h-screen flex flex-col bg-bg-base text-content-primary">

--- a/src/components/Analytics.tsx
+++ b/src/components/Analytics.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect } from 'react';
 import { usePathname } from 'next/navigation';
-import { trackPageView } from '@/lib/analytics';
+import { trackPageView } from '@/services/analytics';
 
 export default function Analytics() {
   const pathname = usePathname();

--- a/src/components/community/RegistrationForm.tsx
+++ b/src/components/community/RegistrationForm.tsx
@@ -3,7 +3,7 @@
 import { useState, useRef, useEffect, useCallback } from "react";
 import Script from "next/script";
 import { Send, User, Mail, MessageSquare, CheckCircle2, AlertCircle, Timer } from "lucide-react";
-import { supabase } from "@/lib/supabase";
+import { submitWaitlistEntry } from "@/services/waitlist";
 
 const COOLDOWN_SECONDS = 30;
 
@@ -113,44 +113,37 @@ export default function RegistrationForm() {
         setIsLoading(true);
         setError(null);
 
-        try {
-            if (!supabase) {
-                setError("Waitlist is not configured yet. Please try again later.");
-                setIsLoading(false);
-                startCooldown();
-                return;
-            }
+        const result = await submitWaitlistEntry({
+            email: formData.email,
+            name: formData.name,
+            purpose: formData.purpose,
+            referral: formData.referral
+        });
 
-            const { error: supabaseError } = await supabase
-                .from("waitlist")
-                .insert([
-                    {
-                        email: formData.email,
-                        name: formData.name,
-                        purpose: formData.purpose,
-                        referral: formData.referral
-                    }
-                ]);
-
-            if (supabaseError) {
-                if (supabaseError.code === "23505") {
-                    setError("This email is already registered on our waitlist.");
-                } else {
-                    setError("Something went wrong. Please try again.");
-                }
-                setIsLoading(false);
-                startCooldown();
-                resetTurnstile();
-                return;
-            }
-
+        if (result.ok) {
             setIsSubmitted(true);
-        } catch {
-            setError("Network error. Please check your connection and try again.");
+            return;
+        }
+
+        // Not-configured is the one branch that leaves the CAPTCHA widget intact,
+        // since no verification attempt was ever made against the backend.
+        if (result.reason === "not_configured") {
+            setError("Waitlist is not configured yet. Please try again later.");
             setIsLoading(false);
             startCooldown();
-            resetTurnstile();
+            return;
         }
+
+        if (result.reason === "duplicate") {
+            setError("This email is already registered on our waitlist.");
+        } else if (result.reason === "error") {
+            setError("Something went wrong. Please try again.");
+        } else {
+            setError("Network error. Please check your connection and try again.");
+        }
+        setIsLoading(false);
+        startCooldown();
+        resetTurnstile();
     };
 
     if (isSubmitted) {

--- a/src/components/community/__tests__/RegistrationForm.test.tsx
+++ b/src/components/community/__tests__/RegistrationForm.test.tsx
@@ -1,14 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, act } from "@testing-library/react";
 import RegistrationForm from "../RegistrationForm";
+import { submitWaitlistEntry } from "@/services/waitlist";
 
-const insert = vi.fn();
-
-vi.mock("@/lib/supabase", () => ({
-  supabase: {
-    from: vi.fn(() => ({ insert })),
-  },
+vi.mock("@/services/waitlist", () => ({
+  submitWaitlistEntry: vi.fn(),
 }));
+
+const submitWaitlistEntryMock = vi.mocked(submitWaitlistEntry);
 
 function fillRequiredFields(container: HTMLElement) {
   const name = container.querySelector<HTMLInputElement>("#name")!;
@@ -33,7 +32,7 @@ function fireInput(el: HTMLInputElement | HTMLTextAreaElement, value: string) {
 
 describe("RegistrationForm", () => {
   beforeEach(() => {
-    insert.mockReset();
+    submitWaitlistEntryMock.mockReset();
   });
 
   afterEach(() => {
@@ -48,11 +47,11 @@ describe("RegistrationForm", () => {
       submitButton.click();
     });
 
-    expect(insert).not.toHaveBeenCalled();
+    expect(submitWaitlistEntry).not.toHaveBeenCalled();
   });
 
-  it("submits to Supabase and shows the success state on valid submission", async () => {
-    insert.mockResolvedValueOnce({ error: null });
+  it("submits the entry and shows the success state on valid submission", async () => {
+    submitWaitlistEntryMock.mockResolvedValueOnce({ ok: true });
     const { container } = render(<RegistrationForm />);
 
     fillRequiredFields(container);
@@ -62,20 +61,18 @@ describe("RegistrationForm", () => {
       submitButton.click();
     });
 
-    expect(insert).toHaveBeenCalledWith([
-      expect.objectContaining({
-        email: "jane@example.com",
-        name: "Jane Doe",
-        purpose: "Building a marketplace",
-        referral: "Friend",
-      }),
-    ]);
+    expect(submitWaitlistEntry).toHaveBeenCalledWith({
+      email: "jane@example.com",
+      name: "Jane Doe",
+      purpose: "Building a marketplace",
+      referral: "Friend",
+    });
 
     expect(await screen.findByText(/you're on the list/i)).toBeInTheDocument();
   });
 
-  it("shows a duplicate-email error and starts the cooldown on a unique-violation response", async () => {
-    insert.mockResolvedValueOnce({ error: { code: "23505" } });
+  it("shows a duplicate-email error and starts the cooldown on a duplicate result", async () => {
+    submitWaitlistEntryMock.mockResolvedValueOnce({ ok: false, reason: "duplicate" });
     const { container } = render(<RegistrationForm />);
 
     fillRequiredFields(container);
@@ -91,7 +88,7 @@ describe("RegistrationForm", () => {
 
   it("prevents resubmission while the cooldown is active", async () => {
     vi.useFakeTimers();
-    insert.mockResolvedValueOnce({ error: { code: "unexpected" } });
+    submitWaitlistEntryMock.mockResolvedValueOnce({ ok: false, reason: "error" });
     const { container } = render(<RegistrationForm />);
 
     fillRequiredFields(container);
@@ -103,7 +100,7 @@ describe("RegistrationForm", () => {
     });
 
     expect(screen.getByText(/something went wrong/i)).toBeInTheDocument();
-    expect(insert).toHaveBeenCalledTimes(1);
+    expect(submitWaitlistEntry).toHaveBeenCalledTimes(1);
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(5000);

--- a/src/lib/mdx.ts
+++ b/src/lib/mdx.ts
@@ -116,6 +116,11 @@ export function getSidebarNav(): SidebarSection[] {
   return sections.sort((a, b) => (a.links[0]?.order ?? 99) - (b.links[0]?.order ?? 99));
 }
 
+/** Read a static MDX file's raw content by path relative to the project root */
+export function getStaticMdxContent(relativePath: string): string {
+  return fs.readFileSync(path.join(process.cwd(), relativePath), "utf-8");
+}
+
 /** Extract h2 and h3 headings from raw MDX content for Table of Contents */
 export function extractHeadings(content: string): Heading[] {
   const headings: Heading[] = [];

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -1,4 +1,6 @@
-import { supabase, isSupabaseConfigured } from './supabase';
+import { supabase, isSupabaseConfigured } from '@/lib/supabase';
+import { getBrowserName, getDeviceType, getOSName } from '@/utils/device';
+import { getGeolocation } from './geolocation';
 
 // Generate a unique visitor ID
 export function generateVisitorId(): string {
@@ -9,42 +11,6 @@ export function generateVisitorId(): string {
   const visitorId = `visitor_${crypto.randomUUID()}`;
   localStorage.setItem('visitor_id', visitorId);
   return visitorId;
-}
-
-// Get device type
-export function getDeviceType(): string {
-  const ua = navigator.userAgent;
-  if (/(tablet|ipad|playbook|silk)|(android(?!.*mobi))/i.test(ua)) {
-    return 'tablet';
-  }
-  if (/Mobile|Android|iP(hone|od)|IEMobile|BlackBerry|Kindle|Silk-Accelerated|(hpw|web)OS|Opera M(obi|ini)/.test(ua)) {
-    return 'mobile';
-  }
-  return 'desktop';
-}
-
-// Get browser name
-export function getBrowserName(): string {
-  const ua = navigator.userAgent;
-  if (ua.includes('Firefox')) return 'Firefox';
-  if (ua.includes('SamsungBrowser')) return 'Samsung Browser';
-  if (ua.includes('Opera') || ua.includes('OPR')) return 'Opera';
-  if (ua.includes('Trident')) return 'Internet Explorer';
-  if (ua.includes('Edge')) return 'Edge';
-  if (ua.includes('Chrome')) return 'Chrome';
-  if (ua.includes('Safari')) return 'Safari';
-  return 'Unknown';
-}
-
-// Get OS name
-export function getOSName(): string {
-  const ua = navigator.userAgent;
-  if (ua.includes('Win')) return 'Windows';
-  if (ua.includes('Mac')) return 'MacOS';
-  if (ua.includes('Linux')) return 'Linux';
-  if (ua.includes('Android')) return 'Android';
-  if (ua.includes('iOS') || ua.includes('iPhone') || ua.includes('iPad')) return 'iOS';
-  return 'Unknown';
 }
 
 // Get session ID
@@ -67,56 +33,6 @@ export function getUTMParams() {
     utm_medium: params.get('utm_medium') || undefined,
     utm_campaign: params.get('utm_campaign') || undefined,
   };
-}
-
-// Get geolocation data from IP (cached per session)
-const emptyGeo = {
-  ip: undefined,
-  country: undefined,
-  country_code: undefined,
-  city: undefined,
-  region: undefined,
-  timezone: undefined,
-};
-
-export async function getGeolocation() {
-  const CACHE_KEY = 'geo_cache';
-
-  try {
-    const cached = sessionStorage.getItem(CACHE_KEY);
-    if (cached) {
-      return JSON.parse(cached);
-    }
-
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 3000);
-
-    try {
-      const response = await fetch('https://ipapi.co/json/', {
-        signal: controller.signal,
-      });
-      if (!response.ok) throw new Error('Failed to fetch geolocation');
-
-      const data = await response.json();
-      const geo = {
-        ip: data.ip,
-        country: data.country_name,
-        country_code: data.country_code,
-        city: data.city,
-        region: data.region,
-        timezone: data.timezone,
-      };
-
-      sessionStorage.setItem(CACHE_KEY, JSON.stringify(geo));
-      return geo;
-    } finally {
-      clearTimeout(timeoutId);
-    }
-  } catch {
-    // Cache the empty result so we don't retry on every navigation
-    sessionStorage.setItem(CACHE_KEY, JSON.stringify(emptyGeo));
-    return emptyGeo;
-  }
 }
 
 // Track page view

--- a/src/services/contact.ts
+++ b/src/services/contact.ts
@@ -1,0 +1,39 @@
+import { supabase } from "@/lib/supabase";
+
+export interface ContactSubmission {
+  company: string;
+  name: string;
+  email: string;
+  message: string;
+}
+
+export type ContactResult =
+  | { ok: true }
+  | { ok: false; reason: "not_configured" | "error" | "network" };
+
+export async function submitContactInquiry(
+  inquiry: ContactSubmission,
+): Promise<ContactResult> {
+  if (!supabase) {
+    return { ok: false, reason: "not_configured" };
+  }
+
+  try {
+    const { error } = await supabase.from("contact_inquiries").insert([
+      {
+        company: inquiry.company,
+        contact_name: inquiry.name,
+        email: inquiry.email,
+        message: inquiry.message,
+      },
+    ]);
+
+    if (error) {
+      return { ok: false, reason: "error" };
+    }
+
+    return { ok: true };
+  } catch {
+    return { ok: false, reason: "network" };
+  }
+}

--- a/src/services/geolocation.ts
+++ b/src/services/geolocation.ts
@@ -1,0 +1,58 @@
+export interface GeoData {
+  ip?: string;
+  country?: string;
+  country_code?: string;
+  city?: string;
+  region?: string;
+  timezone?: string;
+}
+
+// Get geolocation data from IP (cached per session)
+const emptyGeo: GeoData = {
+  ip: undefined,
+  country: undefined,
+  country_code: undefined,
+  city: undefined,
+  region: undefined,
+  timezone: undefined,
+};
+
+export async function getGeolocation(): Promise<GeoData> {
+  const CACHE_KEY = 'geo_cache';
+
+  try {
+    const cached = sessionStorage.getItem(CACHE_KEY);
+    if (cached) {
+      return JSON.parse(cached);
+    }
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 3000);
+
+    try {
+      const response = await fetch('https://ipapi.co/json/', {
+        signal: controller.signal,
+      });
+      if (!response.ok) throw new Error('Failed to fetch geolocation');
+
+      const data = await response.json();
+      const geo = {
+        ip: data.ip,
+        country: data.country_name,
+        country_code: data.country_code,
+        city: data.city,
+        region: data.region,
+        timezone: data.timezone,
+      };
+
+      sessionStorage.setItem(CACHE_KEY, JSON.stringify(geo));
+      return geo;
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  } catch {
+    // Cache the empty result so we don't retry on every navigation
+    sessionStorage.setItem(CACHE_KEY, JSON.stringify(emptyGeo));
+    return emptyGeo;
+  }
+}

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -1,0 +1,345 @@
+import type { PullRequestData } from "@/components/community/RecentPRsSection";
+
+/* -------------------------------------------------------------------------- */
+/*                              Public data shapes                             */
+/* -------------------------------------------------------------------------- */
+
+export interface RepoStats {
+  stars: string;
+  forks: string;
+  contributors: string;
+  openIssues: string;
+}
+
+export interface ContributorData {
+  name: string;
+  username: string;
+  avatar: string;
+  commits: number;
+  profileUrl: string;
+}
+
+export interface IssueData {
+  number: number;
+  title: string;
+  priority: string;
+  url: string;
+  labels: string[];
+}
+
+export interface CommunityData {
+  stats: RepoStats | null;
+  contributors: ContributorData[];
+  pullRequests: PullRequestData[];
+  issues: IssueData[];
+}
+
+export interface ChangelogEntry {
+  version: string;
+  date: string;
+  title: string;
+  badge: string;
+  badgeColor: string;
+  description: string;
+  changes: string[];
+}
+
+/* -------------------------------------------------------------------------- */
+/*                            Raw GitHub API shapes                            */
+/* -------------------------------------------------------------------------- */
+
+interface Contributor {
+  login: string;
+  avatar_url: string;
+  contributions: number;
+  html_url: string;
+}
+
+interface GitHubRepo {
+  stargazers_count: number;
+  forks_count: number;
+  open_issues_count: number;
+}
+
+interface GitHubPullRequest {
+  number: number;
+  title: string;
+  html_url: string;
+  state: string;
+  created_at: string;
+  merged_at: string | null;
+  user: {
+    login: string;
+  } | null;
+}
+
+interface GitHubIssue {
+  number: number;
+  title: string;
+  html_url: string;
+  pull_request?: object;
+  created_at?: string;
+  labels: Array<{
+    name: string;
+  }>;
+}
+
+interface GitHubRelease {
+  tag_name: string;
+  name: string | null;
+  body: string | null;
+  draft: boolean;
+  prerelease: boolean;
+  published_at: string | null;
+  created_at: string;
+}
+
+/* -------------------------------------------------------------------------- */
+/*                                  Community                                  */
+/* -------------------------------------------------------------------------- */
+
+const REPOS = [
+  'OFFER-HUB/offer-hub-monorepo',
+  'OFFER-HUB/OFFER-HUB',
+  'OFFER-HUB/OFFER-HUB-Frontend'
+];
+
+const formatNumber = (num: number): string => {
+  if (num >= 1000) {
+    return `${(num / 1000).toFixed(1)}k`;
+  }
+  return num.toString();
+};
+
+function formatTimeAgo(dateString: string): string {
+  const date = new Date(dateString);
+  const now = new Date();
+  const diffInMs = now.getTime() - date.getTime();
+  const diffInDays = Math.floor(diffInMs / (1000 * 60 * 60 * 24));
+
+  if (diffInDays === 0) return "today";
+  if (diffInDays === 1) return "1 day ago";
+  if (diffInDays < 7) return `${diffInDays} days ago`;
+  if (diffInDays < 14) return "1 week ago";
+  if (diffInDays < 30) return `${Math.floor(diffInDays / 7)} weeks ago`;
+  if (diffInDays < 60) return "1 month ago";
+  return `${Math.floor(diffInDays / 30)} months ago`;
+}
+
+async function fetchRepoData(repo: string) {
+  const cacheOpts = { next: { revalidate: 600 } };
+  const [repoRes, contribRes, prRes, issueRes] = await Promise.all([
+    fetch(`https://api.github.com/repos/${repo}`, cacheOpts),
+    fetch(`https://api.github.com/repos/${repo}/contributors?per_page=100`, cacheOpts),
+    fetch(`https://api.github.com/repos/${repo}/pulls?state=all&sort=updated&direction=desc&per_page=20`, cacheOpts),
+    fetch(`https://api.github.com/repos/${repo}/issues?state=open&sort=created&direction=desc&per_page=20`, cacheOpts),
+  ]);
+
+  if (!repoRes.ok || !contribRes.ok || !prRes.ok || !issueRes.ok) return null;
+
+  return {
+    repo: await repoRes.json() as GitHubRepo,
+    contributors: await contribRes.json() as Contributor[],
+    pullRequests: await prRes.json() as GitHubPullRequest[],
+    issues: await issueRes.json() as GitHubIssue[],
+  };
+}
+
+function processGitHubData(validData: NonNullable<Awaited<ReturnType<typeof fetchRepoData>>>[]): CommunityData {
+  const totalStars = validData.reduce((acc, d) => acc + d.repo.stargazers_count, 0);
+  const totalForks = validData.reduce((acc, d) => acc + d.repo.forks_count, 0);
+  const totalOpenIssues = validData.reduce((acc, d) => acc + d.repo.open_issues_count, 0);
+
+  const contribMap = new Map<string, ContributorData>();
+  validData.forEach(d => {
+    d.contributors.forEach(c => {
+      const existing = contribMap.get(c.login);
+      if (existing) {
+        existing.commits += c.contributions;
+      } else {
+        contribMap.set(c.login, {
+          name: c.login, username: c.login, avatar: c.avatar_url,
+          commits: c.contributions, profileUrl: c.html_url
+        });
+      }
+    });
+  });
+  const contributors = Array.from(contribMap.values()).sort((a, b) => b.commits - a.commits);
+
+  const stats: RepoStats = {
+    stars: formatNumber(totalStars), forks: formatNumber(totalForks),
+    contributors: formatNumber(contributors.length), openIssues: formatNumber(totalOpenIssues),
+  };
+
+  const allPRs = validData.flatMap(d => d.pullRequests)
+    .map(pr => ({
+      number: pr.number,
+      title: pr.title,
+      author: pr.user?.login || "Unknown",
+      timestamp: pr.state === 'open' ? pr.created_at : pr.merged_at || pr.created_at,
+      url: pr.html_url,
+      status: (pr.state === 'open' ? 'Open' : 'Merged') as 'Open' | 'Merged' | 'Closed'
+    }))
+    .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
+
+  const pullRequests: PullRequestData[] = allPRs.slice(0, 30).map(pr => ({ ...pr, timestamp: formatTimeAgo(pr.timestamp) }));
+
+  const allIssues = validData.flatMap(d => d.issues)
+    .filter(issue => !issue.pull_request)
+    .map(issue => {
+      const priorityLabel = issue.labels.find(label => label.name.toLowerCase().includes('priority'));
+      let priority = "Medium";
+      if (priorityLabel) {
+        const labelName = priorityLabel.name.toLowerCase();
+        if (labelName.includes('high') || labelName.includes('critical')) priority = "High";
+        else if (labelName.includes('low')) priority = "Low";
+      }
+      return { number: issue.number, title: issue.title, priority, url: issue.html_url, labels: issue.labels.map(l => l.name), createdAt: issue.created_at || "" };
+    })
+    .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+  const issues: IssueData[] = allIssues.slice(0, 50).map(({ number, title, priority, url, labels }) => ({
+    number,
+    title,
+    priority,
+    url,
+    labels,
+  }));
+
+  return { stats, contributors, pullRequests, issues };
+}
+
+export async function fetchCommunityData() {
+  try {
+    const allPills = await Promise.all(REPOS.map(fetchRepoData));
+
+    const validData = allPills.filter((d): d is NonNullable<typeof d> => d !== null);
+
+    if (validData.length === 0) throw new Error('Failed to fetch any repo data');
+
+    return processGitHubData(validData);
+  } catch (error) {
+    console.error('Error fetching GitHub data:', error);
+    return {
+      stats: null,
+      contributors: [],
+      pullRequests: [],
+      issues: [],
+    } as CommunityData;
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/*                                  Changelog                                  */
+/* -------------------------------------------------------------------------- */
+
+const RELEASES_API_URL = "https://api.github.com/repos/OFFER-HUB/offer-hub-monorepo/releases";
+
+function formatReleaseDate(dateString: string): string {
+  return new Intl.DateTimeFormat("en-US", {
+    month: "long",
+    year: "numeric",
+  }).format(new Date(dateString));
+}
+
+function removeMarkdownInlineSyntax(text: string): string {
+  return text
+    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, "$1")
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/\*\*([^*]+)\*\*/g, "$1")
+    .replace(/\*([^*]+)\*/g, "$1")
+    .replace(/__([^_]+)__/g, "$1")
+    .replace(/_([^_]+)_/g, "$1")
+    .trim();
+}
+
+function parseReleaseBody(body: string | null): Pick<ChangelogEntry, "description" | "changes"> {
+  const rawBody = body?.trim();
+
+  if (!rawBody) {
+    return {
+      description: "No release notes were provided for this version.",
+      changes: ["See full release details on GitHub."],
+    };
+  }
+
+  const lines = rawBody
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  const changes = lines
+    .map((line) => line.match(/^[-*+]\s+(.+)$/)?.[1] ?? line.match(/^\d+\.\s+(.+)$/)?.[1] ?? null)
+    .filter((line): line is string => Boolean(line))
+    .map(removeMarkdownInlineSyntax);
+
+  const firstMeaningfulLine = lines.find(
+    (line) => !/^[-*+]\s+/.test(line) && !/^\d+\.\s+/.test(line) && !/^#+\s+/.test(line),
+  );
+
+  return {
+    description: firstMeaningfulLine
+      ? removeMarkdownInlineSyntax(firstMeaningfulLine)
+      : "Release notes are available in the full GitHub release details.",
+    changes: changes.length > 0 ? changes : ["See full release details on GitHub."],
+  };
+}
+
+function getReleaseBadge(release: Pick<GitHubRelease, "draft" | "prerelease">): Pick<ChangelogEntry, "badge" | "badgeColor"> {
+  if (release.draft) {
+    return {
+      badge: "Draft",
+      badgeColor: "bg-content-secondary/10 text-content-secondary",
+    };
+  }
+
+  if (release.prerelease) {
+    return {
+      badge: "Pre-release",
+      badgeColor: "bg-theme-warning/10 text-theme-warning",
+    };
+  }
+
+  return {
+    badge: "Release",
+    badgeColor: "bg-theme-success/10 text-theme-success",
+  };
+}
+
+function mapReleaseToEntry(release: GitHubRelease): ChangelogEntry {
+  const { description, changes } = parseReleaseBody(release.body);
+  const badge = getReleaseBadge(release);
+
+  return {
+    version: release.tag_name,
+    date: formatReleaseDate(release.published_at ?? release.created_at),
+    title: release.name?.trim() || `Release ${release.tag_name}`,
+    description,
+    changes,
+    ...badge,
+  };
+}
+
+export async function fetchChangelogEntries(): Promise<{ entries: ChangelogEntry[]; hasError: boolean }> {
+  try {
+    const response = await fetch(RELEASES_API_URL, {
+      next: { revalidate: 3600 },
+      headers: {
+        Accept: "application/vnd.github+json",
+      },
+    });
+
+    if (!response.ok) {
+      return { entries: [], hasError: true };
+    }
+
+    const releases = (await response.json()) as GitHubRelease[];
+
+    return {
+      entries: releases.map(mapReleaseToEntry),
+      hasError: false,
+    };
+  } catch (error) {
+    console.error("Failed to fetch GitHub releases:", error);
+    return { entries: [], hasError: true };
+  }
+}

--- a/src/services/waitlist.ts
+++ b/src/services/waitlist.ts
@@ -1,0 +1,44 @@
+import { supabase } from "@/lib/supabase";
+
+export interface WaitlistSubmission {
+  email: string;
+  name: string;
+  purpose: string;
+  referral: string;
+}
+
+export type WaitlistResult =
+  | { ok: true }
+  | { ok: false; reason: "not_configured" | "duplicate" | "error" | "network" };
+
+const UNIQUE_VIOLATION = "23505";
+
+export async function submitWaitlistEntry(
+  entry: WaitlistSubmission,
+): Promise<WaitlistResult> {
+  if (!supabase) {
+    return { ok: false, reason: "not_configured" };
+  }
+
+  try {
+    const { error } = await supabase.from("waitlist").insert([
+      {
+        email: entry.email,
+        name: entry.name,
+        purpose: entry.purpose,
+        referral: entry.referral,
+      },
+    ]);
+
+    if (error) {
+      return {
+        ok: false,
+        reason: error.code === UNIQUE_VIOLATION ? "duplicate" : "error",
+      };
+    }
+
+    return { ok: true };
+  } catch {
+    return { ok: false, reason: "network" };
+  }
+}

--- a/src/utils/device.ts
+++ b/src/utils/device.ts
@@ -1,0 +1,35 @@
+// Get device type
+export function getDeviceType(): string {
+  const ua = navigator.userAgent;
+  if (/(tablet|ipad|playbook|silk)|(android(?!.*mobi))/i.test(ua)) {
+    return 'tablet';
+  }
+  if (/Mobile|Android|iP(hone|od)|IEMobile|BlackBerry|Kindle|Silk-Accelerated|(hpw|web)OS|Opera M(obi|ini)/.test(ua)) {
+    return 'mobile';
+  }
+  return 'desktop';
+}
+
+// Get browser name
+export function getBrowserName(): string {
+  const ua = navigator.userAgent;
+  if (ua.includes('Firefox')) return 'Firefox';
+  if (ua.includes('SamsungBrowser')) return 'Samsung Browser';
+  if (ua.includes('Opera') || ua.includes('OPR')) return 'Opera';
+  if (ua.includes('Trident')) return 'Internet Explorer';
+  if (ua.includes('Edge')) return 'Edge';
+  if (ua.includes('Chrome')) return 'Chrome';
+  if (ua.includes('Safari')) return 'Safari';
+  return 'Unknown';
+}
+
+// Get OS name
+export function getOSName(): string {
+  const ua = navigator.userAgent;
+  if (ua.includes('Win')) return 'Windows';
+  if (ua.includes('Mac')) return 'MacOS';
+  if (ua.includes('Linux')) return 'Linux';
+  if (ua.includes('Android')) return 'Android';
+  if (ua.includes('iOS') || ua.includes('iPhone') || ua.includes('iPad')) return 'iOS';
+  return 'Unknown';
+}


### PR DESCRIPTION
# Pull Request

## Title:
- refactor: introduce a services layer, isolate data-fetching and IO out of pages and components

## Issue
- Closes #1470

## Description
- Data-access logic was embedded directly inside page and component files: GitHub REST calls, Supabase writes, geolocation fetches, and filesystem reads. UI components imported `@/lib/supabase` and knew table names and endpoints directly. This PR introduces a `src/services/` layer that owns those external connections, leaving pages and components as pure consumers.
- Scope decision on the fifth criterion: `src/app/api/privacy/delete/route.ts` and `export/route.ts` also import `@/lib/supabase`, but they are GDPR compliance route handlers rather than UI components, a different concern from the page and form data-fetching this issue targets. They are deliberately left untouched. After this PR the only remaining `@/lib/supabase` importers are the two new services and those two routes.

## Changes applied

**GitHub data fetching**
- Added `src/services/github.ts`. Public surface is `fetchCommunityData` (renamed from `fetchGitHubData`) and `fetchChangelogEntries`, plus the `RepoStats`, `ContributorData`, `IssueData`, `CommunityData`, and `ChangelogEntry` shapes. All helpers (`fetchRepoData`, `processGitHubData`, `formatNumber`, `formatTimeAgo`, the `REPOS` array, the markdown parsers, `RELEASES_API_URL`) and the five raw GitHub API interfaces are module-private.
- `community/page.tsx` and `changelog/page.tsx` drop roughly 240 lines of data logic and now only compose JSX. Every moved body is character-identical, including both error paths: `fetchCommunityData` still throws internally on zero valid repos and catches into an empty `CommunityData`, and `fetchChangelogEntries` still returns `{ entries: [], hasError: true }` from both the failed-response branch and the catch.
- The `revalidate` route segment exports stay in the pages, since Next only reads those from route files.
- The pre-existing `PullRequestData` import from `@/components/community/RecentPRsSection` is left as-is. Type centralization is a separate ticket and pulling it in here would widen the diff.

**Supabase form writes**
- Added `src/services/waitlist.ts` and `src/services/contact.ts`, exposing `submitWaitlistEntry` and `submitContactInquiry`. Both return a discriminated result (`{ ok: true }` or `{ ok: false, reason: ... }`) rather than a boolean.
- The discriminant exists to preserve an exact behavioral asymmetry: in `RegistrationForm`, the unconfigured-client path does **not** call `resetTurnstile()`, while the duplicate, error, and thrown paths all do. Both components branch on `result.reason` so every error string, `setIsLoading` call, `startCooldown()` call, and `resetTurnstile()` call fires exactly as before. All six error strings are unchanged. A comment marks the early return so it isn't later folded into the common path.
- `contact_inquiries`' `name` to `contact_name` column mapping is now internal to the service. Both components dropped their `@/lib/supabase` import entirely.
- Both test files were rewritten rather than re-pointed: they now `vi.mock` the service and assert plain-object calls (`toHaveBeenCalledWith({ email, name, purpose, referral })`) instead of the array-wrapped Supabase insert shape, with mocks resolving `{ ok: false, reason: "duplicate" }` in place of `{ error: { code: "23505" } }`. Left as-is, they would have silently stopped asserting anything.

**Analytics split**
- Split `src/lib/analytics.ts` (199 lines) into `src/utils/device.ts` (device, browser, and OS detection, pure and import-free), `src/services/geolocation.ts` (the `ipapi.co` fetch with its `sessionStorage` cache, 3s `AbortController` timeout, and `emptyGeo` fallback), and `src/services/analytics.ts` (visitor and session IDs, UTM parsing, `trackPageView`).
- `trackPageView` is unchanged, including its four early returns, the un-awaited `page_views` insert, the background `visitors` upsert on `visitor_id`, and the development-only console warnings.
- `Analytics.tsx` now imports from `@/services/analytics`. Confirmed by grep that it was the only consumer (checked both alias and relative import forms, before and after rewiring), so `lib/analytics.ts` is deleted outright with no re-export shim.
- One deliberate addition beyond a pure move: `emptyGeo` was an untyped literal and `getGeolocation` returned `any` via `JSON.parse`. This adds an explicit `GeoData` interface and annotates both, so the `geo.ip` and `geo.country_code` reads in the `visitors` upsert are now type-checked. Runtime behavior is unchanged, since the parse boundary is still `any` and assignment-compatible.

**MDX helper**
- Added `getStaticMdxContent(relativePath)` to `src/lib/mdx.ts`, purely additive. `privacy/page.tsx` and `terms/page.tsx` drop their direct `fs` and `path` imports and call it instead.
- Chose a small dedicated helper over reshaping the existing `getDocBySlug` and `getSidebarNav`, which are frontmatter and slug based and do not apply to privacy/terms (one static file each, no slug, no frontmatter).

## Evidence/Media (screenshots/videos)
- `npm test`: 5 test files, 20 tests, all passing. Note that no test exercises `trackPageView` directly, so the analytics split is verified by `tsc` and the build rather than by coverage. Flagging that as a known gap rather than implying otherwise.
- `npx tsc --noEmit`: clean, exit 0.
- `npm run lint`: no ESLint warnings or errors.
- `npm run build`: succeeded, 38/38 static pages. Route sizes essentially unchanged: `/contact` 3.48 to 3.55 kB (+70 B for the result-union branching), `/privacy` and `/terms` byte-identical at 2.16 kB and 929 B, shared JS 107 kB.
- `grep -rln '@/lib/supabase' src/` after the change returns only the two new services and the two privacy API routes, confirming no UI component imports it.
- Environment note, unrelated to this change: `npm test` initially crashed with `Cannot find module '@rolldown/binding-linux-x64-gnu'`, the known npm optional-dependency resolution bug (rolldown 1.1.5, transitively via `@vitejs/plugin-react`). I installed it with `--no-save` locally so the suite could run. `package.json` and `package-lock.json` are unmodified. If CI hits the same crash it needs a real fix (a lockfile entry or a clean `npm ci`) rather than that workaround.