### PR TITLE
refactor(hooks): extract useScrollSpy, use in SectionNav and TableOfC…

### DIFF
--- a/src/components/docs/TableOfContents.tsx
+++ b/src/components/docs/TableOfContents.tsx
@@ -1,64 +1,38 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import type { Heading } from "@/lib/mdx";
 import { cn } from "@/lib/cn";
+import { useScrollSpy } from "@/hooks/useScrollSpy";
 
 interface TableOfContentsProps {
   headings: Heading[];
 }
 
 export function TableOfContents({ headings }: TableOfContentsProps) {
-  const [activeId, setActiveId] = useState<string>("");
+  const headingIds = headings.map((h) => h.id);
 
-  useEffect(() => {
-    const observer = new IntersectionObserver(
-      (entries) => {
-        const visibleEntries = entries
-          .filter((entry) => entry.isIntersecting)
-          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
+  const activeId = useScrollSpy({
+    ids: headingIds,
+    rootMargin: "-72px 0px -60% 0px",
+    threshold: [0, 1],
+    pickActiveId: (entries) => {
+      const visibleEntries = entries
+        .filter((entry) => entry.isIntersecting)
+        .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
 
-        if (visibleEntries.length > 0) {
-          const isAtBottom =
-            window.innerHeight + window.scrollY >= document.documentElement.scrollHeight - 50;
+      if (visibleEntries.length === 0) return undefined;
 
-          if (isAtBottom) {
-            setActiveId(visibleEntries[visibleEntries.length - 1].target.id);
-          } else {
-            setActiveId(visibleEntries[0].target.id);
-          }
-        }
-      },
-      {
-        rootMargin: "-72px 0px -60% 0px",
-        threshold: [0, 1],
-      }
-    );
+      const isAtBottom =
+        window.innerHeight + window.scrollY >= document.documentElement.scrollHeight - 50;
 
-    headings.forEach(({ id }) => {
-      const el = document.getElementById(id);
-      if (el) observer.observe(el);
-    });
-
-    let scrollTimeout: ReturnType<typeof setTimeout>;
-    const handleScroll = () => {
-      clearTimeout(scrollTimeout);
-      scrollTimeout = setTimeout(() => {
-        const isAtBottom =
-          window.innerHeight + window.scrollY >= document.documentElement.scrollHeight - 50;
-        if (isAtBottom && headings.length > 0) {
-          setActiveId(headings[headings.length - 1].id);
-        }
-      }, 100);
-    };
-
-    window.addEventListener("scroll", handleScroll, { passive: true });
-    return () => {
-      clearTimeout(scrollTimeout);
-      observer.disconnect();
-      window.removeEventListener("scroll", handleScroll);
-    };
-  }, [headings]);
+      return isAtBottom
+        ? visibleEntries[visibleEntries.length - 1].target.id
+        : visibleEntries[0].target.id;
+    },
+    stickyLastOnBottom: true,
+    bottomOffsetPx: 50,
+    bottomCheckDebounceMs: 100,
+  });
 
   const handleClick = (e: React.MouseEvent<HTMLAnchorElement>, id: string) => {
     e.preventDefault();

--- a/src/components/shared/SectionNav.tsx
+++ b/src/components/shared/SectionNav.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import { useEffect, useRef, useState, type MouseEvent } from "react";
+import { useMemo, useRef, type MouseEvent } from "react";
 import { motion, LayoutGroup } from "framer-motion";
 import { cn } from "@/lib/cn";
+import { useScrollProgress } from "@/hooks/useScrollProgress";
+import { useScrollSpy } from "@/hooks/useScrollSpy";
 
 export type SectionNavItem = { id: string; label: string };
 
@@ -21,50 +23,22 @@ export default function SectionNav({
   scrollMarginPx,
   ariaLabel = "Section navigation",
 }: SectionNavProps) {
-  const [activeSection, setActiveSection] = useState(sections[0]?.id ?? "");
-  const [isNavPinned, setIsNavPinned] = useState(false);
   const navRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    const observer = new IntersectionObserver(
-      (entries) => {
-        let best = entries[0];
-        entries.forEach((entry) => {
-          if (entry.intersectionRatio > best.intersectionRatio) best = entry;
-        });
-        if (best?.isIntersecting && best.target.id) {
-          setActiveSection(best.target.id);
-        }
-      },
-      { threshold: [0.08, 0.25, 0.45, 0.65], rootMargin: "-14% 0px -14% 0px" }
-    );
+  const sectionIds = useMemo(() => sections.map(({ id }) => id), [sections]);
+  const activeSection = useScrollSpy({
+    ids: sectionIds,
+    threshold: [0.08, 0.25, 0.45, 0.65],
+    rootMargin: "-14% 0px -14% 0px",
+    initialId: sections[0]?.id ?? "",
+  });
 
-    sections.forEach(({ id }) => {
-      const el = document.getElementById(id);
-      if (el) observer.observe(el);
-    });
-
-    let ticking = false;
-    const onScroll = () => {
-      if (!ticking) {
-        ticking = true;
-        requestAnimationFrame(() => {
-          if (navRef.current) {
-            setIsNavPinned(navRef.current.getBoundingClientRect().top <= 81);
-          }
-          ticking = false;
-        });
-      }
-    };
-
-    window.addEventListener("scroll", onScroll, { passive: true });
-    onScroll();
-
-    return () => {
-      observer.disconnect();
-      window.removeEventListener("scroll", onScroll);
-    };
-  }, [sections]);
+  const scrollY = useScrollProgress();
+  const isNavPinned = useMemo(
+    () => (navRef.current ? navRef.current.getBoundingClientRect().top <= 81 : false),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [scrollY]
+  );
 
   const scrollToId = (e: MouseEvent<HTMLAnchorElement>, id: string) => {
     e.preventDefault();

--- a/src/hooks/useScrollSpy.ts
+++ b/src/hooks/useScrollSpy.ts
@@ -1,0 +1,110 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export interface UseScrollSpyOptions {
+  /** Element ids to observe, in document order. */
+  ids: string[];
+  rootMargin?: string;
+  threshold?: number | number[];
+  /**
+   * Given the batch of entries whose intersection state changed in this
+   * IntersectionObserver callback, return the id that should become
+   * active, or `undefined` to leave the current active id unchanged.
+   *
+   * Defaults to the entry with the highest `intersectionRatio` among the
+   * changed entries (matches the original SectionNav behavior).
+   */
+  pickActiveId?: (entries: IntersectionObserverEntry[]) => string | undefined;
+  /**
+   * When true, adds a debounced `scroll` listener that forces the last id
+   * in `ids` to become active once the user reaches the bottom of the
+   * page — for cases where the final heading/section may never itself
+   * reach `isIntersecting` (matches TableOfContents' fallback).
+   */
+  stickyLastOnBottom?: boolean;
+  /** Distance from the bottom of the page, in px, to count as "at bottom". Default 50. */
+  bottomOffsetPx?: number;
+  /** Debounce delay, in ms, for the bottom-of-page scroll fallback. Default 100. */
+  bottomCheckDebounceMs?: number;
+  /**
+   * Active id before the observer has fired once. Defaults to `""`
+   * (nothing active on first paint). Pass `ids[0]` explicitly if the
+   * consumer should highlight the first item immediately on mount.
+   */
+  initialId?: string;
+}
+
+const defaultPickActiveId = (
+  entries: IntersectionObserverEntry[]
+): string | undefined => {
+  let best = entries[0];
+  entries.forEach((entry) => {
+    if (entry.intersectionRatio > best.intersectionRatio) best = entry;
+  });
+  return best?.isIntersecting && best.target.id ? best.target.id : undefined;
+};
+
+/**
+ * Tracks which of `ids` is "active" based on IntersectionObserver state.
+ * Centralizes the observer setup/teardown boilerplate duplicated across
+ * SectionNav, TableOfContents, UseCasesClient, and Navbar, while leaving
+ * each consumer's tie-breaking logic customizable via `pickActiveId`
+ * since SectionNav and TableOfContents disagree on which visible section
+ * should "win" when more than one is intersecting at once.
+ */
+export function useScrollSpy({
+  ids,
+  rootMargin = "0px",
+  threshold = 0,
+  pickActiveId = defaultPickActiveId,
+  stickyLastOnBottom = false,
+  bottomOffsetPx = 50,
+  bottomCheckDebounceMs = 100,
+  initialId = "",
+}: UseScrollSpyOptions): string {
+  const [activeId, setActiveId] = useState<string>(initialId);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const nextId = pickActiveId(entries);
+        if (nextId) setActiveId(nextId);
+      },
+      { rootMargin, threshold }
+    );
+
+    ids.forEach((id) => {
+      const el = document.getElementById(id);
+      if (el) observer.observe(el);
+    });
+
+    let scrollTimeout: ReturnType<typeof setTimeout>;
+    const handleScroll = () => {
+      if (!stickyLastOnBottom) return;
+      clearTimeout(scrollTimeout);
+      scrollTimeout = setTimeout(() => {
+        const isAtBottom =
+          window.innerHeight + window.scrollY >=
+          document.documentElement.scrollHeight - bottomOffsetPx;
+        const lastId = ids[ids.length - 1];
+        if (isAtBottom && lastId) setActiveId(lastId);
+      }, bottomCheckDebounceMs);
+    };
+
+    if (stickyLastOnBottom) {
+      window.addEventListener("scroll", handleScroll, { passive: true });
+    }
+
+    return () => {
+      observer.disconnect();
+      clearTimeout(scrollTimeout);
+      if (stickyLastOnBottom) {
+        window.removeEventListener("scroll", handleScroll);
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ids.join(","), rootMargin, JSON.stringify(threshold), stickyLastOnBottom, bottomOffsetPx, bottomCheckDebounceMs]);
+
+  return activeId;
+}


### PR DESCRIPTION
# 📝 Pull Request 

## 🔧 Title: 
- refactor(hooks): extract useScrollSpy, use in SectionNav and TableOfContents

## 🛠️ Issue
- Part of #1471 (partial — see Description for scope)

## 📚 Description
- Second slice of the hooks layer from #1471. Adds `useScrollSpy`, a shared IntersectionObserver-based hook, and applies it to `SectionNav` (used on `/architecture` and `/blueprint`) and `TableOfContents` (used on `/docs/*` pages).
- `SectionNav` and `TableOfContents` pick the "active" section differently: `SectionNav` takes whichever visible section has the highest intersection ratio; `TableOfContents` takes the topmost visible heading, falling back to the last heading once the user reaches the bottom of the page. The hook exposes this as a `pickActiveId` override rather than hard-coding one behavior, so both are preserved exactly.
- `UseCasesClient` and `Navbar` also use scroll-spy but have more surrounding state specific to each, so they're left for a follow-up PR rather than risked here.

## ✅ Changes applied
- Added `src/hooks/useScrollSpy.ts`.
- Refactored `src/components/shared/SectionNav.tsx` to use `useScrollSpy` (active section) and the existing `useScrollProgress` (pinned-nav shadow state).
- Refactored `src/components/docs/TableOfContents.tsx` to use `useScrollSpy` with its bottom-of-page fallback via `stickyLastOnBottom`.
- No changes to markup, styling, thresholds, or rootMargin values.

## 🔍 Evidence
- `npx tsc --noEmit`: 0 errors from touched files
- `npm run build`: passes