### PR TITLE
refactor(hooks): extract usePillIndicator, apply useScrollSpy/useScro…

### DIFF
--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -8,6 +8,7 @@ import { Menu, X, Send } from "lucide-react";
 import { cn } from "@/lib/cn";
 import { ThemeToggle } from "@/components/ui/ThemeToggle";
 import { useTheme } from "@/components/providers/ThemeProvider";
+import { useScrollProgress } from "@/hooks/useScrollProgress";
 
 const navLinks = [
   { href: "/#features", label: "Features" },
@@ -41,8 +42,9 @@ export function isLinkActive(href: string, pathname: string): boolean {
 
 export function Navbar() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const [isScrolled, setIsScrolled] = useState(false);
   const pathname = usePathname();
+  const scrollY = useScrollProgress();
+  const isScrolled = scrollY > 12;
 
   const menuRef = useRef<HTMLDivElement>(null);
   const toggleRef = useRef<HTMLButtonElement>(null);
@@ -96,21 +98,6 @@ export function Navbar() {
       wasMenuOpen.current = false;
     }
   }, [isMenuOpen]);
-
-  useEffect(() => {
-    let ticking = false;
-    const onScroll = () => {
-      if (!ticking) {
-        ticking = true;
-        requestAnimationFrame(() => {
-          setIsScrolled(window.scrollY > 12);
-          ticking = false;
-        });
-      }
-    };
-    window.addEventListener("scroll", onScroll, { passive: true });
-    return () => window.removeEventListener("scroll", onScroll);
-  }, []);
 
   useEffect(() => {
     if (isMenuOpen) {

--- a/src/components/use-cases/UseCasesClient.tsx
+++ b/src/components/use-cases/UseCasesClient.tsx
@@ -5,7 +5,7 @@ import {
   useState,
   useEffect,
   useRef,
-  useCallback,
+  useMemo,
   type ComponentType,
   type ReactNode,
 } from "react";
@@ -13,6 +13,9 @@ import {
 import { Navbar } from "@/components/layout/Navbar";
 import { Footer } from "@/components/layout/Footer";
 import { cn } from "@/lib/cn";
+import { useScrollProgress } from "@/hooks/useScrollProgress";
+import { useScrollSpy } from "@/hooks/useScrollSpy";
+import { usePillIndicator } from "@/hooks/usePillIndicator";
 
 import { USE_CASES, PAGE_SECTIONS, SCROLL_OFFSET } from "./constants";
 import type { UseCaseId } from "./constants";
@@ -44,125 +47,62 @@ const SECTIONS: Record<UseCaseId, ComponentType<SectionProps>> = {
   ),
 };
 
+const SECTION_IDS = PAGE_SECTIONS.map((s) => s.id);
+
 export function UseCasesClient() {
   const [activeUseCase, setActiveUseCase] = useState<UseCaseId>("freelance");
-  const [activeSection, setActiveSection] = useState<string>(
-    PAGE_SECTIONS[0].id,
-  );
-  const [isNavPinned, setIsNavPinned] = useState(false);
-  const [pillStyle, setPillStyle] = useState<{
-    left: number;
-    width: number;
-  } | null>(null);
   const [touchedId, setTouchedId] = useState<string | null>(null);
 
   const navRef = useRef<HTMLDivElement>(null);
-  const pillContainerRef = useRef<HTMLDivElement>(null);
-  const linkRefs = useRef<Map<string, HTMLAnchorElement>>(new Map());
+  // Accumulates the latest known ratio per section id across observer
+  // callbacks, since IntersectionObserver only reports entries whose ratio
+  // changed since the last check, not every observed element each time.
+  const visibilityMapRef = useRef<Map<string, number>>(new Map());
 
-  const setLinkRef = useCallback((id: string, el: HTMLAnchorElement | null) => {
-    if (el) linkRefs.current.set(id, el);
-    else linkRefs.current.delete(id);
-  }, []);
-
-  const updatePillIndicator = useCallback(() => {
-    const container = pillContainerRef.current;
-    const activeLink = linkRefs.current.get(activeSection);
-    if (!container || !activeLink) return;
-
-    const containerRect = container.getBoundingClientRect();
-    const linkRect = activeLink.getBoundingClientRect();
-
-    setPillStyle({
-      left: linkRect.left - containerRect.left,
-      width: linkRect.width,
-    });
-  }, [activeSection]);
-
-  // Re-establish the scroll-spy observer whenever the active use case changes:
-  // the new section mounts lazily, so we retry on the next frame until all
-  // section elements exist in the DOM.
+  // Discard stale ratios from the previous tab's sections before the new
+  // tab's observer starts reporting — the section ids are identical across
+  // tabs (PAGE_SECTIONS is fixed), only the DOM nodes get swapped.
   useEffect(() => {
-    let raf = 0;
-    let observer: IntersectionObserver | null = null;
-
-    const setup = () => {
-      const sectionElements = PAGE_SECTIONS.map((s) =>
-        document.getElementById(s.id),
-      ).filter(Boolean) as HTMLElement[];
-
-      if (sectionElements.length < PAGE_SECTIONS.length) {
-        raf = requestAnimationFrame(setup);
-        return;
-      }
-
-      const visibilityMap = new Map<string, number>();
-
-      observer = new IntersectionObserver(
-        (entries) => {
-          entries.forEach((entry) => {
-            visibilityMap.set(entry.target.id, entry.intersectionRatio);
-          });
-
-          let bestId: string = activeSection;
-          let bestRatio = -1;
-
-          visibilityMap.forEach((ratio, id) => {
-            if (ratio > bestRatio) {
-              bestRatio = ratio;
-              bestId = id;
-            }
-          });
-
-          if (bestRatio > 0.05 && bestId !== activeSection) {
-            setActiveSection(bestId);
-          }
-        },
-        {
-          threshold: [0, 0.1, 0.25, 0.4, 0.6, 0.75, 1],
-          rootMargin: "-140px 0px -30% 0px",
-        },
-      );
-
-      sectionElements.forEach((el) => observer!.observe(el));
-    };
-
-    setup();
-
-    return () => {
-      cancelAnimationFrame(raf);
-      observer?.disconnect();
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    visibilityMapRef.current.clear();
   }, [activeUseCase]);
 
-  useEffect(() => {
-    let ticking = false;
-
-    const handleScroll = () => {
-      if (ticking) return;
-      ticking = true;
-      requestAnimationFrame(() => {
-        if (navRef.current) {
-          setIsNavPinned(navRef.current.getBoundingClientRect().top <= 81);
-        }
-        ticking = false;
+  const activeSection = useScrollSpy({
+    ids: SECTION_IDS,
+    threshold: [0, 0.1, 0.25, 0.4, 0.6, 0.75, 1],
+    rootMargin: "-140px 0px -30% 0px",
+    initialId: PAGE_SECTIONS[0].id,
+    // Each use case's sections mount lazily (next/dynamic), so wait until
+    // they all exist in the DOM before attaching the observer, and re-run
+    // that wait whenever the tab changes even though the ids don't.
+    waitForElements: true,
+    resetKey: activeUseCase,
+    pickActiveId: (entries) => {
+      entries.forEach((entry) => {
+        visibilityMapRef.current.set(entry.target.id, entry.intersectionRatio);
       });
-    };
 
-    window.addEventListener("scroll", handleScroll, { passive: true });
-    return () => window.removeEventListener("scroll", handleScroll);
-  }, []);
+      let bestId: string | undefined;
+      let bestRatio = -1;
+      visibilityMapRef.current.forEach((ratio, id) => {
+        if (ratio > bestRatio) {
+          bestRatio = ratio;
+          bestId = id;
+        }
+      });
 
-  useEffect(() => {
-    updatePillIndicator();
-  }, [activeSection, updatePillIndicator]);
+      return bestRatio > 0.05 ? bestId : undefined;
+    },
+  });
 
-  useEffect(() => {
-    const onResize = () => updatePillIndicator();
-    window.addEventListener("resize", onResize, { passive: true });
-    return () => window.removeEventListener("resize", onResize);
-  }, [updatePillIndicator]);
+  const scrollY = useScrollProgress();
+  const isNavPinned = useMemo(
+    () => (navRef.current ? navRef.current.getBoundingClientRect().top <= 81 : false),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [scrollY],
+  );
+
+  const { containerRef: pillContainerRef, setItemRef: setLinkRef, pillStyle } =
+    usePillIndicator(activeSection);
 
   const handleNavClick = (
     e: React.MouseEvent<HTMLAnchorElement>,
@@ -182,7 +122,6 @@ export function UseCasesClient() {
 
   const handleUseCaseSwitch = (id: UseCaseId) => {
     setActiveUseCase(id);
-    setActiveSection("overview");
     window.scrollTo({ top: 0, behavior: "smooth" });
   };
 

--- a/src/hooks/usePillIndicator.ts
+++ b/src/hooks/usePillIndicator.ts
@@ -1,0 +1,52 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export interface PillStyle {
+  left: number;
+  width: number;
+}
+
+/**
+ * Tracks the position/width a "sliding pill" indicator should animate to,
+ * based on which item id is currently active. Extracted out of
+ * UseCasesClient's inline pill-indicator state (container ref, per-item
+ * refs, and the resize/active-id effects that recompute the pill's
+ * bounding box).
+ */
+export function usePillIndicator(activeId: string) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const itemRefs = useRef<Map<string, HTMLElement>>(new Map());
+  const [pillStyle, setPillStyle] = useState<PillStyle | null>(null);
+
+  const setItemRef = useCallback((id: string, el: HTMLElement | null) => {
+    if (el) itemRefs.current.set(id, el);
+    else itemRefs.current.delete(id);
+  }, []);
+
+  const updatePillStyle = useCallback(() => {
+    const container = containerRef.current;
+    const activeEl = itemRefs.current.get(activeId);
+    if (!container || !activeEl) return;
+
+    const containerRect = container.getBoundingClientRect();
+    const itemRect = activeEl.getBoundingClientRect();
+
+    setPillStyle({
+      left: itemRect.left - containerRect.left,
+      width: itemRect.width,
+    });
+  }, [activeId]);
+
+  useEffect(() => {
+    updatePillStyle();
+  }, [activeId, updatePillStyle]);
+
+  useEffect(() => {
+    const onResize = () => updatePillStyle();
+    window.addEventListener("resize", onResize, { passive: true });
+    return () => window.removeEventListener("resize", onResize);
+  }, [updatePillStyle]);
+
+  return { containerRef, setItemRef, pillStyle };
+}

--- a/src/hooks/useScrollSpy.ts
+++ b/src/hooks/useScrollSpy.ts
@@ -33,6 +33,22 @@ export interface UseScrollSpyOptions {
    * consumer should highlight the first item immediately on mount.
    */
   initialId?: string;
+  /**
+   * When true, polls via `requestAnimationFrame` until every id in `ids`
+   * resolves to an element in the DOM before creating the observer,
+   * instead of observing whatever subset exists on the first synchronous
+   * check. Needed when the observed elements are lazy-loaded (e.g. behind
+   * `next/dynamic`) and may not have mounted yet when this hook runs.
+   */
+  waitForElements?: boolean;
+  /**
+   * Extra dependency values that force the observer to be torn down and
+   * re-created, beyond `ids`/`rootMargin`/`threshold`/etc. Needed when the
+   * *set* of ids stays the same across some external change but the
+   * underlying DOM nodes are swapped out (e.g. switching tabs where each
+   * tab lazily mounts its own elements under the same section ids).
+   */
+  resetKey?: string | number;
 }
 
 const defaultPickActiveId = (
@@ -62,22 +78,50 @@ export function useScrollSpy({
   bottomOffsetPx = 50,
   bottomCheckDebounceMs = 100,
   initialId = "",
+  waitForElements = false,
+  resetKey,
 }: UseScrollSpyOptions): string {
   const [activeId, setActiveId] = useState<string>(initialId);
 
   useEffect(() => {
-    const observer = new IntersectionObserver(
-      (entries) => {
-        const nextId = pickActiveId(entries);
-        if (nextId) setActiveId(nextId);
-      },
-      { rootMargin, threshold }
-    );
+    // Whenever the observer is torn down and re-created (new ids, or a
+    // resetKey change), snap back to initialId immediately rather than
+    // waiting for the new observer to fire. Matches consumers that need an
+    // eager reset on external changes (e.g. UseCasesClient resetting to its
+    // first section the instant the active tab changes).
+    setActiveId(initialId);
 
-    ids.forEach((id) => {
-      const el = document.getElementById(id);
-      if (el) observer.observe(el);
-    });
+    let raf = 0;
+    let observer: IntersectionObserver | null = null;
+
+    const attach = () => {
+      observer = new IntersectionObserver(
+        (entries) => {
+          const nextId = pickActiveId(entries);
+          if (nextId) setActiveId(nextId);
+        },
+        { rootMargin, threshold }
+      );
+
+      ids.forEach((id) => {
+        const el = document.getElementById(id);
+        if (el) observer!.observe(el);
+      });
+    };
+
+    if (waitForElements) {
+      const setup = () => {
+        const allMounted = ids.every((id) => document.getElementById(id));
+        if (!allMounted) {
+          raf = requestAnimationFrame(setup);
+          return;
+        }
+        attach();
+      };
+      setup();
+    } else {
+      attach();
+    }
 
     let scrollTimeout: ReturnType<typeof setTimeout>;
     const handleScroll = () => {
@@ -97,14 +141,24 @@ export function useScrollSpy({
     }
 
     return () => {
-      observer.disconnect();
+      cancelAnimationFrame(raf);
+      observer?.disconnect();
       clearTimeout(scrollTimeout);
       if (stickyLastOnBottom) {
         window.removeEventListener("scroll", handleScroll);
       }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [ids.join(","), rootMargin, JSON.stringify(threshold), stickyLastOnBottom, bottomOffsetPx, bottomCheckDebounceMs]);
+  }, [
+    ids.join(","),
+    rootMargin,
+    JSON.stringify(threshold),
+    stickyLastOnBottom,
+    bottomOffsetPx,
+    bottomCheckDebounceMs,
+    waitForElements,
+    resetKey,
+  ]);
 
   return activeId;
 }


### PR DESCRIPTION
# 📝 Pull Request 

## 🔧 Title: 
- refactor(hooks): extract usePillIndicator, apply useScrollSpy/useScrollProgress to UseCasesClient and Navbar

## 🛠️ Issue
- Part of #1471 (partial — completes the RAF/scroll-spy portion of the acceptance criteria)

## 📚 Description
- Final slice of the RAF + scroll-spy duplication from #1471. Covers the two remaining consumers: `UseCasesClient` and `Navbar`.
- `UseCasesClient`'s scroll-spy differs from `SectionNav`/`TableOfContents` in two ways that `useScrollSpy` didn't support yet: it accumulates intersection ratios across observer callbacks (since IntersectionObserver only reports changed entries, not the full set each time), and it waits via `requestAnimationFrame` for its lazily-loaded (`next/dynamic`) sections to mount before attaching the observer, re-running that wait on every tab switch. Extended `useScrollSpy` with `waitForElements` and `resetKey` to cover this — both default to off/unset, so `SectionNav` and `TableOfContents` are unaffected.
- Added `usePillIndicator`, extracting the pill-position-tracking state (container ref, per-item refs, resize/active-id effects) that was inline in `UseCasesClient`, per the issue's explicit callout to extract that logic out of the 310-line file.
- `Navbar` only had its RAF scroll listener (`isScrolled`) in scope here — its focus-trap and body-scroll-lock logic are separate hooks (`useFocusTrap`, `useBodyScrollLock`) for their own slices.

## ✅ Changes applied
- Extended `src/hooks/useScrollSpy.ts` with `waitForElements` (poll for lazy-mounted elements) and `resetKey` (force re-attach + reset to `initialId` on external changes).
- Added `src/hooks/usePillIndicator.ts`.
- Refactored `src/components/use-cases/UseCasesClient.tsx` (317 → 256 lines) to use `useScrollSpy`, `usePillIndicator`, and `useScrollProgress`. Behavior preserved exactly: same tie-break logic, same lazy-mount retry, same eager reset to "Overview" on tab switch.
- Refactored `src/components/layout/Navbar.tsx`'s scroll listener to use `useScrollProgress`. No change to its focus-trap or body-scroll-lock effects.

## 🔍 Evidence
- `npx tsc --noEmit`: 0 errors repo-wide
- `npm run build`: passes