### PR TITLE
refactor(hooks): extract useFocusTrap and useBodyScrollLock

### DIFF
--- a/src/components/docs/DocsLayoutShell.tsx
+++ b/src/components/docs/DocsLayoutShell.tsx
@@ -11,6 +11,7 @@ import { TableOfContents } from "@/components/docs/TableOfContents";
 import { Navbar } from "@/components/layout/Navbar";
 import { Breadcrumb } from "@/components/docs/Breadcrumb";
 import { FileCode2, FileText, Github } from "lucide-react";
+import { useFocusTrap } from "@/hooks/useFocusTrap";
 
 // Use production URL for AI assistant links
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://offer-hub.tech";
@@ -63,35 +64,11 @@ export function DocsLayoutShell({ nav, children }: DocsLayoutShellProps) {
     setIsDrawerOpen(false);
   }, [pathname]);
 
-  useEffect(() => {
-    if (!isDrawerOpen) return;
-    const drawerEl = drawerRef.current;
-    if (!drawerEl) return;
-
-    const focusableSelectors =
-      'a[href], button:not([disabled]), [tabIndex]:not([tabIndex="-1"])';
-    const focusableElements = Array.from(
-      drawerEl.querySelectorAll<HTMLElement>(focusableSelectors)
-    );
-    focusableElements[0]?.focus();
-
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") { setIsDrawerOpen(false); return; }
-      if (e.key === "Tab") {
-        const first = focusableElements[0];
-        const last = focusableElements[focusableElements.length - 1];
-        if (!first || !last) return;
-        if (e.shiftKey) {
-          if (document.activeElement === first) { last.focus(); e.preventDefault(); }
-        } else {
-          if (document.activeElement === last) { first.focus(); e.preventDefault(); }
-        }
-      }
-    };
-
-    document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [isDrawerOpen]);
+  useFocusTrap({
+    containerRef: drawerRef,
+    isActive: isDrawerOpen,
+    onEscape: () => setIsDrawerOpen(false),
+  });
 
   useEffect(() => {
     if (isHub) return;

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useRef } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
@@ -9,6 +9,8 @@ import { cn } from "@/lib/cn";
 import { ThemeToggle } from "@/components/ui/ThemeToggle";
 import { useTheme } from "@/components/providers/ThemeProvider";
 import { useScrollProgress } from "@/hooks/useScrollProgress";
+import { useFocusTrap } from "@/hooks/useFocusTrap";
+import { useBodyScrollLock } from "@/hooks/useBodyScrollLock";
 
 const navLinks = [
   { href: "/#features", label: "Features" },
@@ -48,67 +50,15 @@ export function Navbar() {
 
   const menuRef = useRef<HTMLDivElement>(null);
   const toggleRef = useRef<HTMLButtonElement>(null);
-  const wasMenuOpen = useRef(false);
 
-  useEffect(() => {
-    if (isMenuOpen) {
-      wasMenuOpen.current = true;
-      const menuEl = menuRef.current;
-      if (!menuEl) return;
+  useFocusTrap({
+    containerRef: menuRef,
+    isActive: isMenuOpen,
+    onEscape: () => setIsMenuOpen(false),
+    restoreFocusRef: toggleRef,
+  });
 
-      const focusableSelectors =
-        'a[href], button:not([disabled]), [tabIndex]:not([tabIndex="-1"])';
-      const focusableElements = Array.from(
-        menuEl.querySelectorAll<HTMLElement>(focusableSelectors)
-      );
-
-      if (focusableElements.length > 0) {
-        focusableElements[0].focus();
-      }
-
-      const handleKeyDown = (e: KeyboardEvent) => {
-        if (e.key === "Escape") {
-          setIsMenuOpen(false);
-          return;
-        }
-
-        if (e.key === "Tab") {
-          const firstEl = focusableElements[0];
-          const lastEl = focusableElements[focusableElements.length - 1];
-          if (!firstEl || !lastEl) return;
-
-          if (e.shiftKey) {
-            if (document.activeElement === firstEl) {
-              lastEl.focus();
-              e.preventDefault();
-            }
-          } else {
-            if (document.activeElement === lastEl) {
-              firstEl.focus();
-              e.preventDefault();
-            }
-          }
-        }
-      };
-
-      document.addEventListener("keydown", handleKeyDown);
-      return () => document.removeEventListener("keydown", handleKeyDown);
-    } else if (wasMenuOpen.current) {
-      toggleRef.current?.focus();
-      wasMenuOpen.current = false;
-    }
-  }, [isMenuOpen]);
-
-  useEffect(() => {
-    if (isMenuOpen) {
-      document.body.style.overflow = "hidden";
-    } else {
-      document.body.style.overflow = "";
-    }
-    return () => {
-      document.body.style.overflow = "";
-    };
-  }, [isMenuOpen]);
+  useBodyScrollLock(isMenuOpen);
 
   const { resolvedTheme } = useTheme();
 

--- a/src/components/shared/DiagramZoomModal.tsx
+++ b/src/components/shared/DiagramZoomModal.tsx
@@ -3,6 +3,7 @@
 import { useEffect, type ReactNode } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { X } from "lucide-react";
+import { useBodyScrollLock } from "@/hooks/useBodyScrollLock";
 
 type Props = {
   title: string;
@@ -12,10 +13,7 @@ type Props = {
 };
 
 export function DiagramZoomModal({ title, isOpen, onClose, children }: Props) {
-  useEffect(() => {
-    document.body.style.overflow = isOpen ? "hidden" : "";
-    return () => { document.body.style.overflow = ""; };
-  }, [isOpen]);
+  useBodyScrollLock(isOpen);
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };

--- a/src/hooks/useBodyScrollLock.ts
+++ b/src/hooks/useBodyScrollLock.ts
@@ -1,0 +1,17 @@
+"use client";
+
+import { useEffect } from "react";
+
+/**
+ * Locks `document.body` scroll (via `overflow: hidden`) while `isLocked`
+ * is true, restoring it on unlock/unmount. Matches the pattern duplicated
+ * between Navbar's mobile menu and DiagramZoomModal.
+ */
+export function useBodyScrollLock(isLocked: boolean) {
+  useEffect(() => {
+    document.body.style.overflow = isLocked ? "hidden" : "";
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [isLocked]);
+}

--- a/src/hooks/useFocusTrap.ts
+++ b/src/hooks/useFocusTrap.ts
@@ -1,0 +1,86 @@
+"use client";
+
+import { useEffect, useRef, type RefObject } from "react";
+
+export interface UseFocusTrapOptions {
+  /** Container whose focusable descendants form the trap. */
+  containerRef: RefObject<HTMLElement | null>;
+  /** Whether the trap is currently engaged (e.g. the menu/drawer is open). */
+  isActive: boolean;
+  /** Called when Escape is pressed while the trap is active. */
+  onEscape?: () => void;
+  /**
+   * Element to return focus to once the trap deactivates. Omit if the
+   * consumer doesn't restore focus on close (matches DocsLayoutShell's
+   * drawer, which doesn't restore focus, vs Navbar's mobile menu, which
+   * returns focus to its toggle button).
+   */
+  restoreFocusRef?: RefObject<HTMLElement | null>;
+}
+
+const FOCUSABLE_SELECTORS =
+  'a[href], button:not([disabled]), [tabIndex]:not([tabIndex="-1"])';
+
+/**
+ * Traps Tab/Shift+Tab focus cycling within `containerRef` while `isActive`
+ * is true, focuses the first focusable element on activation, and calls
+ * `onEscape` on Escape. Optionally restores focus to `restoreFocusRef` on
+ * deactivation. Matches the pattern duplicated between Navbar's mobile
+ * menu and DocsLayoutShell's mobile drawer.
+ */
+export function useFocusTrap({
+  containerRef,
+  isActive,
+  onEscape,
+  restoreFocusRef,
+}: UseFocusTrapOptions) {
+  const wasActive = useRef(false);
+
+  useEffect(() => {
+    if (isActive) {
+      wasActive.current = true;
+      const containerEl = containerRef.current;
+      if (!containerEl) return;
+
+      const focusableElements = Array.from(
+        containerEl.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS)
+      );
+
+      if (focusableElements.length > 0) {
+        focusableElements[0].focus();
+      }
+
+      const handleKeyDown = (e: KeyboardEvent) => {
+        if (e.key === "Escape") {
+          onEscape?.();
+          return;
+        }
+
+        if (e.key === "Tab") {
+          const firstEl = focusableElements[0];
+          const lastEl = focusableElements[focusableElements.length - 1];
+          if (!firstEl || !lastEl) return;
+
+          if (e.shiftKey) {
+            if (document.activeElement === firstEl) {
+              lastEl.focus();
+              e.preventDefault();
+            }
+          } else {
+            if (document.activeElement === lastEl) {
+              firstEl.focus();
+              e.preventDefault();
+            }
+          }
+        }
+      };
+
+      document.addEventListener("keydown", handleKeyDown);
+      return () => document.removeEventListener("keydown", handleKeyDown);
+    } else if (wasActive.current) {
+      restoreFocusRef?.current?.focus();
+      wasActive.current = false;
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isActive]);
+}


### PR DESCRIPTION
# 📝 Pull Request 

## 🔧 Title: 
- refactor(hooks): extract useFocusTrap and useBodyScrollLock

## 🛠️ Issue
- Part of #1471 (partial — see Description)

## 📚 Description
- Adds two of the five remaining hooks from #1471.
- `useFocusTrap` covers Navbar's mobile menu and DocsLayoutShell's mobile drawer. They differ in one way: Navbar restores focus to its toggle button when the menu closes; DocsLayoutShell doesn't restore focus at all. Exposed as an optional `restoreFocusRef` rather than hard-coding either behavior.
- `useBodyScrollLock` covers Navbar's mobile menu and `DiagramZoomModal` — identical `document.body.style.overflow` pattern in both, straightforward extraction.

## ✅ Changes applied
- Added `src/hooks/useFocusTrap.ts` and `src/hooks/useBodyScrollLock.ts`.
- Refactored `Navbar.tsx`, `DocsLayoutShell.tsx`, and `DiagramZoomModal.tsx` to use them. No markup or styling changes.

## 🔍 Evidence
- `npx tsc --noEmit`: 0 errors
- `npx next lint`: 0 new warnings (2 pre-existing warnings in already-merged `useScrollSpy.ts`, unrelated)
- `npm run build`: passes