### PR TITLE
refactor(hooks): extract useDebounce, useMediaQuery, useLiquidTextAni…

### DIFF
--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useRef, useEffect } from "react";
+import { useRef } from "react";
 import Link from "next/link";
 import { ArrowRight, ChevronDown } from "lucide-react";
+import { useLiquidTextAnimation } from "@/hooks/useLiquidTextAnimation";
 
 /**
  * Animation-only highlight tones for the liquid text effect. These are NOT
@@ -27,90 +28,7 @@ const LIQUID_HIGHLIGHTS = {
 export function HeroSection() {
   const headingRef = useRef<HTMLHeadingElement>(null);
 
-  useEffect(() => {
-    const el = headingRef.current;
-    if (!el) return;
-
-    // Detect prefers-reduced-motion
-    const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
-    let shouldReduceMotion = mediaQuery.matches;
-
-    const handleMediaChange = (e: MediaQueryListEvent) => {
-      shouldReduceMotion = e.matches;
-      if (shouldReduceMotion) {
-        cancelAnimationFrame(frame);
-        // Set a static beautiful gradient if motion is reduced
-        el.style.backgroundImage = `linear-gradient(135deg, ${LIQUID_HIGHLIGHTS.highlight} 0%, var(--color-primary) 100%)`;
-      } else {
-        frame = requestAnimationFrame(animate);
-      }
-    };
-
-    mediaQuery.addEventListener("change", handleMediaChange);
-
-    let frame: number;
-    let t = 0;
-    let paused = false;
-
-    const animate = () => {
-      if (paused || shouldReduceMotion) return;
-      t += 0.022;
-
-      const b1x = 50 + 28 * Math.sin(t * 0.70);
-      const b1y = 50 + 22 * Math.cos(t * 0.50);
-      const b2x = 50 + 22 * Math.sin(t * 0.40 + 2.0);
-      const b2y = 50 + 28 * Math.cos(t * 0.60 + 1.2);
-      const b3x = 50 + 32 * Math.sin(t * 0.85 + 4.2);
-      const b3y = 50 + 18 * Math.cos(t * 0.75 + 3.0);
-      const b4x = 50 + 18 * Math.sin(t * 1.10 + 1.0);
-      const b4y = 50 + 30 * Math.cos(t * 0.95 + 5.1);
-      const b5x = 50 + 38 * Math.sin(t * 0.55 + 5.5);
-      const b5y = 50 + 24 * Math.cos(t * 0.42 + 4.0);
-      const b6x = 50 + 14 * Math.sin(t * 1.30 + 3.0);
-      const b6y = 50 + 14 * Math.cos(t * 1.15 + 2.0);
-
-      el.style.backgroundImage = [
-        `radial-gradient(ellipse 48% 55% at ${b1x}% ${b1y}%, ${LIQUID_HIGHLIGHTS.highlight} 0%, var(--color-primary) 45%, color-mix(in srgb, var(--color-primary) 0%, transparent) 82%)`,
-        `radial-gradient(ellipse 38% 46% at ${b2x}% ${b2y}%, ${LIQUID_HIGHLIGHTS.brightest} 0%, ${LIQUID_HIGHLIGHTS.highlight} 40%, color-mix(in srgb, ${LIQUID_HIGHLIGHTS.highlight} 0%, transparent) 80%)`,
-        `radial-gradient(ellipse 32% 42% at ${b3x}% ${b3y}%, var(--color-accent) 0%, color-mix(in srgb, var(--color-accent) 0%, transparent) 78%)`,
-        `radial-gradient(ellipse 28% 38% at ${b4x}% ${b4y}%, var(--color-primary-hover) 0%, color-mix(in srgb, var(--color-primary-hover) 0%, transparent) 78%)`,
-        `radial-gradient(ellipse 44% 52% at ${b5x}% ${b5y}%, var(--color-primary) 0%, color-mix(in srgb, var(--color-primary) 0%, transparent) 82%)`,
-        `radial-gradient(ellipse 20% 26% at ${b6x}% ${b6y}%, ${LIQUID_HIGHLIGHTS.brightest} 0%, color-mix(in srgb, ${LIQUID_HIGHLIGHTS.brightest} 0%, transparent) 72%)`,
-        `radial-gradient(ellipse 62% 72% at ${b3x}% ${b2y}%, color-mix(in srgb, var(--color-bg-base) 90%, transparent) 0%, color-mix(in srgb, var(--color-bg-base) 50%, transparent) 40%, color-mix(in srgb, var(--color-bg-base) 0%, transparent) 78%)`,
-        `radial-gradient(ellipse 52% 62% at ${b5x}% ${b4y}%, color-mix(in srgb, var(--color-bg-base) 80%, transparent) 0%, color-mix(in srgb, var(--color-bg-base) 38%, transparent) 38%, color-mix(in srgb, var(--color-bg-base) 0%, transparent) 72%)`,
-        `radial-gradient(ellipse 42% 50% at ${b1x}% ${b6y}%, color-mix(in srgb, var(--color-bg-base) 65%, transparent) 0%, color-mix(in srgb, var(--color-bg-base) 20%, transparent) 45%, color-mix(in srgb, var(--color-bg-base) 0%, transparent) 70%)`,
-      ].join(", ");
-
-      frame = requestAnimationFrame(animate);
-    };
-
-    // Pause animation when tab is hidden to save CPU
-    const onVisibility = () => {
-      if (document.hidden) {
-        paused = true;
-        cancelAnimationFrame(frame);
-      } else {
-        paused = false;
-        if (!shouldReduceMotion) {
-          frame = requestAnimationFrame(animate);
-        }
-      }
-    };
-
-    document.addEventListener("visibilitychange", onVisibility);
-
-    if (shouldReduceMotion) {
-      el.style.backgroundImage = `linear-gradient(135deg, ${LIQUID_HIGHLIGHTS.highlight} 0%, var(--color-primary) 100%)`;
-    } else {
-      frame = requestAnimationFrame(animate);
-    }
-
-    return () => {
-      cancelAnimationFrame(frame);
-      document.removeEventListener("visibilitychange", onVisibility);
-      mediaQuery.removeEventListener("change", handleMediaChange);
-    };
-  }, []);
+  useLiquidTextAnimation(headingRef, LIQUID_HIGHLIGHTS);
 
   return (
     <section

--- a/src/components/docs/DocsSearchBar.tsx
+++ b/src/components/docs/DocsSearchBar.tsx
@@ -5,6 +5,7 @@ import { Search, FileText, ChevronRight, X } from "lucide-react";
 import Fuse, { type FuseResult, type FuseResultMatch } from "fuse.js";
 import { useRouter } from "next/navigation";
 import docsIndex from "@/data/docs-index.json";
+import { useDebounce } from "@/hooks/useDebounce";
 
 interface SearchResult {
     id: string;
@@ -16,7 +17,7 @@ interface SearchResult {
 
 export function DocsSearchBar() {
     const [query, setQuery] = useState("");
-    const [debounceQuery, setDebounceQuery] = useState("");
+    const debounceQuery = useDebounce(query, 300);
     const [results, setResults] = useState<FuseResult<SearchResult>[]>([]);
     const [isOpen, setIsOpen] = useState(false);
     const [activeIndex, setActiveIndex] = useState(-1);
@@ -32,14 +33,6 @@ export function DocsSearchBar() {
         includeMatches: true,
         minMatchCharLength: 2,
     }), []);
-
-    useEffect(() => {
-        const timer = setTimeout(() => {
-            setDebounceQuery(query);
-        }, 300);
-
-        return () => clearTimeout(timer);
-    }, [query]);
 
     useEffect(() => {
         if (debounceQuery.length > 1) {

--- a/src/components/use-cases/shared/EscrowFlowDiagram.tsx
+++ b/src/components/use-cases/shared/EscrowFlowDiagram.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useState, useRef, useEffect, useCallback, useId } from "react";
+import { useState, useRef, useCallback, useId } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { cn } from "@/lib/cn";
+import { useMediaQuery } from "@/hooks/useMediaQuery";
 
 export interface EscrowStep {
   stepNumber: number;
@@ -252,15 +253,7 @@ export function EscrowFlowDiagram({
   className,
 }: EscrowFlowDiagramProps) {
   const [activeStep, setActiveStep] = useState<number | null>(null);
-  const [isMobile, setIsMobile] = useState(false);
-
-  useEffect(() => {
-    const mq = window.matchMedia("(max-width: 767px)");
-    setIsMobile(mq.matches);
-    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
-    mq.addEventListener("change", handler);
-    return () => mq.removeEventListener("change", handler);
-  }, []);
+  const isMobile = useMediaQuery("(max-width: 767px)");
 
   const isOnChainActive =
     activeStep !== null && steps[activeStep - 1]?.isOnChain;

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,0 +1,23 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Returns a debounced copy of `value` that only updates after `delayMs`
+ * has passed without `value` changing again. Matches the pattern
+ * previously duplicated inline (a `useState` + `setTimeout`/`clearTimeout`
+ * effect) for debouncing search input.
+ */
+export function useDebounce<T>(value: T, delayMs: number): T {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delayMs);
+
+    return () => clearTimeout(timer);
+  }, [value, delayMs]);
+
+  return debouncedValue;
+}

--- a/src/hooks/useLiquidTextAnimation.ts
+++ b/src/hooks/useLiquidTextAnimation.ts
@@ -1,0 +1,108 @@
+"use client";
+
+import { useEffect, type RefObject } from "react";
+
+export interface LiquidHighlightColors {
+  highlight: string;
+  brightest: string;
+}
+
+/**
+ * Drives the "liquid text" effect: multiple radial-gradient blobs orbiting
+ * inside an element via requestAnimationFrame, visible through
+ * `background-clip: text`. Respects `prefers-reduced-motion` (falling back
+ * to a static gradient) and pauses while the tab is hidden.
+ *
+ * Extracted from HeroSection as-is. There is currently only one consumer —
+ * this is not deduplicating existing copies, just isolating a large,
+ * highly bespoke effect out of the component per the hooks-layer issue.
+ */
+export function useLiquidTextAnimation(
+  elementRef: RefObject<HTMLElement | null>,
+  colors: LiquidHighlightColors
+) {
+  useEffect(() => {
+    const el = elementRef.current;
+    if (!el) return;
+
+    const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+    let shouldReduceMotion = mediaQuery.matches;
+
+    const staticGradient = `linear-gradient(135deg, ${colors.highlight} 0%, var(--color-primary) 100%)`;
+
+    const handleMediaChange = (e: MediaQueryListEvent) => {
+      shouldReduceMotion = e.matches;
+      if (shouldReduceMotion) {
+        cancelAnimationFrame(frame);
+        el.style.backgroundImage = staticGradient;
+      } else {
+        frame = requestAnimationFrame(animate);
+      }
+    };
+
+    mediaQuery.addEventListener("change", handleMediaChange);
+
+    let frame: number;
+    let t = 0;
+    let paused = false;
+
+    const animate = () => {
+      if (paused || shouldReduceMotion) return;
+      t += 0.022;
+
+      const b1x = 50 + 28 * Math.sin(t * 0.7);
+      const b1y = 50 + 22 * Math.cos(t * 0.5);
+      const b2x = 50 + 22 * Math.sin(t * 0.4 + 2.0);
+      const b2y = 50 + 28 * Math.cos(t * 0.6 + 1.2);
+      const b3x = 50 + 32 * Math.sin(t * 0.85 + 4.2);
+      const b3y = 50 + 18 * Math.cos(t * 0.75 + 3.0);
+      const b4x = 50 + 18 * Math.sin(t * 1.1 + 1.0);
+      const b4y = 50 + 30 * Math.cos(t * 0.95 + 5.1);
+      const b5x = 50 + 38 * Math.sin(t * 0.55 + 5.5);
+      const b5y = 50 + 24 * Math.cos(t * 0.42 + 4.0);
+      const b6x = 50 + 14 * Math.sin(t * 1.3 + 3.0);
+      const b6y = 50 + 14 * Math.cos(t * 1.15 + 2.0);
+
+      el.style.backgroundImage = [
+        `radial-gradient(ellipse 48% 55% at ${b1x}% ${b1y}%, ${colors.highlight} 0%, var(--color-primary) 45%, color-mix(in srgb, var(--color-primary) 0%, transparent) 82%)`,
+        `radial-gradient(ellipse 38% 46% at ${b2x}% ${b2y}%, ${colors.brightest} 0%, ${colors.highlight} 40%, color-mix(in srgb, ${colors.highlight} 0%, transparent) 80%)`,
+        `radial-gradient(ellipse 32% 42% at ${b3x}% ${b3y}%, var(--color-accent) 0%, color-mix(in srgb, var(--color-accent) 0%, transparent) 78%)`,
+        `radial-gradient(ellipse 28% 38% at ${b4x}% ${b4y}%, var(--color-primary-hover) 0%, color-mix(in srgb, var(--color-primary-hover) 0%, transparent) 78%)`,
+        `radial-gradient(ellipse 44% 52% at ${b5x}% ${b5y}%, var(--color-primary) 0%, color-mix(in srgb, var(--color-primary) 0%, transparent) 82%)`,
+        `radial-gradient(ellipse 20% 26% at ${b6x}% ${b6y}%, ${colors.brightest} 0%, color-mix(in srgb, ${colors.brightest} 0%, transparent) 72%)`,
+        `radial-gradient(ellipse 62% 72% at ${b3x}% ${b2y}%, color-mix(in srgb, var(--color-bg-base) 90%, transparent) 0%, color-mix(in srgb, var(--color-bg-base) 50%, transparent) 40%, color-mix(in srgb, var(--color-bg-base) 0%, transparent) 78%)`,
+        `radial-gradient(ellipse 52% 62% at ${b5x}% ${b4y}%, color-mix(in srgb, var(--color-bg-base) 80%, transparent) 0%, color-mix(in srgb, var(--color-bg-base) 38%, transparent) 38%, color-mix(in srgb, var(--color-bg-base) 0%, transparent) 72%)`,
+        `radial-gradient(ellipse 42% 50% at ${b1x}% ${b6y}%, color-mix(in srgb, var(--color-bg-base) 65%, transparent) 0%, color-mix(in srgb, var(--color-bg-base) 20%, transparent) 45%, color-mix(in srgb, var(--color-bg-base) 0%, transparent) 70%)`,
+      ].join(", ");
+
+      frame = requestAnimationFrame(animate);
+    };
+
+    const onVisibility = () => {
+      if (document.hidden) {
+        paused = true;
+        cancelAnimationFrame(frame);
+      } else {
+        paused = false;
+        if (!shouldReduceMotion) {
+          frame = requestAnimationFrame(animate);
+        }
+      }
+    };
+
+    document.addEventListener("visibilitychange", onVisibility);
+
+    if (shouldReduceMotion) {
+      el.style.backgroundImage = staticGradient;
+    } else {
+      frame = requestAnimationFrame(animate);
+    }
+
+    return () => {
+      cancelAnimationFrame(frame);
+      document.removeEventListener("visibilitychange", onVisibility);
+      mediaQuery.removeEventListener("change", handleMediaChange);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [elementRef, colors.highlight, colors.brightest]);
+}

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,0 +1,26 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Subscribes to a CSS media query and returns whether it currently
+ * matches, updating on change. Matches the pattern previously duplicated
+ * inline via `window.matchMedia(...).matches` + a manual `change`
+ * listener.
+ */
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(() =>
+    typeof window === "undefined" ? false : window.matchMedia(query).matches
+  );
+
+  useEffect(() => {
+    const mql = window.matchMedia(query);
+    setMatches(mql.matches);
+
+    const handleChange = (e: MediaQueryListEvent) => setMatches(e.matches);
+    mql.addEventListener("change", handleChange);
+    return () => mql.removeEventListener("change", handleChange);
+  }, [query]);
+
+  return matches;
+}


### PR DESCRIPTION
# 📝 Pull Request 

## 🔧 Title: 
- refactor(hooks): extract useDebounce, useMediaQuery, useLiquidTextAnimation

## 🛠️ Issue
- Closes #1471

## 📚 Description
- Final slice. Adds the last three hooks from the acceptance criteria, completing the hooks layer.
- `useDebounce`: only real consumer is `DocsSearchBar`'s search-input debounce. `NavigationProgress` looked like a candidate (matched a grep for timers) but its staggered `setTimeout` steps drive a fake progress-bar animation, not a debounce — left untouched to avoid forcing an inaccurate abstraction.
- `useMediaQuery`: applied to `EscrowFlowDiagram`'s mobile breakpoint check. `HeroSection`'s media-query usage is folded into `useLiquidTextAnimation` instead, since it's tightly coupled to that effect's pause/resume logic. `BackToTopButton`'s `matchMedia` call is a one-off synchronous read inside a click handler, not a reactive subscription — not a real candidate. `ThemeProvider`'s is left alone too: its cleanup effect calls `addEventListener` again instead of `removeEventListener`, a pre-existing bug that shouldn't get silently fixed as a side effect of this refactor — worth its own issue if you want it raised separately.
- `useLiquidTextAnimation`: extracted from `HeroSection`, its only consumer. No actual duplication exists here — `OrchestratorShowcase`/`WhyStellarSection` only matched a keyword grep on "liquidity" (financial copy), not the animation itself.

## ✅ Changes applied
- Added `src/hooks/useDebounce.ts`, `src/hooks/useMediaQuery.ts`, `src/hooks/useLiquidTextAnimation.ts`.
- Refactored `DocsSearchBar.tsx`, `EscrowFlowDiagram.tsx`, `HeroSection.tsx` to use them. No markup, styling, or timing changes.

## 🔍 Evidence
- `npx tsc --noEmit`: 0 errors
- `npx next lint`: 0 new warnings
- `npm run build`: passes