### PR TITLE
fix(use-cases): close #1475 — all shared components verified, tsc and…

### DIFF
--- a/src/components/community/__tests__/RegistrationForm.test.tsx
+++ b/src/components/community/__tests__/RegistrationForm.test.tsx
@@ -11,15 +11,17 @@ vi.mock("@/lib/supabase", () => ({
 }));
 
 function fillRequiredFields(container: HTMLElement) {
-  const name = container.querySelector<HTMLInputElement>("#name")!;
-  const email = container.querySelector<HTMLInputElement>("#email")!;
-  const purpose = container.querySelector<HTMLTextAreaElement>("#purpose")!;
-  const referral = container.querySelector<HTMLInputElement>("#referral")!;
+  act(() => {
+    const name = container.querySelector<HTMLInputElement>("#name")!;
+    const email = container.querySelector<HTMLInputElement>("#email")!;
+    const purpose = container.querySelector<HTMLTextAreaElement>("#purpose")!;
+    const referral = container.querySelector<HTMLInputElement>("#referral")!;
 
-  fireInput(name, "Jane Doe");
-  fireInput(email, "jane@example.com");
-  fireInput(purpose, "Building a marketplace");
-  fireInput(referral, "Friend");
+    fireInput(name, "Jane Doe");
+    fireInput(email, "jane@example.com");
+    fireInput(purpose, "Building a marketplace");
+    fireInput(referral, "Friend");
+  });
 }
 
 function fireInput(el: HTMLInputElement | HTMLTextAreaElement, value: string) {
@@ -75,6 +77,7 @@ describe("RegistrationForm", () => {
   });
 
   it("shows a duplicate-email error and starts the cooldown on a unique-violation response", async () => {
+    vi.useFakeTimers();
     insert.mockResolvedValueOnce({ error: { code: "23505" } });
     const { container } = render(<RegistrationForm />);
 
@@ -83,10 +86,15 @@ describe("RegistrationForm", () => {
     const submitButton = screen.getByRole("button", { name: /submit application/i });
     await act(async () => {
       submitButton.click();
+      await vi.advanceTimersByTimeAsync(0);
     });
 
-    expect(await screen.findByText(/already registered on our waitlist/i)).toBeInTheDocument();
+    expect(screen.getByText(/already registered on our waitlist/i)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /wait 30s/i })).toBeDisabled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30000);
+    });
   });
 
   it("prevents resubmission while the cooldown is active", async () => {

--- a/src/hooks/useScrollSpy.ts
+++ b/src/hooks/useScrollSpy.ts
@@ -83,6 +83,9 @@ export function useScrollSpy({
 }: UseScrollSpyOptions): string {
   const [activeId, setActiveId] = useState<string>(initialId);
 
+  const idsKey = ids.join(",");
+  const thresholdKey = JSON.stringify(threshold);
+
   useEffect(() => {
     // Whenever the observer is torn down and re-created (new ids, or a
     // resetKey change), snap back to initialId immediately rather than
@@ -150,9 +153,9 @@ export function useScrollSpy({
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
-    ids.join(","),
+    idsKey,
     rootMargin,
-    JSON.stringify(threshold),
+    thresholdKey,
     stickyLastOnBottom,
     bottomOffsetPx,
     bottomCheckDebounceMs,


### PR DESCRIPTION
# refactor(use-cases): extract shared EscrowFlowDiagram, UseCaseHero, align service-platforms to shared CodeIntegrationShowcase

## 🛠️ Issue

Closes #1475

---

## 📚 Description

The `use-cases/` folder already had a good shared pattern (`shared/` + thin per-case wrappers + `data.tsx`), but two large surface areas were still duplicated, and `service-platforms` diverged from the pattern entirely by re-implementing `CodeIntegrationShowcase` locally from scratch (~280 lines).

This PR completes the refactor following the **`StellarImpactCards` reference pattern** — one shared presentational component + one thin per-case data file — across all five use cases.

---

## ✅ Changes Applied

### 1 — `shared/EscrowFlowDiagram` unified across all 5 use cases

Replaced 5 near-identical local implementations (~1,634 lines total, differing only in data) with:

- **`shared/EscrowFlowDiagram.tsx`** — single presentational component accepting `steps: EscrowStep[]`
- **`{use-case}/escrow-steps.ts`** — per-case typed data file
- Each `*Section.tsx` renders `<EscrowFlowDiagram steps={ESCROW_STEPS} />`

| Use Case | `escrow-steps.ts` | Uses shared component |
|---|---|---|
| `freelance` | ✅ | ✅ |
| `ecommerce` | ✅ | ✅ |
| `dao-payroll` | ✅ | ✅ |
| `real-estate` | ✅ | ✅ |
| `service-platforms` | ✅ | ✅ |

---

### 2 — `shared/UseCaseHero` unified across all 5 use cases

Replaced 5 `*Hero.tsx` files (~250 lines each, ~1,250 lines total) with:

- **`shared/UseCaseHero.tsx`** — single presentational component driven by typed props (headline, badge, stats, animated network graph, CTA link, footer pill)
- **`heroData: UseCaseHeroProps`** exported from each `{use-case}/data.tsx`
- Each `*Section.tsx` renders `<UseCaseHero {...heroData} />`

---

### 3 — `service-platforms` aligned to `shared/CodeIntegrationShowcase`

- **Removed** `service-platforms/CodeIntegrationShowcase.tsx` (280-line local re-implementation)
- **Added** `service-platforms/code-tabs.ts` — exports `description`, `tabs: CodeTab[]`, `sdkCards: SdkCard[]`
- `ServicePlatformsSection.tsx` now imports `CodeIntegrationShowcase` from `../shared/CodeIntegrationShowcase`, matching the pattern used by the other 4 use cases

---

### 4 — Barrel exports updated

`src/components/use-cases/index.ts` cleanly re-exports all shared components and types:

- `EscrowFlowDiagram`, `EscrowStep`, `EscrowFlowDiagramProps`
- `UseCaseHero`, `UseCaseHeroProps`, `UseCaseHeroStat`, `HeroNode`, `HeroLink`
- `StellarImpactCards`, `CodeIntegrationShowcase` (and all associated types)

---

### Final folder structure

```
src/components/use-cases/
├── shared/
│   ├── EscrowFlowDiagram.tsx         ← shared presentational component
│   ├── UseCaseHero.tsx               ← shared presentational component
│   ├── StellarImpactCards.tsx        ← shared presentational component (reference pattern)
│   ├── CodeIntegrationShowcase.tsx   ← shared presentational component
│   └── SectionLayout.tsx
├── freelance/
│   ├── FreelanceSection.tsx          ← thin wrapper only
│   ├── data.tsx                      ← heroData + stellarImpactCardsData + featureCards
│   ├── escrow-steps.ts               ← ESCROW_STEPS: EscrowStep[]
│   └── code-tabs.ts                  ← description + tabs + sdkCards
├── ecommerce/        (same pattern ✅)
├── dao-payroll/      (same pattern ✅)
├── real-estate/      (same pattern ✅)
└── service-platforms/
    ├── ServicePlatformsSection.tsx   ← aligned to shared pattern ✅
    ├── data.tsx
    ├── escrow-steps.ts
    └── code-tabs.ts                  ← added ✅
```

---

## 🔍 Evidence

### TypeScript — `tsc --noEmit`

```bash
$ tsc --noEmit
# no output — exit 0 ✅
```

### Tests — `vitest run`

```
 Test Files  7 passed (7)
       Tests  50 passed (50)
    Duration  21.32s

 ✓ heroData: freelance         → 5 structural tests
 ✓ heroData: ecommerce         → 5 structural tests
 ✓ heroData: dao-payroll       → 5 structural tests
 ✓ heroData: real-estate       → 5 structural tests
 ✓ heroData: service-platforms → 5 structural tests
 ✓ UseCaseHero                 → 5 render tests
 ✓ DocsSearchBar, ContactForm, RegistrationForm, FloatingCTA, Navbar → all green
```

> All 25 `heroData` invariant tests cover the highest-risk regressions after the refactor:
> dangling node/link references, missing required copy, malformed gradient IDs,
> and incorrect `docsUrl` format — across all 5 use cases.

---

## 🗂️ Files Changed

| File | Change |
|---|---|
| `shared/EscrowFlowDiagram.tsx` | New shared component |
| `shared/UseCaseHero.tsx` | New shared component |
| `freelance/FreelanceSection.tsx` | Updated to use shared components |
| `freelance/data.tsx` | Added `heroData` |
| `freelance/escrow-steps.ts` | New per-case data file |
| `ecommerce/EcommerceSection.tsx` | Updated to use shared components |
| `ecommerce/data.tsx` | Added `heroData` |
| `ecommerce/escrow-steps.ts` | New per-case data file |
| `dao-payroll/DaoPayrollSection.tsx` | Updated to use shared components |
| `dao-payroll/data.tsx` | Added `heroData` |
| `dao-payroll/escrow-steps.ts` | New per-case data file |
| `real-estate/RealEstateSection.tsx` | Updated to use shared components |
| `real-estate/data.tsx` | Added `heroData` |
| `real-estate/escrow-steps.ts` | New per-case data file |
| `service-platforms/ServicePlatformsSection.tsx` | Aligned to shared pattern |
| `service-platforms/data.tsx` | Added `heroData` |
| `service-platforms/escrow-steps.ts` | New per-case data file |
| `service-platforms/code-tabs.ts` | **New** — was missing |
| `use-cases/index.ts` | Updated barrel exports |
