### PR TITLE
fix: use shared GEO_CACHE_KEY constant in geolocation service

### DIFF
--- a/src/services/geolocation.ts
+++ b/src/services/geolocation.ts
@@ -1,3 +1,5 @@
+import { GEO_CACHE_KEY } from '@/constants/storage';
+
 export interface GeoData {
   ip?: string;
   country?: string;
@@ -18,7 +20,7 @@ const emptyGeo: GeoData = {
 };
 
 export async function getGeolocation(): Promise<GeoData> {
-  const CACHE_KEY = 'geo_cache';
+  const CACHE_KEY = GEO_CACHE_KEY;
 
   try {
     const cached = sessionStorage.getItem(CACHE_KEY);


### PR DESCRIPTION
# 📝 Pull Request

## 🔧 Title:

- fix: use shared GEO_CACHE_KEY constant in geolocation service

## 🛠️ Issue

- Not tied to any open issue — checked all currently open issues; none reference this file or this constant.
- Supersedes #1508, closed only for not following this PR template — same commit, same code, reformatted description per @Josue19-08's review.

## 📚 Description

`src/services/geolocation.ts` hardcoded its sessionStorage key as the literal string `'geo_cache'` instead of importing the shared `GEO_CACHE_KEY` constant from `src/constants/storage.ts`.

Every other storage key in the codebase (`COOKIE_CONSENT_KEY`, `VISITOR_ID_KEY`, `SESSION_ID_KEY`, `THEME_STORAGE_KEY`, `CTA_DISMISSED_KEY`) is consistently sourced from `constants/storage.ts` and imported by its consumer — `geolocation.ts` was the one outlier duplicating the value as a magic string. If `GEO_CACHE_KEY` is ever renamed or changed, the geolocation cache would silently keep using the stale key while nothing else does.

The project's own test suite already anticipated exactly this risk: `src/services/__tests__/geolocation.test.ts` keeps a separately-hardcoded literal specifically commented `"Kept literal so a drift shows up below"` and asserts it equals `GEO_CACHE_KEY` — a canary for this exact class of bug. This PR removes the drift the canary was watching for.

## ✅ Changes applied

- Imported `GEO_CACHE_KEY` from `src/constants/storage.ts` in `src/services/geolocation.ts`.
- Replaced the hardcoded `'geo_cache'` literal with the imported constant.
- No behavior change (the values were already identical), so no test edits were needed.
- No changelog entry added since there's no user-facing behavior change, per CONTRIBUTING.md's guidance that the changelog is for user-facing changes.

## 🔍 Evidence/Media (screenshots/videos)

- `npm run lint` — 0 errors (2 pre-existing, unrelated warnings in `src/hooks/useScrollSpy.ts`, unchanged by this diff).
- `npm run build` — succeeds, all 38 routes generate.
- `npx vitest run src/services/__tests__/geolocation.test.ts src/services/__tests__/analytics.test.ts` — 41/41 passing.
- `npm run test:coverage` — 400/400 tests passing; all coverage thresholds (95% services/hooks, 100% API routes, 40% global floor) met.
