### PR TITLE
docs: fix broken "internal implementation" cross-repo links in the guides

### DIFF
--- a/content/docs/guide/deposits.mdx
+++ b/content/docs/guide/deposits.mdx
@@ -6,7 +6,7 @@ section: Guides
 ---
 
 <Callout type="note">
-  This is the public API/SDK guide for integrators. For internal implementation detail (Orchestrator state machine, signer roles), see [`docs/guides/deposits.md`](https://github.com/OFFER-HUB/offer-hub-monorepo/blob/main/docs/guides/deposits.md) in the repo.
+  This is the public API/SDK guide for integrators. For internal implementation detail (Orchestrator state machine, signer roles), see [`docs/guides/deposits.md`](https://github.com/OFFER-HUB/OFFER-HUB/blob/main/docs/guides/deposits.md) in the repo.
 </Callout>
 
 Before users can create orders or fund escrow, they need balance in their account. OFFER-HUB supports two deposit methods depending on your payment provider configuration.

--- a/content/docs/guide/disputes.mdx
+++ b/content/docs/guide/disputes.mdx
@@ -6,7 +6,7 @@ section: Guides
 ---
 
 <Callout type="note">
-  This is the public API/SDK guide for integrators. For internal implementation detail (Orchestrator state machine, signer roles), see [`docs/guides/disputes.md`](https://github.com/OFFER-HUB/offer-hub-monorepo/blob/main/docs/guides/disputes.md) in the repo.
+  This is the public API/SDK guide for integrators. For internal implementation detail (Orchestrator state machine, signer roles), see [`docs/guides/disputes.md`](https://github.com/OFFER-HUB/OFFER-HUB/blob/main/docs/guides/disputes.md) in the repo.
 </Callout>
 
 Disputes are a critical part of any marketplace. When a buyer and seller disagree, OFFER-HUB provides a structured process to resolve conflicts fairly while funds remain safely locked in escrow.

--- a/content/docs/guide/escrow.mdx
+++ b/content/docs/guide/escrow.mdx
@@ -6,7 +6,7 @@ section: Guides
 ---
 
 <Callout type="note">
-  This is the public API/SDK guide for integrators. For internal implementation detail (Orchestrator state machine, signer roles), see [`docs/guides/escrow.md`](https://github.com/OFFER-HUB/offer-hub-monorepo/blob/main/docs/guides/escrow.md) in the repo.
+  This is the public API/SDK guide for integrators. For internal implementation detail (Orchestrator state machine, signer roles), see [`docs/guides/escrow.md`](https://github.com/OFFER-HUB/OFFER-HUB/blob/main/docs/guides/escrow.md) in the repo.
 </Callout>
 
 Escrow is the core security mechanism in OFFER-HUB. When a buyer pays for a service, funds are locked in a Stellar smart contract until the work is delivered and approved. Neither party can unilaterally access the funds — the contract enforces fair resolution.

--- a/content/docs/guide/orders.mdx
+++ b/content/docs/guide/orders.mdx
@@ -6,7 +6,7 @@ section: Guides
 ---
 
 <Callout type="note">
-  This is the public API/SDK guide for integrators. For internal implementation detail (Orchestrator state machine, signer roles), see [`docs/guides/orders.md`](https://github.com/OFFER-HUB/offer-hub-monorepo/blob/main/docs/guides/orders.md) in the repo.
+  This is the public API/SDK guide for integrators. For internal implementation detail (Orchestrator state machine, signer roles), see [`docs/guides/orders.md`](https://github.com/OFFER-HUB/OFFER-HUB/blob/main/docs/guides/orders.md) in the repo.
 </Callout>
 
 Orders are the core of OFFER-HUB. They represent a transaction between a buyer and seller, with funds protected by escrow until work is completed.

--- a/content/docs/guide/security.mdx
+++ b/content/docs/guide/security.mdx
@@ -6,7 +6,7 @@ section: Guides
 ---
 
 <Callout type="note">
-  This is the public API/SDK guide for integrators. For internal implementation detail (Orchestrator state machine, signer roles), see [`docs/guides/security.md`](https://github.com/OFFER-HUB/offer-hub-monorepo/blob/main/docs/guides/security.md) in the repo.
+  This is the public API/SDK guide for integrators. For internal implementation detail (Orchestrator state machine, signer roles), see [`docs/deployment/security-hardening.md`](https://github.com/OFFER-HUB/OFFER-HUB/blob/main/docs/deployment/security-hardening.md) in the repo.
 </Callout>
 
 Integrating OFFER-HUB into your marketplace means handling real USDC transactions on a public blockchain. A misconfiguration can expose user funds or allow spoofed payment events to reach your system. This guide gives you concrete, OFFER-HUB-specific security practices — not generic web security advice.

--- a/content/docs/guide/wallets.mdx
+++ b/content/docs/guide/wallets.mdx
@@ -6,7 +6,7 @@ section: Guides
 ---
 
 <Callout type="note">
-  This is the public API/SDK guide for integrators. For internal implementation detail (Orchestrator state machine, signer roles), see [`docs/guides/wallets.md`](https://github.com/OFFER-HUB/offer-hub-monorepo/blob/main/docs/guides/wallets.md) in the repo.
+  This is the public API/SDK guide for integrators. For internal implementation detail (Orchestrator state machine, signer roles), see [`docs/guides/wallets.md`](https://github.com/OFFER-HUB/OFFER-HUB/blob/main/docs/guides/wallets.md) in the repo.
 </Callout>
 
 OFFER-HUB uses "invisible wallets" to give users blockchain capabilities without the complexity of managing private keys. Every user gets a Stellar wallet automatically, but they interact with it like a simple account balance.

--- a/content/docs/guide/withdrawals.mdx
+++ b/content/docs/guide/withdrawals.mdx
@@ -6,7 +6,7 @@ section: Guides
 ---
 
 <Callout type="note">
-  This is the public API/SDK guide for integrators. For internal implementation detail (Orchestrator state machine, signer roles), see [`docs/guides/withdrawals.md`](https://github.com/OFFER-HUB/offer-hub-monorepo/blob/main/docs/guides/withdrawals.md) in the repo.
+  This is the public API/SDK guide for integrators. For internal implementation detail (Orchestrator state machine, signer roles), see [`docs/guides/withdrawals.md`](https://github.com/OFFER-HUB/OFFER-HUB/blob/main/docs/guides/withdrawals.md) in the repo.
 </Callout>
 
 When users want to move funds off the platform, they create a withdrawal request. OFFER-HUB supports withdrawals to external Stellar wallets (crypto mode) or bank accounts/local methods (AirTM mode).


### PR DESCRIPTION
## 🔧 Description

Fixes broken "internal implementation detail" callout links across seven guide pages (`deposits.mdx`, `disputes.mdx`, `escrow.mdx`, `orders.mdx`, `security.mdx`, `wallets.mdx`, `withdrawals.mdx`) so they resolve to the orchestrator repository (`OFFER-HUB/OFFER-HUB`) and correct target file paths.

Closes #1527

## 📘 Changes Proposed

### What was the issue?
- Callout links in seven guide pages pointed to `OFFER-HUB/offer-hub-monorepo/blob/main/docs/guides/<name>.md`, where implementation docs do not exist.
- `security.mdx` linked to non-existent `docs/guides/security.md`.

### What did I do?
- Updated link URLs in `deposits.mdx`, `disputes.mdx`, `escrow.mdx`, `orders.mdx`, `wallets.mdx`, and `withdrawals.mdx` to target `https://github.com/OFFER-HUB/OFFER-HUB/blob/main/docs/guides/<name>.md`.
- Corrected link in `security.mdx` to point to `[`docs/deployment/security-hardening.md``](https://github.com/OFFER-HUB/OFFER-HUB/blob/main/docs/deployment/security-hardening.md)`.
- Verified all target documents exist in the orchestrator repository (`OFFER-HUB/OFFER-HUB`).

## ✅ Check List

- [x] Every "internal implementation detail" callout link resolves to a real file in `OFFER-HUB/OFFER-HUB`
- [x] `security.mdx`'s link is corrected to `docs/deployment/security-hardening.md`
- [x] Content reviewed against the orchestrator repo
- [x] Reused existing MDX components (`Callout`) without ad-hoc styling
- [x] Verified build and tests pass (`npm run docs:index` & `npm test`)