### PR TITLE
docs: document the @offerhub/cli tool (#1514)

### DIFF
--- a/content/docs/getting-started.mdx
+++ b/content/docs/getting-started.mdx
@@ -54,10 +54,19 @@ Follow the [Installation guide](/docs/installation) to clone the orchestrator re
   The installation takes about 5 minutes. You'll have a running API at `http://localhost:4000` when you're done.
 </Callout>
 
+## Creating an API Key
+
+After installation, you need an API key to make API calls. The fastest way is with the CLI:
+
+<CommandLine>npm install -g @offerhub/cli && offerhub keys create</CommandLine>
+
+You can also create keys with `curl` — see the [Installation guide](/docs/installation#creating-your-first-api-key) for both methods.
+
 ## Next Steps
 
 Once the Orchestrator is running, explore these guides:
 
+- [CLI Guide](/docs/guide/cli) — Manage API keys and maintenance from the command line
 - [Quick Start](/docs/guide/quick-start) — Create your first user and order in 5 minutes
 - [Orchestrator Guide](/docs/guide/orchestrator) — Deep dive into the Orchestrator architecture
 - [Escrow Flows](/docs/guide/escrow) — Learn about escrow states and transitions

--- a/content/docs/guide/cli.mdx
+++ b/content/docs/guide/cli.mdx
@@ -1,0 +1,325 @@
+---
+title: CLI Tool
+description: Install and use the @offerhub/cli to manage API keys, configuration, and maintenance from the command line.
+order: 2
+section: Guides
+---
+
+The `@offerhub/cli` package provides a command-line interface for managing the OFFER-HUB Orchestrator. It is the fastest way to create API keys, manage configuration, and toggle maintenance mode — no `curl` required.
+
+<Callout type="tip">
+  For hackathon participants, the CLI is significantly faster than the raw `curl` + master-key flow shown in most "first API key" guides. Install it, run `offerhub keys create`, and you have an API key in seconds.
+</Callout>
+
+## Installation
+
+```bash
+# Global installation
+npm install -g @offerhub/cli
+
+# Or run directly with npx (no install required)
+npx @offerhub/cli
+```
+
+The CLI registers a single binary: `offerhub`.
+
+## Configuration
+
+The CLI resolves configuration from three sources, checked in order:
+
+| Priority | Source | Details |
+|----------|--------|---------|
+| 1 | Environment variables | `OFFERHUB_API_URL` and `OFFERHUB_API_KEY` |
+| 2 | `.env` file | In the current working directory |
+| 3 | Global config file | `~/.offerhub/config.json` |
+
+### Option 1: Environment Variables
+
+<CommandLine>export OFFERHUB_API_URL=http://localhost:4000</CommandLine>
+
+<CommandLine>export OFFERHUB_API_KEY=ohk_live_your_api_key</CommandLine>
+
+### Option 2: Interactive Setup
+
+Run the interactive setup wizard — it prompts for your API URL, API key, and payment provider, then saves everything to `~/.offerhub/config.json`:
+
+<CommandLine>offerhub config set</CommandLine>
+
+You can also pass values directly:
+
+<CommandLine>offerhub config set --api-url http://localhost:4000 --api-key ohk_live_your_api_key</CommandLine>
+
+### View Current Configuration
+
+<CommandLine>offerhub config show</CommandLine>
+
+## Commands
+
+### Config
+
+Manage CLI configuration.
+
+#### `offerhub config set`
+
+Set API configuration interactively or via flags.
+
+```bash
+# Interactive — prompts for URL, key, and payment provider
+offerhub config set
+
+# Non-interactive — pass all values as flags
+offerhub config set --api-url http://localhost:4000 --api-key ohk_live_xxx
+```
+
+#### `offerhub config show`
+
+Display the current configuration (API URL, masked key, payment provider).
+
+```bash
+offerhub config show
+```
+
+### API Key Management
+
+#### `offerhub keys list`
+
+List all API keys. Optionally filter by user ID.
+
+```bash
+# List all keys
+offerhub keys list
+
+# Filter by user ID
+offerhub keys list --user-id usr_abc123
+```
+
+| Flag | Description |
+|------|-------------|
+| `-u, --user-id <userId>` | Filter keys by user ID |
+
+Output:
+
+```
+┌──────────┬─────────────┬──────────┬───────────────┬────────────┬───────────┐
+│ ID       │ Key         │ User ID  │ Scopes        │ Created    │ Last Used │
+├──────────┼─────────────┼──────────┼───────────────┼────────────┼───────────┤
+│ key_abc  │ ohk_***xyz  │ usr_123  │ read, write   │ 1/1/2026   │ 1/5/2026  │
+└──────────┴─────────────┴──────────┴───────────────┴────────────┴───────────┘
+```
+
+#### `offerhub keys create`
+
+Create a new API key. Runs interactively if flags are omitted.
+
+```bash
+# Interactive — prompts for user ID, scopes, and name
+offerhub keys create
+
+# Non-interactive
+offerhub keys create \
+  --user-id usr_abc123 \
+  --scopes read,write \
+  --name "Production API Key"
+```
+
+| Flag | Description |
+|------|-------------|
+| `-u, --user-id <userId>` | User ID (required) |
+| `-s, --scopes <scopes>` | Comma-separated: `read`, `write`, `support` |
+| `-n, --name <name>` | Key name or description (optional) |
+
+<Callout type="danger">
+  The full API key is shown only once at creation time. Copy it immediately — you cannot retrieve it later.
+</Callout>
+
+#### `offerhub keys revoke <keyId>`
+
+Revoke an API key. Prompts for confirmation unless `--yes` is passed.
+
+```bash
+# With confirmation prompt
+offerhub keys revoke key_abc123
+
+# Skip confirmation
+offerhub keys revoke key_abc123 --yes
+```
+
+| Flag | Description |
+|------|-------------|
+| `-y, --yes` | Skip confirmation prompt |
+
+#### `offerhub keys token <keyId>`
+
+Generate a short-lived token from an existing API key.
+
+```bash
+# Default TTL (1 hour)
+offerhub keys token key_abc123
+
+# Custom TTL (2 hours)
+offerhub keys token key_abc123 --ttl 7200
+```
+
+| Flag | Description |
+|------|-------------|
+| `-t, --ttl <seconds>` | Token TTL in seconds (default: `3600`) |
+
+Output:
+
+```
+✓ Token generated successfully!
+
+Token: ohk_tok_xyz...
+Expires: 1/5/2026, 2:00:00 PM
+
+⚠️  This token will expire. Save it now!
+```
+
+### Maintenance Mode
+
+Control the Orchestrator's maintenance mode. When enabled, the API becomes read-only.
+
+#### `offerhub maintenance enable`
+
+Enable maintenance mode.
+
+```bash
+# Interactive — prompts for confirmation and message
+offerhub maintenance enable
+
+# Non-interactive
+offerhub maintenance enable --message "Database upgrade" --yes
+```
+
+| Flag | Description |
+|------|-------------|
+| `-m, --message <message>` | Maintenance message |
+| `-y, --yes` | Skip confirmation prompt |
+
+#### `offerhub maintenance disable`
+
+Disable maintenance mode and restore normal operation.
+
+```bash
+# Interactive
+offerhub maintenance disable
+
+# Skip confirmation
+offerhub maintenance disable --yes
+```
+
+| Flag | Description |
+|------|-------------|
+| `-y, --yes` | Skip confirmation prompt |
+
+#### `offerhub maintenance status`
+
+Check whether maintenance mode is currently enabled.
+
+<CommandLine>offerhub maintenance status</CommandLine>
+
+When enabled:
+
+```
+Maintenance Mode Status:
+
+Status: ENABLED
+Message: Scheduled maintenance
+Enabled: 1/5/2026, 1:00:00 PM
+Enabled by: admin@example.com
+```
+
+When disabled:
+
+```
+Maintenance Mode Status:
+
+Status: NORMAL
+API is operating normally
+```
+
+## Common Workflows
+
+### Create Your First API Key (Fastest Path)
+
+After installing and starting the Orchestrator, this is the quickest way to get an API key:
+
+```bash
+# Install the CLI
+npm install -g @offerhub/cli
+
+# Point it at your local instance
+offerhub config set --api-url http://localhost:4000 --api-key YOUR_MASTER_KEY
+
+# Create a key
+offerhub keys create
+```
+
+### Manage Keys for Multiple Users
+
+```bash
+# Create a read-only key for a buyer
+offerhub keys create \
+  --user-id usr_buyer123 \
+  --scopes read \
+  --name "Mobile App (Read Only)"
+
+# Create a read-write key for a seller
+offerhub keys create \
+  --user-id usr_seller456 \
+  --scopes read,write \
+  --name "Seller Dashboard"
+
+# List all keys
+offerhub keys list
+```
+
+### Perform Scheduled Maintenance
+
+```bash
+# Check current status
+offerhub maintenance status
+
+# Enable maintenance mode
+offerhub maintenance enable --message "Database migration in progress" --yes
+
+# ... perform maintenance ...
+
+# Disable when done
+offerhub maintenance disable --yes
+```
+
+## Error Handling
+
+The CLI exits with a clear message when configuration is missing:
+
+```
+❌ Error: No configuration found.
+
+Please configure the CLI using one of these methods:
+
+1. Environment variables:
+   export OFFERHUB_API_URL=https://api.offerhub.com
+   export OFFERHUB_API_KEY=ohk_your_api_key
+
+2. .env file in current directory:
+   OFFERHUB_API_URL=https://api.offerhub.com
+   OFFERHUB_API_KEY=ohk_your_api_key
+
+3. Run: offerhub config set
+```
+
+## Platform Support
+
+| Platform | Status |
+|----------|--------|
+| macOS | Supported |
+| Linux | Supported |
+| Windows (WSL or Git Bash) | Supported |
+
+## Next Steps
+
+- [Quick Start](/docs/guide/quick-start) — Make your first API call
+- [Installation](/docs/installation) — Full Orchestrator setup guide
+- [Configuration](/docs/configuration) — All environment variables
+- [API Reference](/docs/api-reference/overview) — All REST endpoints

--- a/content/docs/installation.mdx
+++ b/content/docs/installation.mdx
@@ -154,7 +154,19 @@ See the [SDK Guide](/docs/sdk/quick-start) for complete documentation.
 
 ## Creating Your First API Key
 
-Once the server is running, create an API key using your master key:
+Once the server is running, create an API key using your master key.
+
+### Option A: Using the CLI (Recommended)
+
+The `@offerhub/cli` is the fastest way to create an API key:
+
+<CommandLine>npm install -g @offerhub/cli</CommandLine>
+
+<CommandLine>offerhub keys create</CommandLine>
+
+This runs an interactive wizard that prompts for user ID, scopes, and key name. See the [CLI Guide](/docs/guide/cli) for all available commands.
+
+### Option B: Using curl
 
 ```bash
 curl -X POST http://localhost:4000/api/v1/auth/api-keys \


### PR DESCRIPTION
## What was changed

- **New page** `content/docs/guide/cli.mdx` — full CLI reference documenting install, auth, and every real subcommand with examples (`config set/show`, `keys list/create/revoke/token`, `maintenance enable/disable/status`)
- **Updated** `content/docs/installation.mdx` — added CLI as the recommended alternative to raw `curl` for creating API keys
- **Updated** `content/docs/getting-started.mdx` — added CLI mention in a new "Creating an API Key" section and linked it in Next Steps

## Why the change was necessary

The site never mentions the CLI at all. `@offerhub/cli` (bin: `offerhub`) is the fastest way for hackathon participants to mint an API key — faster than the raw `curl` + master-key flow shown in every "first API key" section. It should be documented and cross-linked from installation/getting-started.

## Implementation details

- All claims (subcommands, flags, env vars, config paths) verified against the actual `packages/cli` source code in the upstream repo
- Uses existing MDX components (`Callout`, `CommandLine`) and follows the same patterns as other guide pages
- No hardcoded colors — uses CSS custom property tokens for light/dark mode
- Sidebar auto-picks up the new page via frontmatter (`section: Guides`, `order: 2`)
- No new components, utilities, or dependencies added

## Testing / Checks

- Reviewed `git diff` — only the 3 intended files changed, no unrelated modifications
- Content cross-checked against `packages/cli/src/commands/*.ts` source files
- Follows existing docs conventions (frontmatter format, component usage, section ordering)

## Issue

Closes #1514
