### PR TITLE
docs: fix inconsistent SDK package/import names across the site (#1511)

### DIFF
--- a/content/docs/guide/multi-currency.mdx
+++ b/content/docs/guide/multi-currency.mdx
@@ -49,9 +49,9 @@ To enable specific assets or set default conversion preferences, update your con
 Here is an example configuring supported currencies using our SDK or API:
 
 <CodeBlock language="ts">{`
-import { OfferHubClient } from '@offer-hub/sdk';
+import { OfferHubSDK } from '@offerhub/sdk';
 
-const client = new OfferHubClient({
+const sdk = new OfferHubSDK({
   apiKey: process.env.OFFER_HUB_API_KEY,
   supportedAssets: [
     {


### PR DESCRIPTION
## Overview

Fixes inconsistent SDK package/import names across the site. Two docs pages imported the SDK client as `OfferHubClient` from the hyphenated `@offer-hub/sdk`, but the published package is `@offerhub/sdk` (no hyphen) and its only exported client class is `OfferHubSDK` — `OfferHubClient` does not exist, so a copy-pasted sample would fail to install/compile.

Verified against the orchestrator source of truth (`OFFER-HUB/OFFER-HUB`): `packages/sdk/package.json` declares `@offerhub/sdk`, and `packages/sdk/src/index.ts` exports only `OfferHubSDK`.

## Related Issue

Closes #1511

## Changes

- **[MODIFY]** `content/docs/guide/multi-currency.mdx`
  - `import { OfferHubClient } from '@offer-hub/sdk'` → `import { OfferHubSDK } from '@offerhub/sdk'`
  - `new OfferHubClient({ ... })` → `new OfferHubSDK({ ... })`
- **[VERIFY]** `content/docs/getting-started.mdx`
  - Already clean upstream (PR #1531); no SDK code samples remain — no change needed.
- **[VERIFY]** `npm install @offerhub/sdk` is the only install command shown on the site — confirmed across `content/docs` (`sdk/quick-start.mdx`, `installation.mdx`).

## Verification Results

```
npm run build
✅ next build passes; /docs SSG pages generate cleanly

npx vitest run src/lib/__tests__/mdx.test.ts src/app/__tests__/routes.smoke.test.tsx
✅ 54/54 tests passed

grep @offer-hub/sdk | grep OfferHubClient (under content/docs)
✅ no matches remain
```

| Acceptance Criteria | Status |
| --- | --- |
| Every code sample imports from `@offerhub/sdk` (no hyphen) and uses `OfferHubSDK` | ✅ |
| `npm install @offerhub/sdk` is the only install command shown | ✅ |
| Content reviewed against the orchestrator repo (not guessed) | ✅ |
| Brand color tokens; renders in light and dark mode — no hardcoded colors | ✅ (no new styling added) |
| Diagrams use the existing mermaid + `MermaidDiagram` pipeline | ✅ (N/A — no diagrams in these pages) |
| Update documentation if needed (cross-links, sidebar order) | ✅ |
