### PR TITLE
docs: standardize dispute-resolution request field names across guides

### DIFF
--- a/content/docs/guide/disputes.mdx
+++ b/content/docs/guide/disputes.mdx
@@ -63,8 +63,8 @@ curl -X POST http://localhost:4000/api/v1/orders/ord_xyz789/resolution/dispute \
   -H "Authorization: Bearer ohk_live_your_api_key" \
   -H "Content-Type: application/json" \
   -d '{
-    "requestedBy": "usr_buyer123",
-    "reason": "Seller has not delivered the agreed work after 2 weeks"
+    "openedBy": "BUYER",
+    "reason": "NOT_DELIVERED"
   }'
 ```
 
@@ -72,8 +72,8 @@ curl -X POST http://localhost:4000/api/v1/orders/ord_xyz789/resolution/dispute \
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `requestedBy` | string | Yes | User ID of the buyer |
-| `reason` | string | Yes | Description of the issue |
+| `openedBy` | string | Yes | `"BUYER"` or `"SELLER"` |
+| `reason` | string | Yes | `"NOT_DELIVERED"`, `"QUALITY_ISSUE"`, or `"OTHER"` |
 
 ### Response
 
@@ -84,8 +84,8 @@ curl -X POST http://localhost:4000/api/v1/orders/ord_xyz789/resolution/dispute \
     "status": "DISPUTED",
     "dispute": {
       "id": "dsp_abc123",
-      "openedBy": "usr_buyer123",
-      "reason": "Seller has not delivered the agreed work after 2 weeks",
+      "openedBy": "BUYER",
+      "reason": "NOT_DELIVERED",
       "status": "open",
       "openedAt": "2026-02-25T10:00:00.000Z"
     }
@@ -127,7 +127,7 @@ curl -X POST http://localhost:4000/api/v1/disputes/dsp_abc123/resolve \
   -H "Authorization: Bearer ohk_live_your_api_key" \
   -H "Content-Type: application/json" \
   -d '{
-    "resolution": "refund",
+    "decision": "FULL_REFUND",
     "note": "Seller failed to deliver work within agreed timeframe"
   }'
 ```
@@ -141,7 +141,7 @@ curl -X POST http://localhost:4000/api/v1/disputes/dsp_abc123/resolve \
   -H "Authorization: Bearer ohk_live_your_api_key" \
   -H "Content-Type: application/json" \
   -d '{
-    "resolution": "release",
+    "decision": "FULL_RELEASE",
     "note": "Buyer confirmed delivery via email, dispute was a misunderstanding"
   }'
 ```
@@ -155,25 +155,25 @@ curl -X POST http://localhost:4000/api/v1/disputes/dsp_abc123/resolve \
   -H "Authorization: Bearer ohk_live_your_api_key" \
   -H "Content-Type: application/json" \
   -d '{
-    "resolution": "split",
-    "buyerAmount": "30.00",
-    "sellerAmount": "20.00",
+    "decision": "SPLIT",
+    "releaseAmount": "20.00",
+    "refundAmount": "30.00",
     "note": "Seller delivered 40% of agreed work"
   }'
 ```
 
 <Callout type="note">
-  Split resolution requires both amounts to sum to the original escrow amount minus any platform fees.
+  Split resolution requires both `releaseAmount` (seller) and `refundAmount` (buyer) to sum to the original escrow amount.
 </Callout>
 
 ### Resolution Request Body
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `resolution` | string | Yes | `refund`, `release`, or `split` |
-| `note` | string | Yes | Explanation of the decision |
-| `buyerAmount` | string | Split only | Amount to refund to buyer |
-| `sellerAmount` | string | Split only | Amount to release to seller |
+| `decision` | string | Yes | `"FULL_RELEASE"`, `"FULL_REFUND"`, or `"SPLIT"` |
+| `note` | string | No | Internal note for the decision |
+| `releaseAmount` | string | Split only | Amount to release to seller |
+| `refundAmount` | string | Split only | Amount to refund to buyer |
 
 ### Resolution Response
 
@@ -182,7 +182,7 @@ curl -X POST http://localhost:4000/api/v1/disputes/dsp_abc123/resolve \
   "data": {
     "id": "dsp_abc123",
     "status": "resolved",
-    "resolution": "refund",
+    "decision": "FULL_REFUND",
     "resolvedBy": "usr_support",
     "resolvedAt": "2026-02-25T14:00:00.000Z",
     "note": "Seller failed to deliver work within agreed timeframe",
@@ -313,8 +313,8 @@ const sdk = new OfferHubSDK({
 
 // Open a dispute
 const dispute = await sdk.resolution.dispute('ord_xyz789', {
-  requestedBy: 'usr_buyer123',
-  reason: 'Work not delivered as specified'
+  openedBy: 'BUYER',
+  reason: 'NOT_DELIVERED'
 });
 
 // Add a comment
@@ -326,7 +326,7 @@ await sdk.disputes.addComment(dispute.id, {
 
 // Resolve the dispute (requires support scope)
 await sdk.disputes.resolve(dispute.id, {
-  resolution: 'refund',
+  decision: 'FULL_REFUND',
   note: 'Seller confirmed they could not complete the work'
 });
 ```
@@ -343,7 +343,7 @@ events.on('order.disputed', (data) => {
 });
 
 events.on('dispute.resolved', (data) => {
-  console.log('Dispute resolved:', data.resolution);
+  console.log('Dispute resolved:', data.decision);
   // Notify both parties
   notifyParties(data);
 });
@@ -376,8 +376,8 @@ curl -X POST http://localhost:4000/api/v1/webhooks \
   "data": {
     "escrow_id": "esc_xyz789",
     "dispute_id": "dsp_abc123",
-    "opened_by": "usr_buyer123",
-    "reason": "Work not delivered",
+    "opened_by": "BUYER",
+    "reason": "NOT_DELIVERED",
     "order_id": "ord_xyz789"
   }
 }
@@ -424,7 +424,7 @@ curl -X POST http://localhost:4000/api/v1/webhooks \
 | `ORDER_NOT_IN_PROGRESS` | Order not in disputable state | Check order status first |
 | `DISPUTE_ALREADY_EXISTS` | Order already has open dispute | Get existing dispute details |
 | `UNAUTHORIZED_DISPUTE` | Non-buyer trying to open dispute | Only buyers can open disputes |
-| `INVALID_RESOLUTION` | Invalid resolution type | Use `refund`, `release`, or `split` |
+| `INVALID_RESOLUTION` | Invalid decision value | Use `FULL_RELEASE`, `FULL_REFUND`, or `SPLIT` |
 | `INSUFFICIENT_SCOPE` | API key lacks `support` scope | Use key with support permissions |
 
 ## Idempotency
@@ -436,7 +436,7 @@ curl -X POST http://localhost:4000/api/v1/orders/ord_xyz789/resolution/dispute \
   -H "Authorization: Bearer ohk_live_your_api_key" \
   -H "Idempotency-Key: $(uuidgen)" \
   -H "Content-Type: application/json" \
-  -d '{"requestedBy": "usr_buyer123", "reason": "Work not delivered"}'
+  -d '{"openedBy": "BUYER", "reason": "NOT_DELIVERED"}'
 ```
 
 Dispute idempotency keys are stored **forever** — you cannot open the same dispute twice.

--- a/content/docs/guide/escrow-flows.mdx
+++ b/content/docs/guide/escrow-flows.mdx
@@ -245,8 +245,8 @@ curl -X POST http://localhost:4000/api/v1/orders/ord_xyz789/resolution/dispute \
   -H "Authorization: Bearer ohk_live_your_api_key" \
   -H "Content-Type: application/json" \
   -d '{
-    "requestedBy": "usr_buyer123",
-    "reason": "Work delivered does not match agreed specifications"
+    "openedBy": "BUYER",
+    "reason": "QUALITY_ISSUE"
   }'
 ```
 
@@ -259,9 +259,9 @@ Response:
     "status": "DISPUTED",
     "dispute": {
       "id": "dsp_abc123",
-      "reason": "Work delivered does not match agreed specifications",
+      "reason": "QUALITY_ISSUE",
       "openedAt": "2026-03-01T10:00:00.000Z",
-      "openedBy": "usr_buyer123"
+      "openedBy": "BUYER"
     }
   }
 }
@@ -271,8 +271,8 @@ Response:
 
 ```ts
 await sdk.resolution.dispute('ord_xyz789', {
-  requestedBy: 'usr_buyer123',
-  reason: 'Work delivered does not match agreed specifications',
+  openedBy: 'BUYER',
+  reason: 'QUALITY_ISSUE',
 });
 ```
 
@@ -288,11 +288,11 @@ After a dispute is opened, the platform reviews evidence and resolves with a **r
 
 ### Resolution Options
 
-| Resolution | Outcome | On-Chain Transaction |
+| Decision | Outcome | On-Chain Transaction |
 |------------|---------|----------------------|
-| `release` | Funds go to seller | `resolve_dispute` → release |
-| `refund` | Funds return to buyer | `resolve_dispute` → refund |
-| `split` | Custom split between parties | `resolve_dispute` → split |
+| `FULL_RELEASE` | Funds go to seller | `resolve_dispute` → release |
+| `FULL_REFUND` | Funds return to buyer | `resolve_dispute` → refund |
+| `SPLIT` | Custom split between parties | `resolve_dispute` → split |
 
 ### REST — Resolve with Refund
 
@@ -301,7 +301,7 @@ curl -X POST http://localhost:4000/api/v1/disputes/dsp_abc123/resolve \
   -H "Authorization: Bearer ohk_live_your_api_key" \
   -H "Content-Type: application/json" \
   -d '{
-    "resolution": "refund",
+    "decision": "FULL_REFUND",
     "note": "Seller did not deliver agreed deliverables"
   }'
 ```
@@ -313,7 +313,7 @@ curl -X POST http://localhost:4000/api/v1/disputes/dsp_abc123/resolve \
   -H "Authorization: Bearer ohk_live_your_api_key" \
   -H "Content-Type: application/json" \
   -d '{
-    "resolution": "release",
+    "decision": "FULL_RELEASE",
     "note": "Evidence confirms work was delivered as agreed"
   }'
 ```
@@ -323,13 +323,13 @@ curl -X POST http://localhost:4000/api/v1/disputes/dsp_abc123/resolve \
 ```ts
 // Resolve in favor of buyer (refund)
 await sdk.disputes.resolve('dsp_abc123', {
-  resolution: 'refund',
+  decision: 'FULL_REFUND',
   note: 'Seller did not deliver agreed deliverables',
 });
 
 // Resolve in favor of seller (release)
 await sdk.disputes.resolve('dsp_abc123', {
-  resolution: 'release',
+  decision: 'FULL_RELEASE',
   note: 'Evidence confirms work was delivered as agreed',
 });
 ```
@@ -380,8 +380,8 @@ curl -X POST http://localhost:4000/api/v1/orders/ord_xyz789/cancel \
 ```ts
 // Step 1: Buyer raises dispute
 await sdk.resolution.dispute('ord_xyz789', {
-  requestedBy: 'usr_buyer123',
-  reason: 'Work not delivered',
+  openedBy: 'BUYER',
+  reason: 'NOT_DELIVERED',
 });
 
 // Step 2: Platform fetches the dispute
@@ -390,7 +390,7 @@ const dispute = disputes[0];
 
 // Step 3: Platform resolves with refund
 await sdk.disputes.resolve(dispute.id, {
-  resolution: 'refund',
+  decision: 'FULL_REFUND',
   note: 'Verified: seller did not deliver',
 });
 

--- a/content/docs/guide/escrow.mdx
+++ b/content/docs/guide/escrow.mdx
@@ -187,8 +187,8 @@ curl -X POST http://localhost:4000/api/v1/orders/ord_xyz789/resolution/dispute \
   -H "Authorization: Bearer ohk_live_your_api_key" \
   -H "Content-Type: application/json" \
   -d '{
-    "requestedBy": "usr_buyer123",
-    "reason": "Work not delivered as specified"
+    "openedBy": "BUYER",
+    "reason": "QUALITY_ISSUE"
   }'
 ```
 
@@ -201,7 +201,7 @@ curl -X POST http://localhost:4000/api/v1/disputes/dsp_abc123/resolve \
   -H "Authorization: Bearer ohk_live_your_api_key" \
   -H "Content-Type: application/json" \
   -d '{
-    "resolution": "refund",
+    "decision": "FULL_REFUND",
     "note": "Seller did not deliver agreed work"
   }'
 ```

--- a/content/docs/guide/orders.mdx
+++ b/content/docs/guide/orders.mdx
@@ -219,16 +219,19 @@ Reasons: `NOT_DELIVERED`, `QUALITY_ISSUE`, `OTHER`
 # Full release to seller
 curl -X POST http://localhost:4000/api/v1/disputes/dsp_abc123/resolve \
   -H "Authorization: Bearer ohk_live_..." \
+  -H "Content-Type: application/json" \
   -d '{"decision": "FULL_RELEASE"}'
 
 # Full refund to buyer
 curl -X POST http://localhost:4000/api/v1/disputes/dsp_abc123/resolve \
   -H "Authorization: Bearer ohk_live_..." \
+  -H "Content-Type: application/json" \
   -d '{"decision": "FULL_REFUND"}'
 
 # Split between both
 curl -X POST http://localhost:4000/api/v1/disputes/dsp_abc123/resolve \
   -H "Authorization: Bearer ohk_live_..." \
+  -H "Content-Type: application/json" \
   -d '{
     "decision": "SPLIT",
     "releaseAmount": "80.00",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,5 +17,5 @@
     "paths": { "@/*": ["./src/*"] }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules", "backend", "mcp"]
+  "exclude": ["node_modules", "backend", "mcp", "scratch"]
 }


### PR DESCRIPTION
## Issue

Closes #1521

## Description

The dispute-resolution examples across the documentation used inconsistent request schemas. Some guides documented the legacy `resolution`, `buyerAmount`, and `sellerAmount` fields, while others used the orchestrator’s public API contract.

This PR standardizes all dispute-resolution documentation against the verified orchestrator implementation.

## Changes applied

- Updated all dispute-resolution examples to use:
  - `decision`
  - `releaseAmount`
  - `refundAmount`
- Standardized the supported decision values:
  - `FULL_RELEASE`
  - `FULL_REFUND`
  - `SPLIT`
- Removed legacy public fields:
  - `resolution`
  - `buyerAmount`
  - `sellerAmount`
- Updated request tables, curl examples, SDK examples, notes, and error guidance.
- Added `Content-Type: application/json` to dispute-resolution curl examples in the Orders guide.
- Verified the public schema against the orchestrator DTO, resolution service, and SDK.
- Excluded the local orchestrator verification checkout from the website TypeScript project so it does not interfere with the site build.

## Validation

- `npm run build`
- `npm run lint`
- `git diff --check`
- MDX diagnostics
- Site-wide scan confirming legacy dispute-resolution fields are absent

The build and lint checks pass. Lint reports only the existing unused `_err` warning in `src/app/contact/ContactForm.client.tsx`.

## Evidence/Media

Not applicable. This is a documentation-only change with no visual UI changes.