### PR TITLE
docs: unify order and escrow state machine diagrams across guides

### DIFF
--- a/content/docs/guide/disputes.mdx
+++ b/content/docs/guide/disputes.mdx
@@ -35,24 +35,24 @@ A dispute should be opened when:
 ```
 IN_PROGRESS
       ↓
-DISPUTING (opening dispute)
-      ↓
 DISPUTED (awaiting resolution)
       ↓
   ┌───┴───┐
   ↓       ↓
-REFUNDED  CLOSED
+REFUNDED  RELEASED
 (buyer)   (seller)
+      ↓
+    CLOSED
 ```
 
 ### State Descriptions
 
 | State | Description |
 |-------|-------------|
-| `DISPUTING` | Dispute transaction being submitted |
 | `DISPUTED` | Funds locked, awaiting platform resolution |
 | `REFUNDED` | Dispute resolved in buyer's favor |
-| `CLOSED` | Dispute resolved in seller's favor |
+| `RELEASED` | Dispute resolved in seller's favor |
+| `CLOSED` | Order completed after resolution |
 
 ## Opening a Dispute
 

--- a/content/docs/guide/escrow-flows.mdx
+++ b/content/docs/guide/escrow-flows.mdx
@@ -11,21 +11,31 @@ This guide walks through every escrow flow in OFFER-HUB: from creating and fundi
   OFFER-HUB uses [Trustless Work](https://trustlesswork.com) smart contracts on Stellar for non-custodial escrow. All flows ultimately resolve on-chain.
 </Callout>
 
+## State Machines
+
+Escrow and order lifecycles are governed by two canonical state machines (matching `docs/architecture/state-machines.md` in the orchestrator repository exactly). The **Order state machine** tracks the order lifecycle, while the internal **Escrow state machine** tracks the smart contract itself. The flows below map onto these two machines.
+
+<OrderStateMachineDiagram />
+
+<EscrowStateMachineDiagram />
+
+---
+
 ## Creating an Escrow
 
 An escrow contract is created after an order is placed and the buyer's funds are reserved off-chain.
 
 ### Steps
 
-1. **Create the order** — Buyer's balance is reserved
-2. **Call the escrow creation endpoint** — Deploys a Trustless Work contract on Stellar
-3. **Wait for confirmation** — Contract becomes `ESCROW_CREATED`
+1. **Create the order** — Buyer's balance is reserved (`ORDER_CREATED` → `FUNDS_RESERVED`)
+2. **Call the escrow creation endpoint** — Deploys a Trustless Work contract on Stellar (`ESCROW_CREATING`)
+3. **Wait for confirmation** — Contract becomes `CREATED`; the order advances to `ESCROW_FUNDING`
 
 ```mermaid
 flowchart LR
-    A[Order Created] --> B[Funds Reserved]
-    B --> C[Contract Deploying]
-    C --> D[Contract Ready]
+    A[ORDER_CREATED] --> B[FUNDS_RESERVED]
+    B --> C[ESCROW_CREATING]
+    C --> D[CREATED]
 ```
 
 ### REST
@@ -64,12 +74,12 @@ const sdk = new OfferHubSDK({
 // Create escrow contract
 await sdk.escrow.create('ord_xyz789');
 
-// Wait until contract is deployed
-await sdk.orders.waitForStatus('ord_xyz789', 'ESCROW_CREATED');
+// Wait until the contract is deployed (order advances to ESCROW_FUNDING)
+await sdk.orders.waitForStatus('ord_xyz789', 'ESCROW_FUNDING');
 ```
 
 <Callout type="tip">
-  Contract deployment is asynchronous. Use `waitForStatus` or subscribe to the `order.escrow_created` event rather than polling manually.
+  Contract deployment is asynchronous. Use `waitForStatus` or subscribe to the `order.escrow_creating` event rather than polling manually.
 </Callout>
 
 ---
@@ -87,9 +97,8 @@ Once the contract is deployed, the buyer's reserved USDC is transferred on-chain
 
 ```mermaid
 flowchart LR
-    A[ESCROW_CREATED] --> B[ESCROW_FUNDING]
-    B --> C[ESCROW_FUNDED]
-    C --> D[IN_PROGRESS]
+    A[CREATED] --> B[FUNDING]
+    B --> C[FUNDED]
 ```
 
 ### REST
@@ -227,15 +236,13 @@ If the buyer believes the work was not delivered as agreed, they can open a disp
 ### Steps
 
 1. **Buyer opens dispute** — Provides a reason
-2. **Status changes** — Order moves to `DISPUTING` then `DISPUTED`
+2. **Status changes** — Order moves to `DISPUTED` (funds stay locked in the contract)
 3. **Funds remain locked** — Neither party can access the escrow
 4. **Platform reviews** — Manual or automated resolution begins
 
 ```mermaid
 flowchart LR
-    A[IN_PROGRESS] --> B[DISPUTING]
-    B --> C[DISPUTED]
-    C --> D[resolution pending]
+    A[IN_PROGRESS] --> B[DISPUTED]: Open dispute
 ```
 
 ### REST
@@ -408,8 +415,8 @@ Subscribe to lifecycle events to keep your application in sync:
 ```ts
 const events = sdk.events.subscribe();
 
-events.on('order.escrow_created', (data) => {
-  console.log('Contract deployed:', data.contractId);
+events.on('order.escrow_creating', (data) => {
+  console.log('Contract deploying:', data.contractId);
 });
 
 events.on('order.escrow_funded', (data) => {

--- a/content/docs/guide/escrow.mdx
+++ b/content/docs/guide/escrow.mdx
@@ -37,50 +37,27 @@ OFFER-HUB uses [Trustless Work](https://trustlesswork.com) smart contracts on th
 
 ### State Machine
 
-```mermaid
-stateDiagram-v2
-    [*] --> ORDER_CREATED
-    ORDER_CREATED --> FUNDS_RESERVED: Off-chain lock
+The escrow contract follows the internal **Escrow state machine** below — the same canonical diagram used across the docs, matching `docs/architecture/state-machines.md` in the orchestrator repository exactly. The order around it follows the [Order lifecycle](/docs/guide/orders).
 
-    state "Contract Setup" as setup {
-        FUNDS_RESERVED --> ESCROW_CREATING: Init contract
-        ESCROW_CREATING --> ESCROW_CREATED: Deployed
-    }
-
-    state "Funding" as funding {
-        ESCROW_CREATED --> ESCROW_FUNDING: Send USDC
-        ESCROW_FUNDING --> ESCROW_FUNDED: Confirmed
-    }
-
-    ESCROW_FUNDED --> IN_PROGRESS: Work begins
-
-    state "Resolution" as resolution {
-        IN_PROGRESS --> RELEASING: Buyer approves
-        IN_PROGRESS --> DISPUTING: Open dispute
-        RELEASING --> CLOSED: Released
-        DISPUTING --> DISPUTED: Under review
-        DISPUTED --> REFUNDED: Refund
-        DISPUTED --> CLOSED: Release
-    }
-
-    CLOSED --> [*]
-    REFUNDED --> [*]
-```
+<EscrowStateMachineDiagram />
 
 ### State Descriptions
 
 | State | Description |
 |-------|-------------|
-| `ESCROW_CREATING` | Smart contract being deployed |
-| `ESCROW_CREATED` | Contract ready, waiting for funding |
-| `ESCROW_FUNDING` | USDC transfer to contract in progress |
-| `ESCROW_FUNDED` | Funds locked, work can begin |
-| `IN_PROGRESS` | Seller is working on the order |
-| `RELEASING` | Release transaction in progress |
-| `DISPUTING` | Dispute transaction in progress |
-| `DISPUTED` | Awaiting resolution |
-| `CLOSED` | Funds released to seller |
-| `REFUNDED` | Funds returned to buyer |
+| `CREATING` | Creating contract in Trustless Work |
+| `CREATED` | Contract created, not funded |
+| `FUNDING` | Funding contract |
+| `FUNDED` | Funds locked in contract |
+| `RELEASING` | Releasing funds to the seller |
+| `RELEASED` | Funds released |
+| `REFUNDING` | Returning funds to the buyer |
+| `REFUNDED` | Funds returned |
+| `DISPUTED` | Active dispute |
+
+<Callout type="note">
+  Order-level statuses (e.g. `ESCROW_CREATING`, `ESCROW_FUNDING`, `ESCROW_FUNDED`, `IN_PROGRESS`, `CLOSED`) belong to the [Order state machine](/docs/guide/orders). The escrow machine above tracks the smart contract itself.
+</Callout>
 
 ## Creating Escrow
 
@@ -235,8 +212,9 @@ const order = await sdk.orders.get('ord_xyz789');
 // Create escrow contract
 await sdk.escrow.create(order.id);
 
-// Wait for contract creation (or use events)
-await sdk.orders.waitForStatus(order.id, 'ESCROW_CREATED');
+// Wait for contract creation (or use events) — the order advances to
+// ESCROW_FUNDING once Trustless Work confirms the deployment
+await sdk.orders.waitForStatus(order.id, 'ESCROW_FUNDING');
 
 // Fund the escrow
 await sdk.escrow.fund(order.id);
@@ -255,8 +233,8 @@ await sdk.resolution.release(order.id, {
 ```typescript
 const events = sdk.events.subscribe();
 
-events.on('order.escrow_created', (data) => {
-  console.log('Contract deployed:', data.contractId);
+events.on('order.escrow_creating', (data) => {
+  console.log('Contract deploying:', data.contractId);
 });
 
 events.on('order.escrow_funded', (data) => {

--- a/content/docs/guide/orchestrator.mdx
+++ b/content/docs/guide/orchestrator.mdx
@@ -114,35 +114,49 @@ The seller requests a withdrawal. The Orchestrator signs a Stellar payment trans
 
 <CommandLine>POST /api/withdrawals</CommandLine>
 
-## Escrow State Machine
+## State Machines
 
-Every escrow moves through a strict set of states. Invalid transitions are rejected with a `409 Conflict` error.
+The Orchestrator runs two distinct state machines: an **Order state machine** that tracks the order lifecycle, and an internal **Escrow state machine** that tracks the on-chain escrow contract. Invalid transitions are rejected with a `409 Conflict` error. Both diagrams below match `docs/architecture/state-machines.md` in the orchestrator repository exactly.
 
-```mermaid
-stateDiagram-v2
-    [*] --> CREATED: fund()
-    CREATED --> FUNDED: fund()
-    FUNDED --> RELEASED: release()
-    FUNDED --> DISPUTED: dispute()
-    FUNDED --> REFUNDED: refund()
-    DISPUTED --> RELEASED: resolveToSeller()
-    DISPUTED --> SPLIT: resolveToSplit()
-    RELEASED --> [*]
-    REFUNDED --> [*]
-    SPLIT --> [*]
-```
+### Order State Machine
+
+<OrderStateMachineDiagram />
 
 | State | Description |
 |-------|-------------|
-| `CREATED` | Order exists in the ledger, funds reserved but not yet on-chain |
-| `FUNDED` | USDC is locked in the Soroban smart contract |
-| `RELEASED` | Funds sent to seller, escrow is complete |
-| `DISPUTED` | Buyer opened a dispute, funds frozen pending resolution |
-| `REFUNDED` | Funds returned to buyer's available balance |
-| `SPLIT` | Dispute resolved with partial payment to both parties |
+| `ORDER_CREATED` | Order created off-chain, no funds reserved |
+| `FUNDS_RESERVED` | Buyer balance reserved (logical hold) |
+| `ESCROW_CREATING` | Creating escrow contract in Trustless Work |
+| `ESCROW_FUNDING` | Funding escrow with reserved balance |
+| `ESCROW_FUNDED` | Escrow funded, funds locked on-chain |
+| `IN_PROGRESS` | Work in progress |
+| `RELEASE_REQUESTED` | Release requested for the seller |
+| `RELEASED` | Funds released to the seller |
+| `REFUND_REQUESTED` | Refund requested for the buyer |
+| `REFUNDED` | Funds returned to the buyer |
+| `DISPUTED` | Dispute opened, flow frozen |
+| `CLOSED` | Order completed |
+
+### Escrow State Machine (internal)
+
+The escrow contract moves through its own lifecycle inside the Orchestrator while the order machine advances in parallel.
+
+<EscrowStateMachineDiagram />
+
+| State | Description |
+|-------|-------------|
+| `CREATING` | Creating contract in Trustless Work |
+| `CREATED` | Contract created, not funded |
+| `FUNDING` | Funding contract |
+| `FUNDED` | Funds locked in contract |
+| `RELEASING` | Releasing funds to the seller |
+| `RELEASED` | Funds released |
+| `REFUNDING` | Returning funds to the buyer |
+| `REFUNDED` | Funds returned |
+| `DISPUTED` | Active dispute |
 
 <Callout variant="warning">
-  Once an escrow reaches `RELEASED`, `REFUNDED`, or `SPLIT` it is terminal — no further transitions are allowed.
+  Once an escrow reaches `RELEASED` or `REFUNDED` the contract is terminal — no further on-chain transitions are allowed. The order itself only reaches `CLOSED` after the escrow resolves and cleanup completes.
 </Callout>
 
 ## Error Handling

--- a/content/docs/guide/orders.mdx
+++ b/content/docs/guide/orders.mdx
@@ -13,32 +13,13 @@ Orders are the core of OFFER-HUB. They represent a transaction between a buyer a
 
 ## Order Lifecycle
 
-Every order follows a strict state machine:
+Every order follows a strict state machine — the same canonical diagram used across the docs, matching `docs/architecture/state-machines.md` in the orchestrator repository exactly:
 
-```mermaid
-stateDiagram-v2
-    [*] --> ORDER_CREATED
-    ORDER_CREATED --> FUNDS_RESERVED: Reserve funds
-    FUNDS_RESERVED --> ESCROW_CREATING: Create escrow
-    ESCROW_CREATING --> ESCROW_CREATED
-    ESCROW_CREATED --> ESCROW_FUNDING: Fund escrow
-    ESCROW_FUNDING --> ESCROW_FUNDED
-    ESCROW_FUNDED --> IN_PROGRESS: Work begins
+<OrderStateMachineDiagram />
 
-    IN_PROGRESS --> RELEASE_REQUESTED: Buyer approves
-    IN_PROGRESS --> REFUND_REQUESTED: Request refund
-    IN_PROGRESS --> DISPUTED: Open dispute
-
-    RELEASE_REQUESTED --> RELEASED
-    REFUND_REQUESTED --> REFUNDED
-    DISPUTED --> RESOLVED
-
-    RELEASED --> CLOSED
-    REFUNDED --> CLOSED
-    RESOLVED --> CLOSED
-
-    CLOSED --> [*]
-```
+<Callout type="note">
+  The escrow contract itself follows a separate internal [Escrow state machine](/docs/guide/escrow) while the order machine above advances in parallel.
+</Callout>
 
 ## Creating an Order
 

--- a/src/components/docs/EscrowStateMachineDiagram.tsx
+++ b/src/components/docs/EscrowStateMachineDiagram.tsx
@@ -1,0 +1,37 @@
+import { MermaidDiagram } from "@/components/shared/MermaidDiagram";
+
+/**
+ * Canonical internal Escrow state machine diagram.
+ *
+ * Source of truth: `docs/architecture/state-machines.md` (Escrow States
+ * (internal)) in the OFFER-HUB orchestrator repository. Kept verbatim.
+ *
+ * Rendered through the shared MermaidDiagram pipeline so the diagram inherits
+ * the docs theme (brand color tokens, light/dark mode) automatically.
+ */
+const ESCROW_STATE_MACHINE_CHART = `stateDiagram-v2
+    [*] --> CREATING: Call TW API
+
+    CREATING --> CREATED: TW confirms creation
+    CREATED --> FUNDING: Starting funding
+
+    FUNDING --> FUNDED: TW confirms funds
+
+    FUNDED --> RELEASING: Release requested
+    FUNDED --> REFUNDING: Refund requested
+    FUNDED --> DISPUTED: Dispute opened
+
+    RELEASING --> RELEASED: TW confirms
+    REFUNDING --> REFUNDED: TW confirms
+
+    DISPUTED --> RELEASED: Release resolution
+    DISPUTED --> REFUNDED: Refund resolution
+
+    RELEASED --> [*]
+    REFUNDED --> [*]`;
+
+export function EscrowStateMachineDiagram() {
+  return <MermaidDiagram chart={ESCROW_STATE_MACHINE_CHART} variant="framed" />;
+}
+
+export default EscrowStateMachineDiagram;

--- a/src/components/docs/OrderStateMachineDiagram.tsx
+++ b/src/components/docs/OrderStateMachineDiagram.tsx
@@ -1,0 +1,48 @@
+import { MermaidDiagram } from "@/components/shared/MermaidDiagram";
+
+/**
+ * Canonical Order state machine diagram.
+ *
+ * Source of truth: `docs/architecture/state-machines.md` (Order States) in the
+ * OFFER-HUB orchestrator repository. States and transitions are kept verbatim;
+ * the two dispute-resolution edge labels are reworded ("Resolve to release" /
+ * "Resolve to refund") because the original "Resolution: release" labels
+ * contain a colon that mermaid's state-diagram parser rejects.
+ *
+ * Rendered through the shared MermaidDiagram pipeline so the diagram inherits
+ * the docs theme (brand color tokens, light/dark mode) automatically.
+ */
+const ORDER_STATE_MACHINE_CHART = `stateDiagram-v2
+    [*] --> ORDER_CREATED: POST /orders
+
+    ORDER_CREATED --> FUNDS_RESERVED: POST /orders/{id}/reserve
+    ORDER_CREATED --> CLOSED: POST /orders/{id}/cancel
+
+    FUNDS_RESERVED --> ESCROW_CREATING: POST /orders/{id}/escrow
+    FUNDS_RESERVED --> CLOSED: POST /orders/{id}/cancel
+
+    ESCROW_CREATING --> ESCROW_FUNDING: Escrow created in TW
+    ESCROW_FUNDING --> ESCROW_FUNDED: POST /orders/{id}/escrow/fund
+
+    ESCROW_FUNDED --> IN_PROGRESS: Work starts
+
+    IN_PROGRESS --> RELEASE_REQUESTED: POST /orders/{id}/release
+    IN_PROGRESS --> REFUND_REQUESTED: POST /orders/{id}/refund
+    IN_PROGRESS --> DISPUTED: POST /orders/{id}/disputes
+
+    RELEASE_REQUESTED --> RELEASED: TW confirms release
+    REFUND_REQUESTED --> REFUNDED: TW confirms refund
+
+    DISPUTED --> RELEASED: Resolve to release
+    DISPUTED --> REFUNDED: Resolve to refund
+
+    RELEASED --> CLOSED: Cleanup
+    REFUNDED --> CLOSED: Cleanup
+
+    CLOSED --> [*]`;
+
+export function OrderStateMachineDiagram() {
+  return <MermaidDiagram chart={ORDER_STATE_MACHINE_CHART} variant="framed" />;
+}
+
+export default OrderStateMachineDiagram;

--- a/src/components/docs/__tests__/StateMachineDiagrams.test.tsx
+++ b/src/components/docs/__tests__/StateMachineDiagrams.test.tsx
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { OrderStateMachineDiagram } from "../OrderStateMachineDiagram";
+import { EscrowStateMachineDiagram } from "../EscrowStateMachineDiagram";
+
+vi.mock("@/components/shared/MermaidDiagram", () => ({
+  MermaidDiagram: ({ chart, variant }: { chart?: string; variant?: string }) => (
+    <div data-testid="mermaid" data-chart={chart} data-variant={variant} />
+  ),
+}));
+
+describe("state machine diagrams", () => {
+  it("renders the canonical Order state machine through MermaidDiagram", () => {
+    render(<OrderStateMachineDiagram />);
+    const diagram = screen.getByTestId("mermaid");
+    const chart = diagram.getAttribute("data-chart") ?? "";
+
+    expect(diagram.getAttribute("data-variant")).toBe("framed");
+
+    // Canonical states from docs/architecture/state-machines.md (Order States)
+    for (const state of [
+      "ORDER_CREATED",
+      "FUNDS_RESERVED",
+      "ESCROW_CREATING",
+      "ESCROW_FUNDING",
+      "ESCROW_FUNDED",
+      "IN_PROGRESS",
+      "RELEASE_REQUESTED",
+      "RELEASED",
+      "REFUND_REQUESTED",
+      "REFUNDED",
+      "DISPUTED",
+      "CLOSED",
+    ]) {
+      expect(chart).toContain(state);
+    }
+
+    // Canonical transitions
+    for (const transition of [
+      "[*] --> ORDER_CREATED",
+      "ORDER_CREATED --> FUNDS_RESERVED",
+      "ORDER_CREATED --> CLOSED",
+      "FUNDS_RESERVED --> ESCROW_CREATING",
+      "ESCROW_CREATING --> ESCROW_FUNDING",
+      "ESCROW_FUNDING --> ESCROW_FUNDED",
+      "ESCROW_FUNDED --> IN_PROGRESS",
+      "IN_PROGRESS --> RELEASE_REQUESTED",
+      "IN_PROGRESS --> REFUND_REQUESTED",
+      "IN_PROGRESS --> DISPUTED",
+      "RELEASE_REQUESTED --> RELEASED",
+      "REFUND_REQUESTED --> REFUNDED",
+      "DISPUTED --> RELEASED",
+      "DISPUTED --> REFUNDED",
+      "RELEASED --> CLOSED",
+      "REFUNDED --> CLOSED",
+      "CLOSED --> [*]",
+    ]) {
+      expect(chart).toContain(transition);
+    }
+
+    // No states that don't exist in the canonical machine
+    for (const bogus of ["ESCROW_CREATED", "DISPUTING", "RESOLVED", "SPLIT"]) {
+      expect(chart).not.toContain(bogus);
+    }
+  });
+
+  it("renders the canonical internal Escrow state machine through MermaidDiagram", () => {
+    render(<EscrowStateMachineDiagram />);
+    const diagram = screen.getByTestId("mermaid");
+    const chart = diagram.getAttribute("data-chart") ?? "";
+
+    expect(diagram.getAttribute("data-variant")).toBe("framed");
+
+    // Canonical states from docs/architecture/state-machines.md (Escrow States (internal))
+    for (const state of [
+      "CREATING",
+      "CREATED",
+      "FUNDING",
+      "FUNDED",
+      "RELEASING",
+      "RELEASED",
+      "REFUNDING",
+      "REFUNDED",
+      "DISPUTED",
+    ]) {
+      expect(chart).toContain(state);
+    }
+
+    // Canonical transitions
+    for (const transition of [
+      "[*] --> CREATING",
+      "CREATING --> CREATED",
+      "CREATED --> FUNDING",
+      "FUNDING --> FUNDED",
+      "FUNDED --> RELEASING",
+      "FUNDED --> REFUNDING",
+      "FUNDED --> DISPUTED",
+      "RELEASING --> RELEASED",
+      "REFUNDING --> REFUNDED",
+      "DISPUTED --> RELEASED",
+      "DISPUTED --> REFUNDED",
+      "RELEASED --> [*]",
+      "REFUNDED --> [*]",
+    ]) {
+      expect(chart).toContain(transition);
+    }
+
+    // The internal escrow machine must not drift into order-level states
+    for (const bogus of [
+      "IN_PROGRESS",
+      "CLOSED",
+      "ORDER_CREATED",
+      "ESCROW_CREATING",
+      "RELEASE_REQUESTED",
+    ]) {
+      expect(chart).not.toContain(bogus);
+    }
+  });
+});

--- a/src/components/docs/mdx-components.tsx
+++ b/src/components/docs/mdx-components.tsx
@@ -5,6 +5,8 @@ import { Callout } from "./Callout";
 import { CommandLine } from "./CommandLine";
 import { Badge } from "./Badge";
 import { MermaidDiagram } from "@/components/shared/MermaidDiagram";
+import { OrderStateMachineDiagram } from "./OrderStateMachineDiagram";
+import { EscrowStateMachineDiagram } from "./EscrowStateMachineDiagram";
 import { BASE_MDX_COMPONENTS } from "@/components/mdx/base-mdx-components";
 
 export const MDX_COMPONENTS: MDXComponents = {
@@ -16,6 +18,8 @@ export const MDX_COMPONENTS: MDXComponents = {
   CommandLine,
   Badge,
   MermaidDiagram,
+  OrderStateMachineDiagram,
+  EscrowStateMachineDiagram,
 
   // Blockquote → Callout note (docs-specific override of base)
   blockquote: ({ children }) => <Callout type="note">{children}</Callout>,

--- a/src/hooks/__tests__/use-waitlist-form.test.tsx
+++ b/src/hooks/__tests__/use-waitlist-form.test.tsx
@@ -212,7 +212,7 @@ describe("useWaitlistForm cooldown", () => {
 });
 
 describe("useWaitlistForm with Turnstile configured", () => {
-  const render$ = vi.fn(() => "widget-1");
+  const render$ = vi.fn<(...args: unknown[]) => string>(() => "widget-1");
   const reset = vi.fn();
 
   beforeEach(() => {


### PR DESCRIPTION
## Summary

Closes #1515 — unifies the Order and Escrow state machine diagrams across the docs site.

The docs site previously showed **three conflicting state diagrams** for what a reader assumes is the same escrow/order lifecycle: `guide/orchestrator.mdx`, `guide/escrow.mdx`, and `guide/orders.mdx` each drew their own variant with **different state names, different transitions, and states that do not exist in the real system** (e.g. `ESCROW_CREATED`, `DISPUTING`, `RESOLVED`, `SPLIT` as a state). None of the three matched the system exactly.

The orchestrator actually runs **two distinct, well-defined state machines** — an **Order state machine** and an internal **Escrow state machine** — both documented precisely in [`docs/architecture/state-machines.md`](https://github.com/OFFER-HUB/OFFER-HUB/blob/main/docs/architecture/state-machines.md) (the OFFER-HUB orchestrator repo). This PR makes the docs site show exactly those two canonical machines, rendered through the existing `MermaidDiagram` pipeline, and referenced consistently by all four guide pages instead of three ad hoc variants.

---

## Problem: the three conflicting diagrams (before)

<details>
<summary><code>guide/orders.mdx</code> — invented <code>ESCROW_CREATED</code> and <code>RESOLVED</code> states</summary>

```mermaid
stateDiagram-v2
    [*] --> ORDER_CREATED
    ORDER_CREATED --> FUNDS_RESERVED: Reserve funds
    FUNDS_RESERVED --> ESCROW_CREATING: Create escrow
    ESCROW_CREATING --> ESCROW_CREATED
    ESCROW_CREATED --> ESCROW_FUNDING: Fund escrow
    ESCROW_FUNDING --> ESCROW_FUNDED
    ESCROW_FUNDED --> IN_PROGRESS: Work begins

    IN_PROGRESS --> RELEASE_REQUESTED: Buyer approves
    IN_PROGRESS --> REFUND_REQUESTED: Request refund
    IN_PROGRESS --> DISPUTED: Open dispute

    RELEASE_REQUESTED --> RELEASED
    REFUND_REQUESTED --> REFUNDED
    DISPUTED --> RESOLVED

    RELEASED --> CLOSED
    REFUNDED --> CLOSED
    RESOLVED --> CLOSED

    CLOSED --> [*]
```
</details>

<details>
<summary><code>guide/escrow.mdx</code> — conflated the Order machine and the Escrow machine, invented <code>DISPUTING</code>/<code>RELEASING</code> and a <code>CLOSED</code> release outcome</summary>

```mermaid
stateDiagram-v2
    [*] --> ORDER_CREATED
    ORDER_CREATED --> FUNDS_RESERVED: Off-chain lock

    state "Contract Setup" as setup {
        FUNDS_RESERVED --> ESCROW_CREATING: Init contract
        ESCROW_CREATING --> ESCROW_CREATED: Deployed
    }

    state "Funding" as funding {
        ESCROW_CREATED --> ESCROW_FUNDING: Send USDC
        ESCROW_FUNDING --> ESCROW_FUNDED: Confirmed
    }

    ESCROW_FUNDED --> IN_PROGRESS: Work begins

    state "Resolution" as resolution {
        IN_PROGRESS --> RELEASING: Buyer approves
        IN_PROGRESS --> DISPUTING: Open dispute
        RELEASING --> CLOSED: Released
        DISPUTING --> DISPUTED: Under review
        DISPUTED --> REFUNDED: Refund
        DISPUTED --> CLOSED: Release
    }

    CLOSED --> [*]
    REFUNDED --> [*]
```
</details>

<details>
<summary><code>guide/orchestrator.mdx</code> — treated <code>SPLIT</code> as a state, dropped <code>CREATING</code>/<code>FUNDING</code>/<code>RELEASING</code>/<code>REFUNDING</code>, wrong transitions</summary>

```mermaid
stateDiagram-v2
    [*] --> CREATED: fund()
    CREATED --> FUNDED: fund()
    FUNDED --> RELEASED: release()
    FUNDED --> DISPUTED: dispute()
    FUNDED --> REFUNDED: refund()
    DISPUTED --> RELEASED: resolveToSeller()
    DISPUTED --> SPLIT: resolveToSplit()
    RELEASED --> [*]
    REFUNDED --> [*]
    SPLIT --> [*]
```
</details>

**Why each one was wrong** (verified against the orchestrator source, not guessed):

| Old claim | Reality (per `docs/architecture/state-machines.md` + API code) |
|---|---|
| `ESCROW_CREATED` is an order state | Does not exist. Order goes `ESCROW_CREATING → ESCROW_FUNDING → ESCROW_FUNDED` |
| `DISPUTING` is a state | Does not exist. `openDispute()` transitions the order `IN_PROGRESS → DISPUTED` directly (`resolution.service.ts`) |
| `RESOLVED` is an order state | Does not exist. `DISPUTED → RELEASED` or `DISPUTED → REFUNDED` (`OrderStateMachine`) |
| `SPLIT` is a state | It is a resolution **decision** (`FULL_RELEASE` / `FULL_REFUND` / `SPLIT` in `resolveDispute()`), not a state |
| Escrow has only `CREATED/FUNDED/RELEASED/DISPUTED/REFUNDED` | The internal Escrow machine has 9 states: `CREATING, CREATED, FUNDING, FUNDED, RELEASING, RELEASED, REFUNDING, REFUNDED, DISPUTED` |
| `CLOSED` is the seller-favor resolution outcome | Release resolves to `RELEASED`; the order reaches `CLOSED` only afterward as cleanup |

---

## Solution: two canonical diagrams (after)

### 1. Order state machine — `src/components/docs/OrderStateMachineDiagram.tsx`

Chart kept **verbatim** from `docs/architecture/state-machines.md` (Order States), including the REST endpoints on the transition labels:

```mermaid
stateDiagram-v2
    [*] --> ORDER_CREATED: POST /orders

    ORDER_CREATED --> FUNDS_RESERVED: POST /orders/{id}/reserve
    ORDER_CREATED --> CLOSED: POST /orders/{id}/cancel

    FUNDS_RESERVED --> ESCROW_CREATING: POST /orders/{id}/escrow
    FUNDS_RESERVED --> CLOSED: POST /orders/{id}/cancel

    ESCROW_CREATING --> ESCROW_FUNDING: Escrow created in TW
    ESCROW_FUNDING --> ESCROW_FUNDED: POST /orders/{id}/escrow/fund

    ESCROW_FUNDED --> IN_PROGRESS: Work starts

    IN_PROGRESS --> RELEASE_REQUESTED: POST /orders/{id}/release
    IN_PROGRESS --> REFUND_REQUESTED: POST /orders/{id}/refund
    IN_PROGRESS --> DISPUTED: POST /orders/{id}/disputes

    RELEASE_REQUESTED --> RELEASED: TW confirms release
    REFUND_REQUESTED --> REFUNDED: TW confirms refund

    DISPUTED --> RELEASED: Resolve to release
    DISPUTED --> REFUNDED: Resolve to refund

    RELEASED --> CLOSED: Cleanup
    REFUNDED --> CLOSED: Cleanup

    CLOSED --> [*]
```

### 2. Escrow state machine (internal) — `src/components/docs/EscrowStateMachineDiagram.tsx`

Chart kept **verbatim** from `docs/architecture/state-machines.md` (Escrow States (internal)):

```mermaid
stateDiagram-v2
    [*] --> CREATING: Call TW API

    CREATING --> CREATED: TW confirms creation
    CREATED --> FUNDING: Starting funding

    FUNDING --> FUNDED: TW confirms funds

    FUNDED --> RELEASING: Release requested
    FUNDED --> REFUNDING: Refund requested
    FUNDED --> DISPUTED: Dispute opened

    RELEASING --> RELEASED: TW confirms
    REFUNDING --> REFUNDED: TW confirms

    DISPUTED --> RELEASED: Release resolution
    DISPUTED --> REFUNDED: Refund resolution

    RELEASED --> [*]
    REFUNDED --> [*]
```

> **One deliberate deviation:** the two Order-machine dispute-resolution edge labels are reworded from `Resolution: release` / `Resolution: refund` (as written in `state-machines.md`) to `Resolve to release` / `Resolve to refund`. The original labels contain a colon, which mermaid's `stateDiagram-v2` parser rejects as a malformed transition label (verified with `mermaid.parse`). The states and transitions are otherwise identical. This is called out in the component JSDoc.

---

## Changes by file

| File | Change |
|---|---|
| `src/components/docs/OrderStateMachineDiagram.tsx` *(new)* | Canonical Order machine, verbatim chart, rendered via `MermaidDiagram` `variant="framed"` |
| `src/components/docs/EscrowStateMachineDiagram.tsx` *(new)* | Canonical internal Escrow machine, verbatim chart, rendered via `MermaidDiagram` `variant="framed"` |
| `src/components/docs/__tests__/StateMachineDiagrams.test.tsx` *(new)* | Unit tests asserting every canonical state/transition is present and deprecated/foreign states are absent (see Testing) |
| `src/components/docs/mdx-components.tsx` | Registers both components in `MDX_COMPONENTS` so they can be used as `<OrderStateMachineDiagram />` / `<EscrowStateMachineDiagram />` in MDX |
| `content/docs/guide/orders.mdx` | Replaces its inline `stateDiagram-v2` with `<OrderStateMachineDiagram />`; adds a note cross-linking to the internal Escrow machine |
| `content/docs/guide/escrow.mdx` | Replaces its inline `stateDiagram-v2` with `<EscrowStateMachineDiagram />`; rewrites the state table to the 9 internal escrow states; adds a callout distinguishing order-level vs escrow-level statuses; fixes `waitForStatus` target and event name (below) |
| `content/docs/guide/orchestrator.mdx` | Replaces its single inline machine with **both** canonical diagrams + full state-description tables for each; updates the terminal-state warning |
| `content/docs/guide/escrow-flows.mdx` | Adds a "State Machines" section referencing both canonical diagrams; corrects stale state names in flow illustrations, code samples, and event names (below) |
| `content/docs/guide/disputes.mdx` | Corrects the dispute-lifecycle diagram (`DISPUTING` removed; seller-favor resolution is `RELEASED`, then `CLOSED`) and state table (see Terminology corrections) |
| `src/hooks/__tests__/use-waitlist-form.test.tsx` | Fixes a pre-existing whole-project `tsc` error (`TS2493`) so type checks pass (see Drive-by fix) |

---

## Terminology corrections (all cross-checked against the orchestrator repo)

| Location | Before (wrong) | After (canonical) | Verified against |
|---|---|---|---|
| `escrow.mdx` / `escrow-flows.mdx` examples | `order.escrow_created` event | `order.escrow_creating` | `event-catalog.ts`: `ORDER_ESCROW_CREATING: 'order.escrow_creating'` |
| `escrow.mdx` / `escrow-flows.mdx` samples | `waitForStatus(order.id, 'ESCROW_CREATED')` | `waitForStatus(order.id, 'ESCROW_FUNDING')` | `orders.service.ts`: order advances to `ESCROW_FUNDING` once TW confirms deployment |
| `escrow-flows.mdx` create steps | contract becomes `ESCROW_CREATED` | contract becomes `CREATED`; order advances to `ESCROW_FUNDING` | `state-machines.md` Escrow states + `webhook.service.ts` (`ESCROW_FUNDING_STARTED` → order `ESCROW_FUNDING`) |
| `escrow-flows.mdx` funding flow | `ESCROW_CREATED → ESCROW_FUNDING → ESCROW_FUNDED → IN_PROGRESS` | `CREATED → FUNDING → FUNDED` (escrow machine) | `state-machines.md` |
| `escrow-flows.mdx` dispute flow | `IN_PROGRESS → DISPUTING → DISPUTED → resolution pending` | `IN_PROGRESS → DISPUTED` (open dispute) | `resolution.service.ts` `openDispute()` |
| `escrow.mdx` state table | 10 order/escrow states mixed (`ESCROW_CREATING`, `ESCROW_CREATED`, `IN_PROGRESS`, `CLOSED`, …) | 9 internal escrow states only (`CREATING`…`DISPUTED`) | `state-machines.md` |
| `orchestrator.mdx` machine | `CREATED → FUNDED` direct; `SPLIT` terminal state; `resolveToSeller()`/`resolveToSplit()` | canonical two machines; `SPLIT` removed as a state; `resolveDispute()` decisions `FULL_RELEASE`/`FULL_REFUND`/`SPLIT` | `state-machines.md` + `resolution.service.ts` |
| `orchestrator.mdx` warning | "terminal: `RELEASED`, `REFUNDED`, or `SPLIT`" | "terminal on-chain: `RELEASED`/`REFUNDED`; order reaches `CLOSED` after cleanup" | `confirmRelease()`/`confirmRefund()` update order `→ RELEASED/REFUNDED → CLOSED` |
| `disputes.mdx` lifecycle | `DISPUTING` state; seller-favor → `CLOSED` | `IN_PROGRESS → DISPUTED → RELEASED/REFUNDED → CLOSED` | `resolution.service.ts` + `state-machines.md` |

`SPLIT` was **intentionally kept** in the dispute API examples (`disputes.mdx`, `orders.mdx`) because `resolveDispute()` genuinely supports `{ "decision": "SPLIT", releaseAmount, refundAmount }` — it is a resolution decision, not a state, and the issue only concerns the state machines.

---

## Design decisions

1. **Shared components instead of inline ` ```mermaid ` blocks.** The issue asks for *"one canonical diagram… referenced consistently everywhere instead of three ad hoc variants"*. A shared component makes the mermaid source exist **once**, so the four pages can never drift apart again — the exact failure mode this issue fixes. Copy-pasting the same fenced block into four pages would recreate it. The components are deliberately **not hand-rolled renderers**: they are thin, unstyled wrappers that pass a single chart string to the mandated `MermaidDiagram` (`src/components/shared/MermaidDiagram.tsx`) with `variant="framed"`, so they look and behave identically to every other diagram on the site.
2. **Zero styling in new code.** No hardcoded colors, no layout, no custom theming — brand color tokens (`#149A9B` teal, dark/light palettes) and `ThemeProvider` switching all come from `MermaidDiagram`, matching the issue's requirement.
3. **Diagrams stay in sync with the orchestrator repo.** Each component's JSDoc names the source of truth (`docs/architecture/state-machines.md`) so future edits know where the canonical chart lives.

---

## Acceptance criteria mapping

| # | Criterion (from issue) | Status | How |
|---|---|---|---|
| 1 | One canonical Order diagram and one canonical Escrow diagram exist, matching `docs/architecture/state-machines.md` exactly | ✅ | Charts kept verbatim (states + transitions identical; only the two colon-bearing edge labels reworded for mermaid compatibility, documented in JSDoc + this description) |
| 2 | `orchestrator.mdx`, `escrow.mdx`, `orders.mdx`, `escrow-flows.mdx` all reference the same two diagrams | ✅ | Every page now renders `<OrderStateMachineDiagram />` / `<EscrowStateMachineDiagram />`; none draws its own state machine |
| 3 | Diagrams rendered visually (mermaid), not just prose lists of states | ✅ | Rendered client-side through `MermaidDiagram` |
| 4 | Content reviewed against the orchestrator repo (not guessed) | ✅ | Every claim cross-checked against `state-machines.md`, `event-catalog.ts`, `orders.service.ts`, `resolution.service.ts`, `webhook.service.ts` (see Terminology corrections) |
| 5 | Brand color tokens; correct in light and dark mode; no hardcoded colors | ✅ | New components contain zero color values; theming entirely from `MermaidDiagram` |
| 6 | Uses the existing ` ```mermaid ` + `MermaidDiagram` pipeline | ✅ | Both components delegate 100% of rendering to `src/components/shared/MermaidDiagram.tsx` with `variant="framed"` |
| 7 | Update documentation if needed (cross-links, sidebar order, etc.) | ✅ | Cross-links added between the Order machine (`orders.mdx`) and internal Escrow machine (`escrow.mdx`); both referenced from `escrow-flows.mdx` and `orchestrator.mdx` |

---

## Local verification (all passing)

Run from the repo root unless noted:

| Check | Command | Result |
|---|---|---|
| Lint | `npm run lint` | ✅ No errors; no new warnings (only pre-existing warnings in `useScrollSpy.ts`) |
| Frontend build | `npm run build` | ✅ All `/docs/[...slug]` pages SSG-render with the new components |
| Tests + coverage | `npm run test:coverage` | ✅ 402/402 tests; coverage thresholds in `vitest.config.ts` met |
| Whole-project typecheck | `npx tsc --noEmit` | ✅ Clean (pre-existing `TS2493` fixed — see below) |
| Backend build | `cd backend && npm ci && npm run build` | ✅ |
| Mermaid syntax | `mermaid.parse()` on both charts (jsdom) | ✅ Both charts parse; the original colon-bearing labels were confirmed rejected, justifying the reword |

These mirror the CI jobs in `.github/workflows/ci.yml` (frontend: `lint` + `build` + `test:coverage`; backend: `build`), so the PR's CI is expected to pass.

---

## Testing strategy

**New:** `src/components/docs/__tests__/StateMachineDiagrams.test.tsx` guards against future drift by asserting, for each diagram:

- **Order machine:** all 12 canonical states (`ORDER_CREATED`, `FUNDS_RESERVED`, `ESCROW_CREATING`, `ESCROW_FUNDING`, `ESCROW_FUNDED`, `IN_PROGRESS`, `RELEASE_REQUESTED`, `RELEASED`, `REFUND_REQUESTED`, `REFUNDED`, `DISPUTED`, `CLOSED`) and all 17 transitions, including the REST endpoints on labels.
- **Escrow machine:** all 9 canonical states and all 13 transitions.
- **Negative guards:** states that must *not* appear — `ESCROW_CREATED`, `DISPUTING`, `RESOLVED`, `SPLIT` (order) and order-level states `IN_PROGRESS`, `CLOSED`, `ORDER_CREATED`, `ESCROW_CREATING`, `RELEASE_REQUESTED` (escrow) — so a future edit can't smuggle a deprecated or foreign state into either machine.

**Existing:** `src/lib/__tests__/mdx.test.ts` compiles the docs MDX, covering that the new components resolve in MDX; the full suite (402 tests) passes with coverage thresholds.

---

## Drive-by fix (kept minimal and unrelated-safe)

`src/hooks/__tests__/use-waitlist-form.test.tsx`: the Turnstile `render` mock was declared as `vi.fn(() => "widget-1")` (zero-parameter signature) but tests index `render$.mock.calls[0][1]`, which fails whole-project `tsc --noEmit` with `TS2493: Tuple type '[]' of length '0' has no element at index '1'`. Typed as `vi.fn<(...args: unknown[]) => string>(() => "widget-1")` so `calls[0][1]` is valid. No behavior change; the test still passes. This was a pre-existing error on `main`, included only so the project's type check is green (CI itself doesn't run whole-project `tsc`, but the issue asks for passing type checks).

---

## Out of scope (unchanged, for reviewer awareness)

- **`/architecture` page** (`src/components/architecture/payment-flow.charts.ts`) still shows a simplified conceptual payment flow (`CREATED → RESERVED → ESCROW_FUNDED → IN_PROGRESS → COMPLETED/DISPUTED → RESOLVED`). It is a high-level architecture embed, not one of the four files the issue lists, and uses intentionally simplified labels — left as-is to keep this PR scoped.
- **`guide/withdrawals.mdx`** has its own `stateDiagram-v2` for the separate Withdrawal machine — unchanged (not part of this issue).

---

Closes #1515
