### PR TITLE
Share validation layer between client and server; adopt accessible Input component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "remark-gfm": "^4.0.1",
         "shiki": "^3.22.0",
         "tailwind-merge": "^3.5.0",
-        "zod": "^4.4.3"
+        "zod": "^3.24.0"
       },
       "devDependencies": {
         "@axe-core/playwright": "^4.13.0",
@@ -71,15 +71,6 @@
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "mcp/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -13190,9 +13181,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,8 @@
         "react-dom": "^19.0.0",
         "remark-gfm": "^4.0.1",
         "shiki": "^3.22.0",
-        "tailwind-merge": "^3.5.0"
+        "tailwind-merge": "^3.5.0",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@axe-core/playwright": "^4.13.0",
@@ -70,6 +71,15 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "mcp/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -6108,9 +6118,9 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.6.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
-      "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.7.0.tgz",
+      "integrity": "sha512-hOwV7WOxXfjRpAM1DSJWZDXx3GhplwD8IfwuwvogD8i1Qnkgosw/H45s4ZnFAUHDAhPjlY9hLBvJhKmGMyY26g==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.3",
@@ -7086,9 +7096,9 @@
       "license": "MIT"
     },
     "node_modules/ip-address": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
-      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.7.0.tgz",
+      "integrity": "sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -10271,6 +10281,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -10557,9 +10568,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",
@@ -13179,9 +13190,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "remark-gfm": "^4.0.1",
     "shiki": "^3.22.0",
     "tailwind-merge": "^3.5.0",
-    "zod": "^4.4.3"
+    "zod": "^3.24.0"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.13.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "react-dom": "^19.0.0",
     "remark-gfm": "^4.0.1",
     "shiki": "^3.22.0",
-    "tailwind-merge": "^3.5.0"
+    "tailwind-merge": "^3.5.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.13.0",

--- a/src/app/api/contact/__tests__/route.test.ts
+++ b/src/app/api/contact/__tests__/route.test.ts
@@ -1,0 +1,102 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const state = vi.hoisted(() => ({
+  configured: true,
+  supabase: null as unknown,
+}));
+
+vi.mock("@/lib/supabase", () => ({
+  get supabase() {
+    return state.supabase;
+  },
+  get isSupabaseConfigured() {
+    return state.configured;
+  },
+}));
+
+import { POST } from "../route";
+
+const insert = vi.fn();
+const from = vi.fn(() => ({ insert }));
+
+function request(body: unknown, raw = false) {
+  return new NextRequest("https://offer-hub.tech/api/contact", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: raw ? (body as string) : JSON.stringify(body),
+  });
+}
+
+const VALID = {
+  company: "Acme Inc",
+  name: "Jane Doe",
+  email: "jane@acme.com",
+  message: "Hello",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  insert.mockResolvedValue({ error: null });
+  state.configured = true;
+  state.supabase = { from };
+});
+
+describe("POST /api/contact — input validation", () => {
+  it.each([
+    ["a missing body key", { name: "Jane", email: "jane@acme.com" }],
+    ["an empty company", { ...VALID, company: "" }],
+    ["an invalid email", { ...VALID, email: "a@@b.co" }],
+    ["a multi-@ email", { ...VALID, email: "a@b@c.co" }],
+  ])("rejects %s with 400 field errors", async (_label, body) => {
+    const res = await POST(request(body));
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.errors).toBeDefined();
+    expect(from).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid JSON with 400", async () => {
+    const res = await POST(request("<html>", true));
+
+    expect(res.status).toBe(400);
+    expect(from).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/contact — persistence", () => {
+  it("inserts a valid inquiry and returns ok", async () => {
+    const res = await POST(request(VALID));
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ ok: true });
+    expect(from).toHaveBeenCalledWith("contact_inquiries");
+    expect(insert).toHaveBeenCalledWith([
+      {
+        company: "Acme Inc",
+        contact_name: "Jane Doe",
+        email: "jane@acme.com",
+        message: "Hello",
+      },
+    ]);
+  });
+
+  it("returns 503 when Supabase is not configured", async () => {
+    state.configured = false;
+
+    const res = await POST(request(VALID));
+
+    expect(res.status).toBe(503);
+    expect(from).not.toHaveBeenCalled();
+  });
+
+  it("returns 500 when insert fails", async () => {
+    insert.mockResolvedValue({ error: { message: "denied" } });
+
+    const res = await POST(request(VALID));
+
+    expect(res.status).toBe(500);
+  });
+});

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabase, isSupabaseConfigured } from "@/lib/supabase";
+import { contactFormSchema } from "@/lib/validation/contact.schema";
+import {
+  formatFieldErrors,
+  validationErrorResponse,
+} from "@/lib/validation/errors";
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const body = await req.json().catch(() => null);
+  const parsed = contactFormSchema.safeParse(body ?? {});
+
+  if (!parsed.success) {
+    return NextResponse.json(
+      validationErrorResponse(formatFieldErrors(parsed.error)),
+      { status: 400 },
+    );
+  }
+
+  if (!isSupabaseConfigured || !supabase) {
+    return NextResponse.json(
+      { error: "Service temporarily unavailable." },
+      { status: 503 },
+    );
+  }
+
+  const { company, name, email, message } = parsed.data;
+
+  const { error } = await supabase.from("contact_inquiries").insert([
+    {
+      company,
+      contact_name: name,
+      email,
+      message,
+    },
+  ]);
+
+  if (error) {
+    return NextResponse.json(
+      { error: "Failed to process contact inquiry." },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/privacy/__tests__/delete.route.test.ts
+++ b/src/app/api/privacy/__tests__/delete.route.test.ts
@@ -60,7 +60,7 @@ describe("POST /api/privacy/delete — input validation", () => {
 
     expect(res.status).toBe(400);
     await expect(res.json()).resolves.toEqual({
-      error: "A valid email address is required.",
+      errors: { email: "A valid email address is required." },
     });
     expect(from).not.toHaveBeenCalled();
   });

--- a/src/app/api/privacy/__tests__/export.route.test.ts
+++ b/src/app/api/privacy/__tests__/export.route.test.ts
@@ -63,7 +63,7 @@ describe("POST /api/privacy/export - input validation", () => {
 
     expect(res.status).toBe(400);
     await expect(res.json()).resolves.toEqual({
-      error: "A valid email address is required.",
+      errors: { email: "A valid email address is required." },
     });
     expect(from).not.toHaveBeenCalled();
   });

--- a/src/app/api/privacy/delete/route.ts
+++ b/src/app/api/privacy/delete/route.ts
@@ -1,48 +1,59 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { supabase, isSupabaseConfigured } from '@/lib/supabase';
-import { isValidEmail } from '@/utils/email';
+import { NextRequest, NextResponse } from "next/server";
+import { supabase, isSupabaseConfigured } from "@/lib/supabase";
+import {
+  dataRightsSchema,
+  DATA_RIGHTS_EMAIL_ERROR,
+} from "@/lib/validation/data-rights.schema";
+import {
+  formatFieldErrors,
+  validationErrorResponse,
+} from "@/lib/validation/errors";
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
   const body = await req.json().catch(() => null);
-  const email = (body?.email ?? '').trim();
+  const parsed = dataRightsSchema.safeParse(body ?? {});
 
-  if (!email || !isValidEmail(email)) {
-    return NextResponse.json(
-      { error: 'A valid email address is required.' },
-      { status: 400 },
-    );
+  if (!parsed.success) {
+    const errors = formatFieldErrors(parsed.error);
+    if (errors.email) {
+      errors.email = DATA_RIGHTS_EMAIL_ERROR;
+    }
+    return NextResponse.json(validationErrorResponse(errors), { status: 400 });
   }
+
+  const { email } = parsed.data;
 
   if (!isSupabaseConfigured || !supabase) {
     return NextResponse.json(
-      { error: 'Service temporarily unavailable.' },
+      { error: "Service temporarily unavailable." },
       { status: 503 },
     );
   }
 
   const { data: existing } = await supabase
-    .from('waitlist')
-    .select('id')
-    .eq('email', email)
+    .from("waitlist")
+    .select("id")
+    .eq("email", email)
     .maybeSingle();
 
   if (!existing) {
     return NextResponse.json(
-      { error: 'No record found for that email address.' },
+      { error: "No record found for that email address." },
       { status: 404 },
     );
   }
 
-  const { error } = await supabase.from('waitlist').delete().eq('email', email);
+  const { error } = await supabase.from("waitlist").delete().eq("email", email);
 
   if (error) {
     return NextResponse.json(
-      { error: 'Failed to process deletion request.' },
+      { error: "Failed to process deletion request." },
       { status: 500 },
     );
   }
 
   return NextResponse.json({
-    message: 'Your data has been successfully deleted. Per GDPR Article 17, deletion is confirmed within 30 days.',
+    message:
+      "Your data has been successfully deleted. Per GDPR Article 17, deletion is confirmed within 30 days.",
   });
 }

--- a/src/app/api/privacy/delete/route.ts
+++ b/src/app/api/privacy/delete/route.ts
@@ -14,10 +14,10 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   const parsed = dataRightsSchema.safeParse(body ?? {});
 
   if (!parsed.success) {
+    // dataRightsSchema only validates `email`, so any failure is an email
+    // failure — normalize it to the user-facing message.
     const errors = formatFieldErrors(parsed.error);
-    if (errors.email) {
-      errors.email = DATA_RIGHTS_EMAIL_ERROR;
-    }
+    errors.email = DATA_RIGHTS_EMAIL_ERROR;
     return NextResponse.json(validationErrorResponse(errors), { status: 400 });
   }
 

--- a/src/app/api/privacy/export/route.ts
+++ b/src/app/api/privacy/export/route.ts
@@ -15,10 +15,10 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   const parsed = dataRightsSchema.safeParse(body ?? {});
 
   if (!parsed.success) {
+    // dataRightsSchema only validates `email`, so any failure is an email
+    // failure — normalize it to the user-facing message.
     const errors = formatFieldErrors(parsed.error);
-    if (errors.email) {
-      errors.email = DATA_RIGHTS_EMAIL_ERROR;
-    }
+    errors.email = DATA_RIGHTS_EMAIL_ERROR;
     return NextResponse.json(validationErrorResponse(errors), { status: 400 });
   }
 

--- a/src/app/api/privacy/export/route.ts
+++ b/src/app/api/privacy/export/route.ts
@@ -1,42 +1,52 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { supabase, isSupabaseConfigured } from '@/lib/supabase';
-import type { WaitlistRow } from '@/types/database';
-import { isValidEmail } from '@/utils/email';
+import { NextRequest, NextResponse } from "next/server";
+import { supabase, isSupabaseConfigured } from "@/lib/supabase";
+import type { WaitlistRow } from "@/types/database";
+import {
+  dataRightsSchema,
+  DATA_RIGHTS_EMAIL_ERROR,
+} from "@/lib/validation/data-rights.schema";
+import {
+  formatFieldErrors,
+  validationErrorResponse,
+} from "@/lib/validation/errors";
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
   const body = await req.json().catch(() => null);
-  const email = (body?.email ?? '').trim();
+  const parsed = dataRightsSchema.safeParse(body ?? {});
 
-  if (!email || !isValidEmail(email)) {
-    return NextResponse.json(
-      { error: 'A valid email address is required.' },
-      { status: 400 },
-    );
+  if (!parsed.success) {
+    const errors = formatFieldErrors(parsed.error);
+    if (errors.email) {
+      errors.email = DATA_RIGHTS_EMAIL_ERROR;
+    }
+    return NextResponse.json(validationErrorResponse(errors), { status: 400 });
   }
+
+  const { email } = parsed.data;
 
   if (!isSupabaseConfigured || !supabase) {
     return NextResponse.json(
-      { error: 'Service temporarily unavailable.' },
+      { error: "Service temporarily unavailable." },
       { status: 503 },
     );
   }
 
   const { data, error } = await supabase
-    .from('waitlist')
-    .select('*')
-    .eq('email', email)
+    .from("waitlist")
+    .select("*")
+    .eq("email", email)
     .maybeSingle<WaitlistRow>();
 
   if (error) {
     return NextResponse.json(
-      { error: 'Failed to retrieve data.' },
+      { error: "Failed to retrieve data." },
       { status: 500 },
     );
   }
 
   if (!data) {
     return NextResponse.json(
-      { error: 'No record found for that email address.' },
+      { error: "No record found for that email address." },
       { status: 404 },
     );
   }

--- a/src/app/api/waitlist/__tests__/route.test.ts
+++ b/src/app/api/waitlist/__tests__/route.test.ts
@@ -1,0 +1,103 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const state = vi.hoisted(() => ({
+  configured: true,
+  supabase: null as unknown,
+}));
+
+vi.mock("@/lib/supabase", () => ({
+  get supabase() {
+    return state.supabase;
+  },
+  get isSupabaseConfigured() {
+    return state.configured;
+  },
+}));
+
+import { POST } from "../route";
+
+const insert = vi.fn();
+const from = vi.fn(() => ({ insert }));
+
+function request(body: unknown, raw = false) {
+  return new NextRequest("https://offer-hub.tech/api/waitlist", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: raw ? (body as string) : JSON.stringify(body),
+  });
+}
+
+const VALID = {
+  name: "Jane Doe",
+  email: "jane@acme.com",
+  purpose: "Marketplace payouts",
+  referral: "Twitter",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  insert.mockResolvedValue({ error: null });
+  state.configured = true;
+  state.supabase = { from };
+});
+
+describe("POST /api/waitlist — input validation", () => {
+  it.each([
+    ["a missing body key", { email: "jane@acme.com" }],
+    ["an invalid email", { ...VALID, email: "a@@b.co" }],
+    ["a multi-@ email", { ...VALID, email: "a@b@c.co" }],
+  ])("rejects %s with 400 field errors", async (_label, body) => {
+    const res = await POST(request(body));
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.errors).toBeDefined();
+    expect(from).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid JSON with 400", async () => {
+    const res = await POST(request("<html>", true));
+
+    expect(res.status).toBe(400);
+    expect(from).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/waitlist — persistence", () => {
+  it("inserts a valid entry and returns ok", async () => {
+    const res = await POST(request(VALID));
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ ok: true });
+    expect(from).toHaveBeenCalledWith("waitlist");
+    expect(insert).toHaveBeenCalledWith([VALID]);
+  });
+
+  it("returns 503 when Supabase is not configured", async () => {
+    state.configured = false;
+
+    const res = await POST(request(VALID));
+
+    expect(res.status).toBe(503);
+    expect(from).not.toHaveBeenCalled();
+  });
+
+  it("returns 409 on duplicate email", async () => {
+    insert.mockResolvedValue({ error: { code: "23505" } });
+
+    const res = await POST(request(VALID));
+
+    expect(res.status).toBe(409);
+    await expect(res.json()).resolves.toEqual({ error: "duplicate" });
+  });
+
+  it("returns 500 when insert fails", async () => {
+    insert.mockResolvedValue({ error: { code: "42501" } });
+
+    const res = await POST(request(VALID));
+
+    expect(res.status).toBe(500);
+  });
+});

--- a/src/app/api/waitlist/route.ts
+++ b/src/app/api/waitlist/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabase, isSupabaseConfigured } from "@/lib/supabase";
+import { waitlistFormSchema } from "@/lib/validation/waitlist.schema";
+import {
+  formatFieldErrors,
+  validationErrorResponse,
+} from "@/lib/validation/errors";
+
+const UNIQUE_VIOLATION = "23505";
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const body = await req.json().catch(() => null);
+  const parsed = waitlistFormSchema.safeParse(body ?? {});
+
+  if (!parsed.success) {
+    return NextResponse.json(
+      validationErrorResponse(formatFieldErrors(parsed.error)),
+      { status: 400 },
+    );
+  }
+
+  if (!isSupabaseConfigured || !supabase) {
+    return NextResponse.json(
+      { error: "Service temporarily unavailable." },
+      { status: 503 },
+    );
+  }
+
+  const { email, name, purpose, referral } = parsed.data;
+
+  const { error } = await supabase.from("waitlist").insert([
+    {
+      email,
+      name,
+      purpose,
+      referral,
+    },
+  ]);
+
+  if (error) {
+    if (error.code === UNIQUE_VIOLATION) {
+      return NextResponse.json({ error: "duplicate" }, { status: 409 });
+    }
+
+    return NextResponse.json(
+      { error: "Failed to process waitlist submission." },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/contact/ContactForm.tsx
+++ b/src/app/contact/ContactForm.tsx
@@ -28,7 +28,7 @@ export function ContactForm() {
   }
 
   return (
-    <form onSubmit={handleSubmit} className="p-8 rounded-[2.5rem] bg-bg-elevated shadow-neu-raised flex flex-col gap-6">
+    <form onSubmit={handleSubmit} noValidate className="p-8 rounded-[2.5rem] bg-bg-elevated shadow-neu-raised flex flex-col gap-6">
       {submitError && (
         <div role="alert" aria-live="assertive" className="p-4 rounded-2xl bg-red-50 dark:bg-red-950/50 border border-red-200 dark:border-red-800 flex items-start gap-3 animate-fadeIn">
           <AlertCircle size={20} className="text-red-500 flex-shrink-0 mt-0.5" />

--- a/src/app/contact/__tests__/ContactForm.test.tsx
+++ b/src/app/contact/__tests__/ContactForm.test.tsx
@@ -1,14 +1,20 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { ContactForm } from "../ContactForm";
 
-const insert = vi.fn();
+function mockFetch(impl: () => Promise<unknown>) {
+  const fn = vi.fn(impl);
+  vi.stubGlobal("fetch", fn);
+  return fn;
+}
 
-vi.mock("@/lib/supabase", () => ({
-  supabase: {
-    from: vi.fn(() => ({ insert })),
-  },
-}));
+function jsonResponse(status: number, body: unknown) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  };
+}
 
 function fillField(container: HTMLElement, id: string, value: string) {
   const field = container.querySelector<HTMLInputElement | HTMLTextAreaElement>(`#${id}`)!;
@@ -17,7 +23,12 @@ function fillField(container: HTMLElement, id: string, value: string) {
 
 describe("ContactForm", () => {
   beforeEach(() => {
-    insert.mockReset();
+    vi.restoreAllMocks();
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it("shows required-field errors and does not submit when fields are empty", () => {
@@ -29,7 +40,7 @@ describe("ContactForm", () => {
     expect(screen.getByText(/company name is required/i)).toBeInTheDocument();
     expect(screen.getByText(/contact name is required/i)).toBeInTheDocument();
     expect(screen.getByText(/work email is required/i)).toBeInTheDocument();
-    expect(insert).not.toHaveBeenCalled();
+    expect(vi.mocked(fetch)).not.toHaveBeenCalled();
   });
 
   it("shows a format error for an invalid work email", () => {
@@ -43,11 +54,25 @@ describe("ContactForm", () => {
     fireEvent.submit(form);
 
     expect(screen.getByText(/enter a valid work email/i)).toBeInTheDocument();
-    expect(insert).not.toHaveBeenCalled();
+    expect(vi.mocked(fetch)).not.toHaveBeenCalled();
   });
 
-  it("submits to Supabase and shows the success state with valid data", async () => {
-    insert.mockResolvedValueOnce({ error: null });
+  it("rejects divergent invalid emails such as a@@b.co", () => {
+    const { container } = render(<ContactForm />);
+    const form = container.querySelector("form")!;
+
+    fillField(container, "company", "Acme Inc");
+    fillField(container, "name", "Jane Doe");
+    fillField(container, "email", "a@@b.co");
+
+    fireEvent.submit(form);
+
+    expect(screen.getByText(/enter a valid work email/i)).toBeInTheDocument();
+    expect(vi.mocked(fetch)).not.toHaveBeenCalled();
+  });
+
+  it("submits to the contact API and shows the success state with valid data", async () => {
+    mockFetch(async () => jsonResponse(200, { ok: true }));
     const { container } = render(<ContactForm />);
     const form = container.querySelector("form")!;
 
@@ -58,17 +83,19 @@ describe("ContactForm", () => {
     fireEvent.submit(form);
 
     expect(await screen.findByText(/thanks — we'll be in touch/i)).toBeInTheDocument();
-    expect(insert).toHaveBeenCalledWith([
-      expect.objectContaining({
+    expect(fetch).toHaveBeenCalledWith("/api/contact", expect.objectContaining({
+      method: "POST",
+      body: JSON.stringify({
         company: "Acme Inc",
-        contact_name: "Jane Doe",
+        name: "Jane Doe",
         email: "jane@acme.com",
+        message: "",
       }),
-    ]);
+    }));
   });
 
-  it("renders the submit error with role=alert when Supabase returns an error", async () => {
-    insert.mockResolvedValueOnce({ error: { message: "boom" } });
+  it("renders the submit error with role=alert when the API returns an error", async () => {
+    mockFetch(async () => jsonResponse(500, { error: "boom" }));
     const { container } = render(<ContactForm />);
     const form = container.querySelector("form")!;
 
@@ -78,7 +105,6 @@ describe("ContactForm", () => {
 
     fireEvent.submit(form);
 
-    const alert = await screen.findByRole("alert");
-    expect(alert).toHaveTextContent(/something went wrong/i);
+    expect(await screen.findByRole("alert")).toHaveTextContent(/something went wrong/i);
   });
 });

--- a/src/components/api-explorer/EndpointPanel.tsx
+++ b/src/components/api-explorer/EndpointPanel.tsx
@@ -7,6 +7,7 @@ import type { ApiEndpoint } from "@/data/api-schema";
 import { MethodBadge } from "./MethodBadge";
 import { ParameterInput } from "./ParameterInput";
 import { ResponseViewer } from "./ResponseViewer";
+import { Textarea } from "@/components/ui/Textarea";
 
 const BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:4000/api/v1";
 
@@ -149,18 +150,18 @@ export function EndpointPanel({ endpoint }: EndpointPanelProps) {
 
               {endpoint.requestBody && (
                 <div className="space-y-2">
-                  <h4 className="text-[11px] font-black uppercase tracking-widest text-theme-primary">
-                    Request Body{" "}
-                    <span className="ml-2 font-normal normal-case tracking-normal text-content-secondary">
-                      {endpoint.requestBody.contentType}
-                    </span>
-                  </h4>
-                  <textarea
+                  <Textarea
+                    id={`request-body-${endpoint.path}`}
+                    label="Request body"
+                    labelClassName="text-[11px] font-black uppercase tracking-widest text-theme-primary"
                     value={bodyValue}
                     onChange={(e) => setBodyValue(e.target.value)}
                     rows={Math.min(bodyValue.split("\n").length + 1, 12)}
-                    className="w-full rounded-xl px-4 py-3 text-sm font-mono text-content-primary resize-y bg-bg-sunken shadow-neu-sunken transition-shadow focus-visible:outline-2 focus-visible:outline-theme-primary focus-visible:outline-offset-2 focus-visible:ring-2 focus-visible:ring-theme-primary focus-visible:ring-offset-0"
+                    className="text-sm font-mono resize-y"
                   />
+                  <p className="text-xs text-content-secondary">
+                    {endpoint.requestBody.contentType}
+                  </p>
                 </div>
               )}
             </div>

--- a/src/components/api-explorer/ParameterInput.tsx
+++ b/src/components/api-explorer/ParameterInput.tsx
@@ -1,4 +1,5 @@
 import { cn } from "@/lib/cn";
+import { Input } from "@/components/ui/Input";
 
 interface ParameterInputProps {
   name: string;
@@ -9,6 +10,7 @@ interface ParameterInputProps {
   options?: string[];
   value: string;
   onChange: (value: string) => void;
+  error?: string;
 }
 
 export function ParameterInput({
@@ -20,24 +22,23 @@ export function ParameterInput({
   options,
   value,
   onChange,
+  error,
 }: ParameterInputProps) {
   const inputId = `param-${name}`;
+  const labelId = `${inputId}-label`;
+  const descriptionId = `${inputId}-description`;
 
   const inputClasses = cn(
-    "w-full rounded-xl px-3 py-2.5 text-sm font-medium",
-    "bg-bg-sunken shadow-neu-sunken-subtle",
-    "text-content-primary placeholder:text-content-muted",
-    "border border-transparent transition-shadow duration-200",
-    "focus-visible:outline-2 focus-visible:outline-theme-primary focus-visible:outline-offset-2",
-    "focus-visible:ring-2 focus-visible:ring-theme-primary focus-visible:ring-offset-0"
+    "px-3 py-2.5 text-sm font-medium",
+    "border border-transparent"
   );
 
   return (
     <div className="space-y-1.5">
-      <label htmlFor={inputId} className="flex items-center gap-2">
-        <span className="text-sm font-semibold font-mono text-content-primary">
+      <div id={labelId} className="flex items-center gap-2">
+        <label htmlFor={inputId} className="text-sm font-semibold font-mono text-content-primary">
           {name}
-        </span>
+        </label>
         <span
           className={cn(
             "text-xs font-medium px-1.5 py-0.5 rounded",
@@ -46,17 +47,28 @@ export function ParameterInput({
         >
           {required ? "required" : "optional"}
         </span>
-      </label>
-      <p className="text-xs text-content-secondary">
+      </div>
+      <p id={descriptionId} className="text-xs text-content-secondary">
         {description}
       </p>
 
       {type === "select" && options ? (
         <select
           id={inputId}
+          aria-labelledby={labelId}
+          aria-describedby={descriptionId}
+          aria-invalid={error ? "true" : undefined}
           value={value}
           onChange={(e) => onChange(e.target.value)}
-          className={inputClasses}
+          className={cn(
+            "w-full rounded-xl px-3 py-2.5 text-sm font-medium",
+            "bg-bg-sunken shadow-neu-sunken-subtle",
+            "text-content-primary",
+            "border border-transparent transition-all duration-200",
+            "focus-visible:outline-2 focus-visible:outline-theme-primary focus-visible:outline-offset-2",
+            "focus-visible:ring-2 focus-visible:ring-theme-primary focus-visible:ring-offset-0",
+            error && "ring-2 ring-theme-error"
+          )}
         >
           <option value="">Select...</option>
           {options.map((opt) => (
@@ -66,14 +78,23 @@ export function ParameterInput({
           ))}
         </select>
       ) : (
-        <input
+        <Input
           id={inputId}
+          labelledBy={labelId}
+          aria-describedby={descriptionId}
           type={type === "number" ? "number" : "text"}
           value={value}
           onChange={(e) => onChange(e.target.value)}
           placeholder={placeholder}
+          error={error}
+          hideWrapper
           className={inputClasses}
         />
+      )}
+      {error && type === "select" && (
+        <span id={`${inputId}-error`} className="text-sm text-theme-error" role="alert">
+          {error}
+        </span>
       )}
     </div>
   );

--- a/src/components/community/RegistrationForm.tsx
+++ b/src/components/community/RegistrationForm.tsx
@@ -58,6 +58,7 @@ export function RegistrationForm() {
 
                 <form
                     onSubmit={handleSubmit}
+                    noValidate
                     className="p-10 rounded-[2.5rem] bg-bg-elevated shadow-neu-raised flex flex-col gap-8"
                 >
                     {error && (

--- a/src/components/community/RegistrationForm.tsx
+++ b/src/components/community/RegistrationForm.tsx
@@ -11,6 +11,7 @@ export function RegistrationForm() {
         isSubmitted,
         isLoading,
         error,
+        errors,
         cooldownSeconds,
         turnstileContainerRef,
         isTurnstileConfigured,
@@ -86,6 +87,7 @@ export function RegistrationForm() {
                         required
                         disabled={isDisabled}
                         icon={User}
+                        error={errors.name}
                     />
 
                     <FormField
@@ -100,6 +102,7 @@ export function RegistrationForm() {
                         required
                         disabled={isDisabled}
                         icon={Mail}
+                        error={errors.email}
                     />
 
                     <FormField
@@ -116,6 +119,7 @@ export function RegistrationForm() {
                         required
                         disabled={isDisabled}
                         icon={MessageSquare}
+                        error={errors.purpose}
                     />
 
                     <FormField
@@ -129,6 +133,7 @@ export function RegistrationForm() {
                         required
                         disabled={isDisabled}
                         icon={Send}
+                        error={errors.referral}
                     />
 
                     {isTurnstileConfigured && (

--- a/src/components/community/__tests__/RegistrationForm.test.tsx
+++ b/src/components/community/__tests__/RegistrationForm.test.tsx
@@ -2,13 +2,19 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, act } from "@testing-library/react";
 import { RegistrationForm } from "../RegistrationForm";
 
-const insert = vi.fn();
+function mockFetch(impl: () => Promise<unknown>) {
+  const fn = vi.fn(impl);
+  vi.stubGlobal("fetch", fn);
+  return fn;
+}
 
-vi.mock("@/lib/supabase", () => ({
-  supabase: {
-    from: vi.fn(() => ({ insert })),
-  },
-}));
+function jsonResponse(status: number, body: unknown) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  };
+}
 
 function fillRequiredFields(container: HTMLElement) {
   const name = container.querySelector<HTMLInputElement>("#name")!;
@@ -33,14 +39,16 @@ function fireInput(el: HTMLInputElement | HTMLTextAreaElement, value: string) {
 
 describe("RegistrationForm", () => {
   beforeEach(() => {
-    insert.mockReset();
+    vi.restoreAllMocks();
+    vi.stubGlobal("fetch", vi.fn());
   });
 
   afterEach(() => {
+    vi.unstubAllGlobals();
     vi.useRealTimers();
   });
 
-  it("blocks submission via native field validation when required fields are empty", async () => {
+  it("blocks submission and shows field errors when required fields are empty", async () => {
     render(<RegistrationForm />);
 
     const submitButton = screen.getByRole("button", { name: /submit application/i });
@@ -48,11 +56,12 @@ describe("RegistrationForm", () => {
       submitButton.click();
     });
 
-    expect(insert).not.toHaveBeenCalled();
+    expect(screen.getByText(/full name is required/i)).toBeInTheDocument();
+    expect(vi.mocked(fetch)).not.toHaveBeenCalled();
   });
 
-  it("submits to Supabase and shows the success state on valid submission", async () => {
-    insert.mockResolvedValueOnce({ error: null });
+  it("submits to the waitlist API and shows the success state on valid submission", async () => {
+    mockFetch(async () => jsonResponse(200, { ok: true }));
     const { container } = render(<RegistrationForm />);
 
     fillRequiredFields(container);
@@ -62,20 +71,21 @@ describe("RegistrationForm", () => {
       submitButton.click();
     });
 
-    expect(insert).toHaveBeenCalledWith([
-      expect.objectContaining({
-        email: "jane@example.com",
+    expect(fetch).toHaveBeenCalledWith("/api/waitlist", expect.objectContaining({
+      method: "POST",
+      body: JSON.stringify({
         name: "Jane Doe",
+        email: "jane@example.com",
         purpose: "Building a marketplace",
         referral: "Friend",
       }),
-    ]);
+    }));
 
     expect(await screen.findByText(/you're on the list/i)).toBeInTheDocument();
   });
 
-  it("shows a duplicate-email error and starts the cooldown on a unique-violation response", async () => {
-    insert.mockResolvedValueOnce({ error: { code: "23505" } });
+  it("shows a duplicate-email error and starts the cooldown on a 409 response", async () => {
+    mockFetch(async () => jsonResponse(409, { error: "duplicate" }));
     const { container } = render(<RegistrationForm />);
 
     fillRequiredFields(container);
@@ -91,7 +101,7 @@ describe("RegistrationForm", () => {
 
   it("prevents resubmission while the cooldown is active", async () => {
     vi.useFakeTimers();
-    insert.mockResolvedValueOnce({ error: { code: "unexpected" } });
+    mockFetch(async () => jsonResponse(500, { error: "boom" }));
     const { container } = render(<RegistrationForm />);
 
     fillRequiredFields(container);
@@ -103,7 +113,7 @@ describe("RegistrationForm", () => {
     });
 
     expect(screen.getByText(/something went wrong/i)).toBeInTheDocument();
-    expect(insert).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledTimes(1);
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(5000);

--- a/src/components/forms/FormField.tsx
+++ b/src/components/forms/FormField.tsx
@@ -1,6 +1,9 @@
 "use client"
 
 import type { LucideIcon } from "lucide-react"
+import { Input } from "@/components/ui/Input"
+import { Textarea } from "@/components/ui/Textarea"
+import { cn } from "@/lib/cn"
 
 interface FormFieldProps {
   id: string
@@ -21,8 +24,8 @@ interface FormFieldProps {
   labelExtra?: React.ReactNode
 }
 
-const INPUT_CLASS =
-  "w-full pl-12 pr-6 py-3.5 rounded-xl bg-bg-sunken shadow-neu-sunken-subtle text-sm text-content-primary placeholder:text-content-muted border-none transition-[box-shadow,opacity] font-medium disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-2 focus-visible:outline-theme-primary focus-visible:outline-offset-2 focus-visible:ring-2 focus-visible:ring-theme-primary"
+const FIELD_CLASS =
+  "pl-12 pr-6 py-3.5 text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
 
 export function FormField({
   id,
@@ -42,7 +45,7 @@ export function FormField({
   error,
   labelExtra,
 }: FormFieldProps) {
-  const errorId = error ? `${id}-error` : undefined
+  const labelId = `${id}-label`
   const charCountClass =
     value.length >= (maxLength ?? 500) * 0.96
       ? "text-red-500"
@@ -54,6 +57,7 @@ export function FormField({
     <div className="flex flex-col gap-2">
       <div className="flex justify-between items-center ml-2">
         <label
+          id={labelId}
           htmlFor={id}
           className="text-[10px] font-black uppercase tracking-widest text-content-secondary"
         >
@@ -72,44 +76,44 @@ export function FormField({
         {Icon && (
           <Icon
             size={16}
-            className={`absolute left-5 text-content-muted group-focus-within:text-theme-primary transition-colors ${
+            className={cn(
+              "absolute left-5 z-10 text-content-muted group-focus-within:text-theme-primary transition-colors pointer-events-none",
               as === "textarea" ? "top-6" : "top-1/2 -translate-y-1/2"
-            }`}
+            )}
           />
         )}
         {as === "textarea" ? (
-          <textarea
+          <Textarea
             id={id}
-            required={required}
-            rows={rows}
+            labelledBy={labelId}
             name={name}
             value={value}
             onChange={onChange}
             placeholder={placeholder}
             maxLength={maxLength}
+            required={required}
             disabled={disabled}
-            aria-describedby={errorId}
-            className={`${INPUT_CLASS} resize-none ${error ? "ring-1 ring-red-400" : ""}`}
+            rows={rows}
+            error={error}
+            hideWrapper
+            className={cn(FIELD_CLASS, Icon && "pl-12")}
           />
         ) : (
-          <input
+          <Input
             id={id}
-            required={required}
+            labelledBy={labelId}
             type={type}
             name={name}
             value={value}
             onChange={onChange}
             placeholder={placeholder}
             maxLength={maxLength}
+            required={required}
             disabled={disabled}
-            aria-describedby={errorId}
-            className={`${INPUT_CLASS} ${error ? "ring-1 ring-red-400" : ""}`}
+            error={error}
+            hideWrapper
+            className={cn(FIELD_CLASS, Icon && "pl-12")}
           />
-        )}
-        {error && (
-          <p id={errorId} className="text-xs text-red-600 mt-1 pl-2">
-            {error}
-          </p>
         )}
       </div>
     </div>

--- a/src/components/mdx/DataRightsForm.tsx
+++ b/src/components/mdx/DataRightsForm.tsx
@@ -43,7 +43,7 @@ export function DataRightsForm({
         <h3 className="text-xl font-black tracking-tight mb-2 text-content-primary">{title}</h3>
         <p className="text-sm font-medium leading-relaxed text-content-secondary">{description}</p>
       </div>
-      <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+      <form onSubmit={handleSubmit} noValidate className="flex flex-col gap-3">
         <Input
           id={`data-rights-email-${endpoint}`}
           label="Email address"

--- a/src/components/mdx/DataRightsForm.tsx
+++ b/src/components/mdx/DataRightsForm.tsx
@@ -3,6 +3,7 @@
 import React from "react";
 import { ShieldCheck, Trash2, Download } from "lucide-react";
 import { useDataRightsForm } from "@/hooks/use-data-rights-form";
+import { Input } from "@/components/ui/Input";
 
 const iconMap = {
   ShieldCheck,
@@ -27,7 +28,7 @@ export function DataRightsForm({
   buttonLabel: string;
   destructive?: boolean;
 }) {
-  const { email, status, loading, setEmail, handleSubmit } = useDataRightsForm(
+  const { email, errors, status, loading, setEmail, handleSubmit } = useDataRightsForm(
     endpoint,
     successMessage
   );
@@ -43,13 +44,16 @@ export function DataRightsForm({
         <p className="text-sm font-medium leading-relaxed text-content-secondary">{description}</p>
       </div>
       <form onSubmit={handleSubmit} className="flex flex-col gap-3">
-        <input
+        <Input
+          id={`data-rights-email-${endpoint}`}
+          label="Email address"
           type="email"
           required
           value={email}
           onChange={(e) => setEmail(e.target.value)}
           placeholder="your@email.com"
-          className="rounded-xl px-4 py-3 text-sm bg-bg-sunken shadow-neu-sunken-subtle text-content-primary placeholder:text-content-secondary/60 outline-none focus:ring-2 focus:ring-theme-primary/30 transition-shadow"
+          error={errors.email}
+          disabled={loading}
         />
         <button
           type="submit"
@@ -63,7 +67,10 @@ export function DataRightsForm({
           {loading ? "Processing…" : buttonLabel}
         </button>
         {status && (
-          <p className={`text-xs font-medium ${status.ok ? "text-theme-primary" : "text-red-500"}`}>
+          <p
+            role="alert"
+            className={`text-xs font-medium ${status.ok ? "text-theme-primary" : "text-red-500"}`}
+          >
             {status.message}
           </p>
         )}

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -1,0 +1,104 @@
+import { useId } from "react";
+import { cn } from "@/lib/cn";
+import type { InputHTMLAttributes, ReactNode } from "react";
+
+interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+    label?: string;
+    labelClassName?: string;
+    labelledBy?: string;
+    error?: string;
+    icon?: ReactNode;
+    iconPosition?: "left" | "right";
+    rightElement?: ReactNode;
+    hideWrapper?: boolean;
+}
+
+export function Input({
+    label,
+    labelClassName,
+    labelledBy,
+    error,
+    icon,
+    iconPosition = "left",
+    rightElement,
+    className,
+    id,
+    hideWrapper = false,
+    "aria-describedby": ariaDescribedBy,
+    ...props
+}: InputProps) {
+    const generatedId = useId();
+    const inputId = id || generatedId;
+    const errorId = `${inputId}-error`;
+
+    const inputElement = (
+        <div className="relative w-full">
+            {icon && iconPosition === "left" && (
+                <span className="absolute left-4 top-1/2 -translate-y-1/2 text-content-secondary" aria-hidden="true">
+                    {icon}
+                </span>
+            )}
+            <input
+                id={inputId}
+                aria-labelledby={labelledBy}
+                aria-invalid={error ? "true" : undefined}
+                aria-describedby={error ? errorId : ariaDescribedBy}
+                className={cn(
+                    "w-full rounded-xl px-4 py-3",
+                    "bg-bg-sunken shadow-neu-sunken-subtle",
+                    "text-content-primary placeholder:text-content-muted",
+                    "focus-visible:outline-2 focus-visible:outline-theme-primary focus-visible:outline-offset-2",
+                    "focus-visible:ring-2 focus-visible:ring-theme-primary",
+                    "transition-all duration-200",
+                    icon && iconPosition === "left" && "pl-12",
+                    icon && iconPosition === "right" && "pr-12",
+                    error && "ring-2 ring-theme-error",
+                    className
+                )}
+                {...props}
+            />
+            {icon && iconPosition === "right" && !rightElement && (
+                <span className="absolute right-4 top-1/2 -translate-y-1/2 text-content-secondary" aria-hidden="true">
+                    {icon}
+                </span>
+            )}
+            {rightElement && (
+                <div className="absolute right-4 top-1/2 -translate-y-1/2 flex items-center">
+                    {rightElement}
+                </div>
+            )}
+        </div>
+    );
+
+    if (hideWrapper) {
+        return (
+            <>
+                {inputElement}
+                {error && (
+                    <span id={errorId} className="text-sm text-theme-error" role="alert">
+                        {error}
+                    </span>
+                )}
+            </>
+        );
+    }
+
+    return (
+        <div className="flex flex-col gap-1.5 w-full">
+            {label && (
+                <label
+                    htmlFor={inputId}
+                    className={cn("text-sm font-medium text-content-primary", labelClassName)}
+                >
+                    {label}
+                </label>
+            )}
+            {inputElement}
+            {error && (
+                <span id={errorId} className="text-sm text-theme-error" role="alert">
+                    {error}
+                </span>
+            )}
+        </div>
+    );
+}

--- a/src/components/ui/Textarea.tsx
+++ b/src/components/ui/Textarea.tsx
@@ -1,0 +1,79 @@
+import { useId } from "react";
+import { cn } from "@/lib/cn";
+import type { TextareaHTMLAttributes } from "react";
+
+interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
+    label?: string;
+    labelClassName?: string;
+    labelledBy?: string;
+    error?: string;
+    hideWrapper?: boolean;
+}
+
+export function Textarea({
+    label,
+    labelClassName,
+    labelledBy,
+    error,
+    className,
+    id,
+    hideWrapper = false,
+    "aria-describedby": ariaDescribedBy,
+    ...props
+}: TextareaProps) {
+    const generatedId = useId();
+    const textareaId = id || generatedId;
+    const errorId = `${textareaId}-error`;
+
+    const textareaElement = (
+        <textarea
+            id={textareaId}
+            aria-labelledby={labelledBy}
+            aria-invalid={error ? "true" : undefined}
+            aria-describedby={error ? errorId : ariaDescribedBy}
+            className={cn(
+                "w-full rounded-xl px-4 py-3",
+                "bg-bg-sunken shadow-neu-sunken-subtle",
+                "text-content-primary placeholder:text-content-muted",
+                "focus-visible:outline-2 focus-visible:outline-theme-primary focus-visible:outline-offset-2",
+                "focus-visible:ring-2 focus-visible:ring-theme-primary",
+                "transition-all duration-200 resize-none",
+                error && "ring-2 ring-theme-error",
+                className
+            )}
+            {...props}
+        />
+    );
+
+    if (hideWrapper) {
+        return (
+            <>
+                {textareaElement}
+                {error && (
+                    <span id={errorId} className="text-sm text-theme-error" role="alert">
+                        {error}
+                    </span>
+                )}
+            </>
+        );
+    }
+
+    return (
+        <div className="flex flex-col gap-1.5 w-full">
+            {label && (
+                <label
+                    htmlFor={textareaId}
+                    className={cn("text-sm font-medium text-content-primary", labelClassName)}
+                >
+                    {label}
+                </label>
+            )}
+            {textareaElement}
+            {error && (
+                <span id={errorId} className="text-sm text-theme-error" role="alert">
+                    {error}
+                </span>
+            )}
+        </div>
+    );
+}

--- a/src/hooks/__tests__/use-contact-form.test.tsx
+++ b/src/hooks/__tests__/use-contact-form.test.tsx
@@ -180,6 +180,22 @@ describe("useContactForm", () => {
     expect(result.current.isLoading).toBe(false);
   });
 
+  it("applies server-side field errors when the response reports validation failures", async () => {
+    submitContactInquiry.mockResolvedValue({
+      ok: false,
+      reason: "validation",
+      errors: { email: "Enter a valid work email" },
+    });
+    const { result } = renderHook(() => useContactForm());
+    fill(result, VALID);
+
+    await submit(result);
+
+    expect(result.current.errors.email).toBe("Enter a valid work email");
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.submitError).toBeNull();
+  });
+
   it("clears a previous submit error when the user edits any field", async () => {
     submitContactInquiry.mockResolvedValue({ ok: false, reason: "error" });
     const { result } = renderHook(() => useContactForm());

--- a/src/hooks/__tests__/use-contact-form.test.tsx
+++ b/src/hooks/__tests__/use-contact-form.test.tsx
@@ -120,7 +120,7 @@ describe("useContactForm", () => {
     expect(submitContactInquiry).toHaveBeenCalled();
   });
 
-  it.each(["not-an-email", "jane@acme", "jane acme.com", "@acme.com"])(
+  it.each(["not-an-email", "jane@acme", "jane acme.com", "@acme.com", "a@@b.co", "a@b@c.co"])(
     "rejects %j as a work email",
     async (email) => {
       const { result } = renderHook(() => useContactForm());

--- a/src/hooks/__tests__/use-data-rights-form.test.tsx
+++ b/src/hooks/__tests__/use-data-rights-form.test.tsx
@@ -110,6 +110,23 @@ describe("useDataRightsForm", () => {
     expect(result.current.email).toBe("ghost@acme.com");
   });
 
+  it("applies server-side field errors when the response reports a validation failure", async () => {
+    submitDataRightsRequest.mockResolvedValue({
+      ok: false,
+      reason: "validation",
+      message: "A valid email address is required.",
+      errors: { email: "A valid email address is required." },
+    });
+    const { result } = renderHook(() => useDataRightsForm(ENDPOINT));
+    act(() => result.current.setEmail("a@@b.co"));
+
+    await submit(result);
+
+    expect(result.current.errors.email).toBe(
+      "A valid email address is required.",
+    );
+  });
+
   it("does not substitute the success message on a failed request", async () => {
     submitDataRightsRequest.mockResolvedValue({
       ok: false,

--- a/src/hooks/__tests__/use-data-rights-form.test.tsx
+++ b/src/hooks/__tests__/use-data-rights-form.test.tsx
@@ -25,10 +25,11 @@ beforeEach(() => {
 });
 
 describe("useDataRightsForm", () => {
-  it("starts with an empty email, no status and not loading", () => {
+  it("starts with an empty email, no status, no errors and not loading", () => {
     const { result } = renderHook(() => useDataRightsForm(ENDPOINT));
 
     expect(result.current.email).toBe("");
+    expect(result.current.errors).toEqual({});
     expect(result.current.status).toBeNull();
     expect(result.current.loading).toBe(false);
   });
@@ -118,6 +119,7 @@ describe("useDataRightsForm", () => {
     const { result } = renderHook(() =>
       useDataRightsForm(ENDPOINT, "Check your inbox."),
     );
+    act(() => result.current.setEmail("jane@acme.com"));
 
     await submit(result);
 
@@ -134,6 +136,7 @@ describe("useDataRightsForm", () => {
       }),
     );
     const { result } = renderHook(() => useDataRightsForm(ENDPOINT));
+    act(() => result.current.setEmail("jane@acme.com"));
 
     let pending!: Promise<void>;
     act(() => {
@@ -158,9 +161,11 @@ describe("useDataRightsForm", () => {
       message: "Nope.",
     });
     const { result } = renderHook(() => useDataRightsForm(ENDPOINT));
+    act(() => result.current.setEmail("ghost@acme.com"));
     await submit(result);
     expect(result.current.status?.ok).toBe(false);
 
+    act(() => result.current.setEmail("jane@acme.com"));
     submitDataRightsRequest.mockResolvedValueOnce({
       ok: true,
       message: "Done.",
@@ -168,6 +173,18 @@ describe("useDataRightsForm", () => {
     await submit(result);
 
     expect(result.current.status).toEqual({ ok: true, message: "Done." });
+  });
+
+  it("blocks submission for invalid emails before calling the service", async () => {
+    const { result } = renderHook(() => useDataRightsForm(ENDPOINT));
+    act(() => result.current.setEmail("a@@b.co"));
+
+    await submit(result);
+
+    expect(submitDataRightsRequest).not.toHaveBeenCalled();
+    expect(result.current.errors.email).toBe(
+      "A valid email address is required.",
+    );
   });
 
   it("works against the delete endpoint too", async () => {

--- a/src/hooks/__tests__/use-waitlist-form.test.tsx
+++ b/src/hooks/__tests__/use-waitlist-form.test.tsx
@@ -73,6 +73,28 @@ describe("useWaitlistForm", () => {
     expect(result.current.canSubmit).toBe(true);
   });
 
+  it("blocks submission when required fields are empty", async () => {
+    const { result } = renderHook(() => useWaitlistForm());
+
+    await submit(result);
+
+    expect(result.current.errors.name).toBeDefined();
+    expect(submitWaitlistEntry).not.toHaveBeenCalled();
+  });
+
+  it.each(["a@@b.co", "a@b@c.co"])(
+    "rejects %s before calling the service",
+    async (email) => {
+      const { result } = renderHook(() => useWaitlistForm());
+      fill(result, { ...VALID, email });
+
+      await submit(result);
+
+      expect(result.current.errors.email).toBeDefined();
+      expect(submitWaitlistEntry).not.toHaveBeenCalled();
+    },
+  );
+
   it("tracks input changes by field name", () => {
     const { result } = renderHook(() => useWaitlistForm());
 
@@ -122,6 +144,7 @@ describe("useWaitlistForm", () => {
   ])("maps %j to a user-facing message", async (serviceResult, message) => {
     submitWaitlistEntry.mockResolvedValue(serviceResult);
     const { result } = renderHook(() => useWaitlistForm());
+    fill(result, VALID);
 
     await submit(result);
 
@@ -133,6 +156,7 @@ describe("useWaitlistForm", () => {
   it("clears the error as soon as the user edits a field", async () => {
     submitWaitlistEntry.mockResolvedValue({ ok: false, reason: "error" });
     const { result } = renderHook(() => useWaitlistForm());
+    fill(result, VALID);
     await submit(result);
     expect(result.current.error).not.toBeNull();
 
@@ -150,6 +174,7 @@ describe("useWaitlistForm cooldown", () => {
 
   it("starts a 30 second cooldown after a failed submission", async () => {
     const { result } = renderHook(() => useWaitlistForm());
+    fill(result, VALID);
 
     await submit(result);
 
@@ -159,6 +184,7 @@ describe("useWaitlistForm cooldown", () => {
 
   it("counts the cooldown down once per second", async () => {
     const { result } = renderHook(() => useWaitlistForm());
+    fill(result, VALID);
     await submit(result);
 
     act(() => {
@@ -170,6 +196,7 @@ describe("useWaitlistForm cooldown", () => {
 
   it("clears the cooldown and becomes submittable again after 30 seconds", async () => {
     const { result } = renderHook(() => useWaitlistForm());
+    fill(result, VALID);
     await submit(result);
 
     act(() => {
@@ -182,6 +209,7 @@ describe("useWaitlistForm cooldown", () => {
 
   it("ignores a submission attempted during the cooldown", async () => {
     const { result } = renderHook(() => useWaitlistForm());
+    fill(result, VALID);
     await submit(result);
     expect(submitWaitlistEntry).toHaveBeenCalledTimes(1);
 
@@ -193,6 +221,7 @@ describe("useWaitlistForm cooldown", () => {
   it("does not start a cooldown after a successful submission", async () => {
     submitWaitlistEntry.mockResolvedValue({ ok: true });
     const { result } = renderHook(() => useWaitlistForm());
+    fill(result, VALID);
 
     await submit(result);
 
@@ -202,6 +231,7 @@ describe("useWaitlistForm cooldown", () => {
   it("clears its interval on unmount", async () => {
     const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval");
     const { result, unmount } = renderHook(() => useWaitlistForm());
+    fill(result, VALID);
     await submit(result);
 
     unmount();
@@ -325,6 +355,7 @@ describe("useWaitlistForm with Turnstile configured", () => {
       callback: (token: string) => void;
     };
     act(() => options.callback("token-abc"));
+    fill(result, VALID);
 
     await submit(result);
 

--- a/src/hooks/__tests__/use-waitlist-form.test.tsx
+++ b/src/hooks/__tests__/use-waitlist-form.test.tsx
@@ -164,6 +164,22 @@ describe("useWaitlistForm", () => {
 
     expect(result.current.error).toBeNull();
   });
+
+  it("applies server-side field errors when the response reports a validation failure", async () => {
+    submitWaitlistEntry.mockResolvedValue({
+      ok: false,
+      reason: "validation",
+      errors: { email: "Enter a valid work email" },
+    });
+    const { result } = renderHook(() => useWaitlistForm());
+    fill(result, VALID);
+
+    await submit(result);
+
+    expect(result.current.errors.email).toBe("Enter a valid work email");
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
 });
 
 describe("useWaitlistForm cooldown", () => {

--- a/src/hooks/use-contact-form.ts
+++ b/src/hooks/use-contact-form.ts
@@ -2,7 +2,8 @@
 
 import { useState } from "react"
 import { submitContactInquiry } from "@/services/contact"
-import { isValidEmail } from "@/utils/email"
+import { contactFormSchema } from "@/lib/validation/contact.schema"
+import { formatFieldErrors } from "@/lib/validation/errors"
 
 export interface ContactFormData {
   company: string
@@ -23,15 +24,6 @@ const ERROR_MESSAGES = {
   error: "Something went wrong. Please try again.",
   network: "Network error. Please check your connection and try again.",
 } as const
-
-function validateContactForm(formData: ContactFormData) {
-  const next: Partial<Record<keyof ContactFormData, string>> = {}
-  if (!formData.company.trim()) next.company = "Company name is required"
-  if (!formData.name.trim()) next.name = "Contact name is required"
-  if (!formData.email.trim()) next.email = "Work email is required"
-  else if (!isValidEmail(formData.email)) next.email = "Enter a valid work email"
-  return next
-}
 
 export function useContactForm() {
   const [formData, setFormData] = useState<ContactFormData>(INITIAL_FORM_DATA)
@@ -55,27 +47,28 @@ export function useContactForm() {
     e.preventDefault()
     setSubmitError(null)
 
-    const validationErrors = validateContactForm(formData)
-    if (Object.keys(validationErrors).length) {
-      setErrors(validationErrors)
+    const parsed = contactFormSchema.safeParse(formData)
+    if (!parsed.success) {
+      setErrors(formatFieldErrors(parsed.error))
       return
     }
 
     setIsLoading(true)
 
-    const result = await submitContactInquiry({
-      company: formData.company,
-      name: formData.name,
-      email: formData.email,
-      message: formData.message,
-    })
+    const result = await submitContactInquiry(parsed.data)
 
     if (result.ok) {
       setIsSubmitted(true)
       return
     }
 
-    setSubmitError(ERROR_MESSAGES[result.reason])
+    if (result.reason === "validation" && result.errors) {
+      setErrors(result.errors)
+      setIsLoading(false)
+      return
+    }
+
+    setSubmitError(ERROR_MESSAGES[result.reason as keyof typeof ERROR_MESSAGES] ?? ERROR_MESSAGES.error)
     setIsLoading(false)
   }
 

--- a/src/hooks/use-data-rights-form.ts
+++ b/src/hooks/use-data-rights-form.ts
@@ -2,6 +2,9 @@
 
 import { useState } from "react"
 import { submitDataRightsRequest } from "@/services/data-rights"
+import { dataRightsSchema } from "@/lib/validation/data-rights.schema"
+import { formatFieldErrors } from "@/lib/validation/errors"
+import { DATA_RIGHTS_EMAIL_ERROR } from "@/lib/validation/data-rights.schema"
 
 type RequestStatus = { ok: boolean; message: string } | null
 
@@ -10,17 +13,38 @@ export function useDataRightsForm(
   successMessage?: string
 ) {
   const [email, setEmail] = useState("")
+  const [errors, setErrors] = useState<{ email?: string }>({})
   const [status, setStatus] = useState<RequestStatus>(null)
   const [loading, setLoading] = useState(false)
 
+  const handleEmailChange = (value: string) => {
+    setEmail(value)
+    setErrors((prev) => ({ ...prev, email: undefined }))
+    setStatus(null)
+  }
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-    setLoading(true)
     setStatus(null)
 
-    const result = await submitDataRightsRequest(endpoint, email)
+    const parsed = dataRightsSchema.safeParse({ email })
+    if (!parsed.success) {
+      const fieldErrors = formatFieldErrors(parsed.error)
+      if (fieldErrors.email) {
+        fieldErrors.email = DATA_RIGHTS_EMAIL_ERROR
+      }
+      setErrors(fieldErrors)
+      return
+    }
+
+    setLoading(true)
+
+    const result = await submitDataRightsRequest(endpoint, parsed.data.email)
 
     if (!result.ok) {
+      if (result.reason === "validation" && result.errors) {
+        setErrors(result.errors)
+      }
       setStatus({ ok: false, message: result.message })
     } else {
       setStatus({
@@ -28,6 +52,7 @@ export function useDataRightsForm(
         message: successMessage ?? result.message,
       })
       setEmail("")
+      setErrors({})
     }
 
     setLoading(false)
@@ -35,9 +60,10 @@ export function useDataRightsForm(
 
   return {
     email,
+    errors,
     status,
     loading,
-    setEmail,
+    setEmail: handleEmailChange,
     handleSubmit,
   }
 }

--- a/src/hooks/use-waitlist-form.ts
+++ b/src/hooks/use-waitlist-form.ts
@@ -2,6 +2,8 @@
 
 import { useState, useRef, useEffect, useCallback } from "react"
 import { submitWaitlistEntry } from "@/services/waitlist"
+import { waitlistFormSchema } from "@/lib/validation/waitlist.schema"
+import { formatFieldErrors } from "@/lib/validation/errors"
 
 const COOLDOWN_SECONDS = 30
 
@@ -48,6 +50,9 @@ export function useWaitlistForm() {
   const [isSubmitted, setIsSubmitted] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [errors, setErrors] = useState<
+    Partial<Record<keyof WaitlistFormData, string>>
+  >({})
   const [cooldownSeconds, setCooldownSeconds] = useState(0)
   const [turnstileToken, setTurnstileToken] = useState<string | null>(null)
   const [formData, setFormData] = useState<WaitlistFormData>(INITIAL_FORM_DATA)
@@ -122,6 +127,7 @@ export function useWaitlistForm() {
   ) => {
     const { name, value } = e.target
     setFormData((prev) => ({ ...prev, [name]: value }))
+    setErrors((prev) => ({ ...prev, [name]: undefined }))
     setError(null)
   }
 
@@ -134,17 +140,29 @@ export function useWaitlistForm() {
       return
     }
 
+    const parsed = waitlistFormSchema.safeParse(formData)
+    if (!parsed.success) {
+      setErrors(formatFieldErrors(parsed.error))
+      return
+    }
+
     setIsLoading(true)
     setError(null)
 
-    const result = await submitWaitlistEntry(formData)
+    const result = await submitWaitlistEntry(parsed.data)
 
     if (result.ok) {
       setIsSubmitted(true)
       return
     }
 
-    setError(ERROR_MESSAGES[result.reason])
+    if (result.reason === "validation" && result.errors) {
+      setErrors(result.errors)
+      setIsLoading(false)
+      return
+    }
+
+    setError(ERROR_MESSAGES[result.reason as keyof typeof ERROR_MESSAGES] ?? ERROR_MESSAGES.error)
     setIsLoading(false)
     startCooldown()
     resetTurnstile()
@@ -155,6 +173,7 @@ export function useWaitlistForm() {
     isSubmitted,
     isLoading,
     error,
+    errors,
     cooldownSeconds,
     turnstileContainerRef,
     isTurnstileConfigured,

--- a/src/lib/validation/__tests__/email-parity.test.ts
+++ b/src/lib/validation/__tests__/email-parity.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { contactFormSchema } from "../contact.schema";
+import { waitlistFormSchema } from "../waitlist.schema";
+import { dataRightsSchema } from "../data-rights.schema";
+
+const VALID_CONTACT = {
+  company: "Acme Inc",
+  name: "Jane Doe",
+  email: "ok@mail.com",
+  message: "",
+};
+
+const VALID_WAITLIST = {
+  name: "Jane Doe",
+  email: "ok@mail.com",
+  purpose: "Marketplace integration",
+  referral: "Friend",
+};
+
+describe("email validation parity", () => {
+  it.each([
+    ["a@@b.co", false],
+    ["a@b@c.co", false],
+    ["ok@mail.com", true],
+    ["", false],
+    ["not-an-email", false],
+    ["jane@acme", false],
+    ["@acme.com", false],
+    ["jane doe@acme.com", false],
+  ])("treats %s identically across all schemas (valid=%s)", (email, expected) => {
+    const contact = contactFormSchema.safeParse({ ...VALID_CONTACT, email });
+    const waitlist = waitlistFormSchema.safeParse({ ...VALID_WAITLIST, email });
+    const dataRights = dataRightsSchema.safeParse({ email });
+
+    expect(contact.success).toBe(expected);
+    expect(waitlist.success).toBe(expected);
+    expect(dataRights.success).toBe(expected);
+  });
+});

--- a/src/lib/validation/contact.schema.ts
+++ b/src/lib/validation/contact.schema.ts
@@ -1,10 +1,16 @@
 import { z } from "zod";
-import { emailField } from "./email";
+import { EMAIL_REGEX, EMAIL_INVALID_MESSAGE } from "./email";
+
+const contactEmailField = z
+  .string()
+  .trim()
+  .min(1, "Work email is required")
+  .regex(EMAIL_REGEX, EMAIL_INVALID_MESSAGE);
 
 export const contactFormSchema = z.object({
   company: z.string().trim().min(1, "Company name is required"),
   name: z.string().trim().min(1, "Contact name is required"),
-  email: emailField,
+  email: contactEmailField,
   message: z.string().trim().optional().default(""),
 });
 

--- a/src/lib/validation/contact.schema.ts
+++ b/src/lib/validation/contact.schema.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+import { emailField } from "./email";
+
+export const contactFormSchema = z.object({
+  company: z.string().trim().min(1, "Company name is required"),
+  name: z.string().trim().min(1, "Contact name is required"),
+  email: emailField,
+  message: z.string().trim().optional().default(""),
+});
+
+export type ContactFormPayload = z.infer<typeof contactFormSchema>;

--- a/src/lib/validation/data-rights.schema.ts
+++ b/src/lib/validation/data-rights.schema.ts
@@ -1,8 +1,14 @@
 import { z } from "zod";
-import { emailField, EMAIL_REQUIRED_MESSAGE } from "./email";
+import { EMAIL_REGEX, EMAIL_REQUIRED_MESSAGE } from "./email";
+
+const dataRightsEmailField = z
+  .string()
+  .trim()
+  .min(1, EMAIL_REQUIRED_MESSAGE)
+  .regex(EMAIL_REGEX, EMAIL_REQUIRED_MESSAGE);
 
 export const dataRightsSchema = z.object({
-  email: emailField,
+  email: dataRightsEmailField,
 });
 
 export type DataRightsPayload = z.infer<typeof dataRightsSchema>;

--- a/src/lib/validation/data-rights.schema.ts
+++ b/src/lib/validation/data-rights.schema.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+import { emailField, EMAIL_REQUIRED_MESSAGE } from "./email";
+
+export const dataRightsSchema = z.object({
+  email: emailField,
+});
+
+export type DataRightsPayload = z.infer<typeof dataRightsSchema>;
+
+/** Message used by GDPR API routes for invalid email. */
+export const DATA_RIGHTS_EMAIL_ERROR = EMAIL_REQUIRED_MESSAGE;

--- a/src/lib/validation/email.ts
+++ b/src/lib/validation/email.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+/** Canonical email rule — rejects a@@b.co and a@b@c.co. */
+export const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export const EMAIL_REQUIRED_MESSAGE = "A valid email address is required.";
+export const EMAIL_INVALID_MESSAGE = "Enter a valid work email";
+
+export const emailField = z
+  .string()
+  .trim()
+  .min(1, EMAIL_REQUIRED_MESSAGE)
+  .regex(EMAIL_REGEX, EMAIL_INVALID_MESSAGE);

--- a/src/lib/validation/errors.ts
+++ b/src/lib/validation/errors.ts
@@ -1,0 +1,16 @@
+import type { ZodError } from "zod";
+
+export function formatFieldErrors(error: ZodError): Record<string, string> {
+  const errors: Record<string, string> = {};
+  for (const issue of error.issues) {
+    const field = issue.path[0];
+    if (typeof field === "string" && !errors[field]) {
+      errors[field] = issue.message;
+    }
+  }
+  return errors;
+}
+
+export function validationErrorResponse(errors: Record<string, string>) {
+  return { errors };
+}

--- a/src/lib/validation/waitlist.schema.ts
+++ b/src/lib/validation/waitlist.schema.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+import { emailField } from "./email";
+
+export const waitlistFormSchema = z.object({
+  name: z
+    .string()
+    .trim()
+    .min(1, "Full name is required")
+    .max(100, "Name must be 100 characters or fewer"),
+  email: emailField.max(320, "Email must be 320 characters or fewer"),
+  purpose: z
+    .string()
+    .trim()
+    .min(1, "Please tell us how you would use Offer Hub")
+    .max(500, "Purpose must be 500 characters or fewer"),
+  referral: z
+    .string()
+    .trim()
+    .min(1, "Please tell us how you heard about us")
+    .max(200, "Referral must be 200 characters or fewer"),
+});
+
+export type WaitlistFormPayload = z.infer<typeof waitlistFormSchema>;

--- a/src/services/__tests__/contact.test.ts
+++ b/src/services/__tests__/contact.test.ts
@@ -1,22 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-
-const state = vi.hoisted(() => ({
-  supabase: null as { from: (table: string) => { insert: unknown } } | null,
-}));
-
-vi.mock("@/lib/supabase", () => ({
-  get supabase() {
-    return state.supabase;
-  },
-  get isSupabaseConfigured() {
-    return state.supabase !== null;
-  },
-}));
-
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { submitContactInquiry, type ContactSubmission } from "../contact";
-
-const insert = vi.fn();
-const from = vi.fn(() => ({ insert }));
 
 const INQUIRY: ContactSubmission = {
   company: "Acme Inc",
@@ -25,69 +8,70 @@ const INQUIRY: ContactSubmission = {
   message: "We'd like to discuss enterprise pricing.",
 };
 
+function mockFetch(impl: () => Promise<unknown>) {
+  const fn = vi.fn(impl);
+  vi.stubGlobal("fetch", fn);
+  return fn;
+}
+
+function jsonResponse(status: number, body: unknown) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  };
+}
+
 describe("submitContactInquiry", () => {
   beforeEach(() => {
-    insert.mockReset();
-    from.mockClear();
-    state.supabase = { from } as unknown as typeof state.supabase;
+    vi.restoreAllMocks();
   });
 
-  it("returns not_configured without touching the network when Supabase is null", async () => {
-    state.supabase = null;
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("POSTs the inquiry as JSON to /api/contact", async () => {
+    const fetchMock = mockFetch(async () => jsonResponse(200, { ok: true }));
+
+    await submitContactInquiry(INQUIRY);
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/contact", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(INQUIRY),
+    });
+  });
+
+  it("returns ok on success", async () => {
+    mockFetch(async () => jsonResponse(200, { ok: true }));
+
+    await expect(submitContactInquiry(INQUIRY)).resolves.toEqual({ ok: true });
+  });
+
+  it("maps 400 field errors to validation", async () => {
+    mockFetch(async () =>
+      jsonResponse(400, { errors: { email: "Enter a valid work email" } }),
+    );
+
+    await expect(submitContactInquiry(INQUIRY)).resolves.toEqual({
+      ok: false,
+      reason: "validation",
+      errors: { email: "Enter a valid work email" },
+    });
+  });
+
+  it("maps 503 to not_configured", async () => {
+    mockFetch(async () => jsonResponse(503, { error: "unavailable" }));
 
     await expect(submitContactInquiry(INQUIRY)).resolves.toEqual({
       ok: false,
       reason: "not_configured",
     });
-    expect(from).not.toHaveBeenCalled();
-    expect(insert).not.toHaveBeenCalled();
   });
 
-  it("inserts into contact_inquiries, mapping name to contact_name", async () => {
-    insert.mockResolvedValueOnce({ error: null });
-
-    await expect(submitContactInquiry(INQUIRY)).resolves.toEqual({ ok: true });
-
-    expect(from).toHaveBeenCalledWith("contact_inquiries");
-    expect(insert).toHaveBeenCalledWith([
-      {
-        company: "Acme Inc",
-        contact_name: "Jane Doe",
-        email: "jane@acme.com",
-        message: "We'd like to discuss enterprise pricing.",
-      },
-    ]);
-  });
-
-  it("sends only the four declared columns", async () => {
-    insert.mockResolvedValueOnce({ error: null });
-
-    await submitContactInquiry({
-      ...INQUIRY,
-      ...({ role: "admin" } as unknown as ContactSubmission),
-    });
-
-    const [[rows]] = insert.mock.calls as [[Record<string, unknown>[]]];
-    expect(Object.keys(rows[0]).sort()).toEqual([
-      "company",
-      "contact_name",
-      "email",
-      "message",
-    ]);
-  });
-
-  it("forwards an empty message through rather than dropping the column", async () => {
-    insert.mockResolvedValueOnce({ error: null });
-
-    await submitContactInquiry({ ...INQUIRY, message: "" });
-
-    expect(insert).toHaveBeenCalledWith([
-      expect.objectContaining({ message: "" }),
-    ]);
-  });
-
-  it("maps a Supabase error to error", async () => {
-    insert.mockResolvedValueOnce({ error: { message: "permission denied" } });
+  it("maps other non-2xx responses to error", async () => {
+    mockFetch(async () => jsonResponse(500, { error: "boom" }));
 
     await expect(submitContactInquiry(INQUIRY)).resolves.toEqual({
       ok: false,
@@ -95,8 +79,10 @@ describe("submitContactInquiry", () => {
     });
   });
 
-  it("maps a thrown request (network failure) to network", async () => {
-    insert.mockRejectedValueOnce(new TypeError("Failed to fetch"));
+  it("maps a thrown request to network", async () => {
+    mockFetch(async () => {
+      throw new TypeError("Failed to fetch");
+    });
 
     await expect(submitContactInquiry(INQUIRY)).resolves.toEqual({
       ok: false,

--- a/src/services/__tests__/contact.test.ts
+++ b/src/services/__tests__/contact.test.ts
@@ -89,4 +89,19 @@ describe("submitContactInquiry", () => {
       reason: "network",
     });
   });
+
+  it("falls back to an empty body when the response is not valid JSON", async () => {
+    mockFetch(async () => ({
+      ok: false,
+      status: 500,
+      json: async () => {
+        throw new SyntaxError("Unexpected end of JSON input");
+      },
+    }));
+
+    await expect(submitContactInquiry(INQUIRY)).resolves.toEqual({
+      ok: false,
+      reason: "error",
+    });
+  });
 });

--- a/src/services/__tests__/data-rights.test.ts
+++ b/src/services/__tests__/data-rights.test.ts
@@ -70,6 +70,23 @@ describe("submitDataRightsRequest", () => {
     });
   });
 
+  it("maps 400 field errors to validation", async () => {
+    mockFetch(async () =>
+      jsonResponse(400, {
+        errors: { email: "A valid email address is required." },
+      }),
+    );
+
+    await expect(
+      submitDataRightsRequest(ENDPOINT, "a@@b.co"),
+    ).resolves.toEqual({
+      ok: false,
+      reason: "validation",
+      message: "A valid email address is required.",
+      errors: { email: "A valid email address is required." },
+    });
+  });
+
   it("falls back to a generic error message when the error body has none", async () => {
     mockFetch(async () => jsonResponse(500, {}));
 

--- a/src/services/__tests__/data-rights.test.ts
+++ b/src/services/__tests__/data-rights.test.ts
@@ -99,6 +99,21 @@ describe("submitDataRightsRequest", () => {
     });
   });
 
+  it("falls back to a generic validation message when the errors body has no email key", async () => {
+    mockFetch(async () =>
+      jsonResponse(400, { errors: { other: "Some other field is invalid." } }),
+    );
+
+    await expect(
+      submitDataRightsRequest(ENDPOINT, "a@@b.co"),
+    ).resolves.toEqual({
+      ok: false,
+      reason: "validation",
+      message: "A valid email address is required.",
+      errors: { other: "Some other field is invalid." },
+    });
+  });
+
   it("returns a network result when fetch rejects", async () => {
     mockFetch(async () => {
       throw new TypeError("Failed to fetch");

--- a/src/services/__tests__/waitlist.test.ts
+++ b/src/services/__tests__/waitlist.test.ts
@@ -98,4 +98,19 @@ describe("submitWaitlistEntry", () => {
       reason: "network",
     });
   });
+
+  it("falls back to an empty body when the response is not valid JSON", async () => {
+    mockFetch(async () => ({
+      ok: false,
+      status: 500,
+      json: async () => {
+        throw new SyntaxError("Unexpected end of JSON input");
+      },
+    }));
+
+    await expect(submitWaitlistEntry(ENTRY)).resolves.toEqual({
+      ok: false,
+      reason: "error",
+    });
+  });
 });

--- a/src/services/__tests__/waitlist.test.ts
+++ b/src/services/__tests__/waitlist.test.ts
@@ -1,27 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-
-/**
- * `waitlist.ts` reads `supabase` at call time, so a getter-backed mock lets
- * each test swap the client (or drop it to `null` for the
- * "Supabase not configured" path) without re-importing the module.
- */
-const state = vi.hoisted(() => ({
-  supabase: null as { from: (table: string) => { insert: unknown } } | null,
-}));
-
-vi.mock("@/lib/supabase", () => ({
-  get supabase() {
-    return state.supabase;
-  },
-  get isSupabaseConfigured() {
-    return state.supabase !== null;
-  },
-}));
-
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { submitWaitlistEntry, type WaitlistSubmission } from "../waitlist";
-
-const insert = vi.fn();
-const from = vi.fn(() => ({ insert }));
 
 const ENTRY: WaitlistSubmission = {
   email: "jane@acme.com",
@@ -30,60 +8,70 @@ const ENTRY: WaitlistSubmission = {
   referral: "Twitter",
 };
 
+function mockFetch(impl: () => Promise<unknown>) {
+  const fn = vi.fn(impl);
+  vi.stubGlobal("fetch", fn);
+  return fn;
+}
+
+function jsonResponse(status: number, body: unknown) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  };
+}
+
 describe("submitWaitlistEntry", () => {
   beforeEach(() => {
-    insert.mockReset();
-    from.mockClear();
-    state.supabase = { from } as unknown as typeof state.supabase;
+    vi.restoreAllMocks();
   });
 
-  it("returns not_configured without touching the network when Supabase is null", async () => {
-    state.supabase = null;
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("POSTs the entry as JSON to /api/waitlist", async () => {
+    const fetchMock = mockFetch(async () => jsonResponse(200, { ok: true }));
+
+    await submitWaitlistEntry(ENTRY);
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/waitlist", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(ENTRY),
+    });
+  });
+
+  it("returns ok on success", async () => {
+    mockFetch(async () => jsonResponse(200, { ok: true }));
+
+    await expect(submitWaitlistEntry(ENTRY)).resolves.toEqual({ ok: true });
+  });
+
+  it("maps 400 field errors to validation", async () => {
+    mockFetch(async () =>
+      jsonResponse(400, { errors: { email: "Enter a valid work email" } }),
+    );
+
+    await expect(submitWaitlistEntry(ENTRY)).resolves.toEqual({
+      ok: false,
+      reason: "validation",
+      errors: { email: "Enter a valid work email" },
+    });
+  });
+
+  it("maps 503 to not_configured", async () => {
+    mockFetch(async () => jsonResponse(503, { error: "unavailable" }));
 
     await expect(submitWaitlistEntry(ENTRY)).resolves.toEqual({
       ok: false,
       reason: "not_configured",
     });
-    expect(from).not.toHaveBeenCalled();
-    expect(insert).not.toHaveBeenCalled();
   });
 
-  it("inserts the entry into the waitlist table and reports success", async () => {
-    insert.mockResolvedValueOnce({ error: null });
-
-    await expect(submitWaitlistEntry(ENTRY)).resolves.toEqual({ ok: true });
-
-    expect(from).toHaveBeenCalledWith("waitlist");
-    expect(insert).toHaveBeenCalledWith([
-      {
-        email: "jane@acme.com",
-        name: "Jane Doe",
-        purpose: "Marketplace payouts",
-        referral: "Twitter",
-      },
-    ]);
-  });
-
-  it("sends only the four declared columns (no extra fields leak through)", async () => {
-    insert.mockResolvedValueOnce({ error: null });
-
-    await submitWaitlistEntry({
-      ...ENTRY,
-      // Simulates a caller passing a wider object than the interface allows.
-      ...({ isAdmin: true } as unknown as WaitlistSubmission),
-    });
-
-    const [[rows]] = insert.mock.calls as [[Record<string, unknown>[]]];
-    expect(Object.keys(rows[0]).sort()).toEqual([
-      "email",
-      "name",
-      "purpose",
-      "referral",
-    ]);
-  });
-
-  it("maps the unique-violation code 23505 to duplicate", async () => {
-    insert.mockResolvedValueOnce({ error: { code: "23505" } });
+  it("maps 409 duplicate to duplicate", async () => {
+    mockFetch(async () => jsonResponse(409, { error: "duplicate" }));
 
     await expect(submitWaitlistEntry(ENTRY)).resolves.toEqual({
       ok: false,
@@ -91,8 +79,8 @@ describe("submitWaitlistEntry", () => {
     });
   });
 
-  it("maps any other Postgres error to error", async () => {
-    insert.mockResolvedValueOnce({ error: { code: "42501" } });
+  it("maps other non-2xx responses to error", async () => {
+    mockFetch(async () => jsonResponse(500, { error: "boom" }));
 
     await expect(submitWaitlistEntry(ENTRY)).resolves.toEqual({
       ok: false,
@@ -100,17 +88,10 @@ describe("submitWaitlistEntry", () => {
     });
   });
 
-  it("maps an error without a code to error", async () => {
-    insert.mockResolvedValueOnce({ error: { message: "boom" } });
-
-    await expect(submitWaitlistEntry(ENTRY)).resolves.toEqual({
-      ok: false,
-      reason: "error",
+  it("maps a thrown request to network", async () => {
+    mockFetch(async () => {
+      throw new TypeError("Failed to fetch");
     });
-  });
-
-  it("maps a thrown request (network failure) to network", async () => {
-    insert.mockRejectedValueOnce(new TypeError("Failed to fetch"));
 
     await expect(submitWaitlistEntry(ENTRY)).resolves.toEqual({
       ok: false,

--- a/src/services/contact.ts
+++ b/src/services/contact.ts
@@ -1,34 +1,35 @@
-import { supabase } from "@/lib/supabase";
-
-export interface ContactSubmission {
+export type ContactSubmission = {
   company: string;
   name: string;
   email: string;
   message: string;
-}
+};
 
 export type ContactResult =
   | { ok: true }
-  | { ok: false; reason: "not_configured" | "error" | "network" };
+  | { ok: false; reason: "not_configured" | "error" | "network" | "validation"; errors?: Record<string, string> };
 
 export async function submitContactInquiry(
   inquiry: ContactSubmission,
 ): Promise<ContactResult> {
-  if (!supabase) {
-    return { ok: false, reason: "not_configured" };
-  }
-
   try {
-    const { error } = await supabase.from("contact_inquiries").insert([
-      {
-        company: inquiry.company,
-        contact_name: inquiry.name,
-        email: inquiry.email,
-        message: inquiry.message,
-      },
-    ]);
+    const res = await fetch("/api/contact", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(inquiry),
+    });
 
-    if (error) {
+    const json = await res.json().catch(() => ({}));
+
+    if (res.status === 400 && json.errors) {
+      return { ok: false, reason: "validation", errors: json.errors };
+    }
+
+    if (res.status === 503) {
+      return { ok: false, reason: "not_configured" };
+    }
+
+    if (!res.ok) {
       return { ok: false, reason: "error" };
     }
 

--- a/src/services/data-rights.ts
+++ b/src/services/data-rights.ts
@@ -1,37 +1,53 @@
 export type DataRightsResult =
   | { ok: true; message: string }
-  | { ok: false; reason: "error" | "network"; message: string }
+  | {
+      ok: false;
+      reason: "error" | "network" | "validation";
+      message: string;
+      errors?: Record<string, string>;
+    };
 
 export async function submitDataRightsRequest(
   endpoint: string,
-  email: string
+  email: string,
 ): Promise<DataRightsResult> {
   try {
     const res = await fetch(endpoint, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ email }),
-    })
+    });
 
-    const json = await res.json()
+    const json = await res.json();
+
+    if (res.status === 400 && json.errors) {
+      const emailError =
+        json.errors.email ?? "A valid email address is required.";
+      return {
+        ok: false,
+        reason: "validation",
+        message: emailError,
+        errors: json.errors,
+      };
+    }
 
     if (!res.ok) {
       return {
         ok: false,
         reason: "error",
         message: json.error ?? "An error occurred.",
-      }
+      };
     }
 
     return {
       ok: true,
       message: json.message ?? "Done.",
-    }
+    };
   } catch {
     return {
       ok: false,
       reason: "network",
       message: "Network error. Please try again.",
-    }
+    };
   }
 }

--- a/src/services/waitlist.ts
+++ b/src/services/waitlist.ts
@@ -1,40 +1,44 @@
-import { supabase } from "@/lib/supabase";
-
-export interface WaitlistSubmission {
+export type WaitlistSubmission = {
   email: string;
   name: string;
   purpose: string;
   referral: string;
-}
+};
 
 export type WaitlistResult =
   | { ok: true }
-  | { ok: false; reason: "not_configured" | "duplicate" | "error" | "network" };
-
-const UNIQUE_VIOLATION = "23505";
+  | {
+      ok: false;
+      reason: "not_configured" | "duplicate" | "error" | "network" | "validation";
+      errors?: Record<string, string>;
+    };
 
 export async function submitWaitlistEntry(
   entry: WaitlistSubmission,
 ): Promise<WaitlistResult> {
-  if (!supabase) {
-    return { ok: false, reason: "not_configured" };
-  }
-
   try {
-    const { error } = await supabase.from("waitlist").insert([
-      {
-        email: entry.email,
-        name: entry.name,
-        purpose: entry.purpose,
-        referral: entry.referral,
-      },
-    ]);
+    const res = await fetch("/api/waitlist", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(entry),
+    });
 
-    if (error) {
-      return {
-        ok: false,
-        reason: error.code === UNIQUE_VIOLATION ? "duplicate" : "error",
-      };
+    const json = await res.json().catch(() => ({}));
+
+    if (res.status === 400 && json.errors) {
+      return { ok: false, reason: "validation", errors: json.errors };
+    }
+
+    if (res.status === 503) {
+      return { ok: false, reason: "not_configured" };
+    }
+
+    if (res.status === 409 && json.error === "duplicate") {
+      return { ok: false, reason: "duplicate" };
+    }
+
+    if (!res.ok) {
+      return { ok: false, reason: "error" };
     }
 
     return { ok: true };


### PR DESCRIPTION
## Summary
- Add Zod schemas for contact, waitlist, and data-rights payloads with a single canonical email rule (`/^[^\s@]+@[^\s@]+\.[^\s@]+$/`), fixing the client/server divergence where `a@@b.co` and `a@b@c.co` were accepted by the contact form but rejected by GDPR endpoints
- Introduce `/api/contact` and `/api/waitlist` routes; refactor privacy routes to use the shared data-rights schema; return field-level `errors` on 400 responses
- Adopt `Input`/`Textarea` in FormField, DataRightsForm, ParameterInput, and EndpointPanel for associated labels, `aria-invalid`, and announced validation errors

Absorbs the email-regex consolidation bullet from #1476 to avoid duplicate work.

## Test plan
- [x] Parity test passes for divergent emails (`a@@b.co`, `a@b@c.co`, `ok@mail.com`)
- [x] Contact form rejects `a@@b.co` before submit
- [x] GDPR export/delete use the same email rule as contact/waitlist forms
- [x] DataRightsForm has a real label; field errors use `aria-invalid` and `role="alert"`
- [x] `npm test` passes for hooks, services, API routes, and form components
- [x] `npm run build` passes


Closes #1503 