### PR TITLE
Fix theme hydration/FOUC and make the motion system actually neumorphic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
           cache: "npm"
       - run: npm ci
       - run: npm run lint
+      - run: npm run lint:classes
       - run: npm run build
       # Runs the suite and enforces the coverage thresholds in
       # vitest.config.ts - the job fails if coverage drops below them.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "lint:classes": "node scripts/check-undefined-utility-classes.js",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",

--- a/scripts/check-undefined-utility-classes.js
+++ b/scripts/check-undefined-utility-classes.js
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+/**
+ * Fails the build if source files reference an `animate-*` or `shadow-*`
+ * Tailwind class that isn't actually defined anywhere (globals.css keyframes,
+ * tailwind.config.ts, or an inline `.animate-x { }` / `.shadow-x { }` rule in
+ * a component). Catches typos like `animate-fade-in-up` vs `animate-fadeInUp`
+ * silently rendering as a no-op (see issue #1500).
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const ROOT = path.resolve(__dirname, "..");
+const SRC_DIR = path.join(ROOT, "src");
+
+// Tailwind's built-in utilities that never need a local definition.
+const BUILTIN_ANIMATE = new Set(["spin", "ping", "pulse", "bounce", "none"]);
+const BUILTIN_SHADOW = new Set(["sm", "md", "lg", "xl", "2xl", "inner", "none"]);
+// Default Tailwind color palette base names, valid as `shadow-{color}`.
+const BUILTIN_COLOR_NAMES = new Set([
+  "inherit", "current", "transparent", "black", "white",
+  "slate", "gray", "zinc", "neutral", "stone", "red", "orange", "amber",
+  "yellow", "lime", "green", "emerald", "teal", "cyan", "sky", "blue",
+  "indigo", "violet", "purple", "fuchsia", "pink", "rose",
+]);
+
+function walk(dir, exts, out = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === "node_modules" || entry.name.startsWith(".")) continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(full, exts, out);
+    } else if (exts.some((ext) => entry.name.endsWith(ext))) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function collectDefined() {
+  const animate = new Set(BUILTIN_ANIMATE);
+  const shadow = new Set(BUILTIN_SHADOW);
+
+  // tailwind.config.ts: keys under `boxShadow` and `animation`.
+  const twConfigPath = path.join(ROOT, "tailwind.config.ts");
+  const twConfig = fs.readFileSync(twConfigPath, "utf8");
+
+  const boxShadowMatch = twConfig.match(/boxShadow:\s*{([\s\S]*?)\n\s*},/);
+  if (boxShadowMatch) {
+    for (const m of boxShadowMatch[1].matchAll(/["']?([a-zA-Z0-9-]+)["']?\s*:/g)) {
+      shadow.add(m[1]);
+    }
+  }
+
+  const animationMatch = twConfig.match(/\banimation:\s*{([\s\S]*?)\n\s*},/);
+  if (animationMatch) {
+    for (const m of animationMatch[1].matchAll(/["']?([a-zA-Z0-9-]+)["']?\s*:/g)) {
+      animate.add(m[1]);
+    }
+  }
+
+  // Extended color names, valid as `shadow-{color}`.
+  const colorsMatch = twConfig.match(/colors:\s*{([\s\S]*?)\n\s*},\n\s*keyframes/);
+  if (colorsMatch) {
+    for (const m of colorsMatch[1].matchAll(/["']?([a-zA-Z0-9-]+)["']?\s*:/g)) {
+      BUILTIN_COLOR_NAMES.add(m[1]);
+    }
+  }
+
+  // globals.css + any .css files: `@keyframes name` and `.animate-x {` / `.shadow-x {`.
+  const cssFiles = walk(SRC_DIR, [".css"]);
+  // Component/script files can also define local `.animate-x { }` blocks
+  // (e.g. inline <style jsx> in a .tsx file).
+  const codeFiles = walk(SRC_DIR, [".ts", ".tsx"]);
+
+  for (const file of [...cssFiles, ...codeFiles]) {
+    const content = fs.readFileSync(file, "utf8");
+    for (const m of content.matchAll(/@keyframes\s+([a-zA-Z0-9_-]+)/g)) {
+      animate.add(m[1]);
+    }
+    for (const m of content.matchAll(/\.animate-([a-zA-Z0-9_-]+)\s*{/g)) {
+      animate.add(m[1]);
+    }
+    for (const m of content.matchAll(/\.shadow-([a-zA-Z0-9_-]+)\s*{/g)) {
+      shadow.add(m[1]);
+    }
+  }
+
+  return { animate, shadow };
+}
+
+function checkUsages(defined) {
+  const errors = [];
+  const codeFiles = walk(SRC_DIR, [".ts", ".tsx"]);
+
+  for (const file of codeFiles) {
+    const content = fs.readFileSync(file, "utf8");
+    const lines = content.split("\n");
+    lines.forEach((line, idx) => {
+      // Negative lookbehind excludes CSS custom properties like `var(--shadow-dark)`.
+      for (const m of line.matchAll(/(?<!-)\b(animate|shadow)-([a-zA-Z][a-zA-Z0-9_-]*)/g)) {
+        const [, kind, rawName] = m;
+        const name = rawName.replace(/\/\d+$/, ""); // strip opacity modifier, e.g. shadow-black/10
+        const set = kind === "animate" ? defined.animate : defined.shadow;
+        const colorSet = kind === "shadow" ? BUILTIN_COLOR_NAMES : null;
+        if (set.has(name)) continue;
+        if (colorSet && colorSet.has(name)) continue;
+        errors.push(`${path.relative(ROOT, file)}:${idx + 1}: undefined class "${kind}-${rawName}"`);
+      }
+    });
+  }
+
+  return errors;
+}
+
+function main() {
+  const defined = collectDefined();
+  const errors = checkUsages(defined);
+
+  if (errors.length > 0) {
+    console.error(`Found ${errors.length} undefined animate-*/shadow-* class usage(s):\n`);
+    errors.forEach((e) => console.error(`  ${e}`));
+    process.exit(1);
+  }
+
+  console.log("No undefined animate-*/shadow-* classes found.");
+}
+
+main();

--- a/src/app/accessibility/page.tsx
+++ b/src/app/accessibility/page.tsx
@@ -120,10 +120,10 @@ export default function AccessibilityPage() {
                               return (
                                    <div
                                         key={feature.title}
-                                        className="p-10 rounded-[2.5rem] bg-bg-elevated shadow-neu-raised flex flex-col gap-6 group hover:shadow-neu-raised-hover transition-all duration-500"
+                                        className="p-10 rounded-[2.5rem] bg-bg-elevated shadow-neu-raised flex flex-col gap-6 group hover:shadow-neu-raised-hover transition-shadow duration-500"
                                    >
                                         <div
-                                             className="w-14 h-14 rounded-2xl shadow-neu-sunken-subtle flex items-center justify-center shrink-0 bg-bg-elevated group-hover:shadow-neu-sunken transition-all duration-300"
+                                             className="w-14 h-14 rounded-2xl shadow-neu-sunken-subtle flex items-center justify-center shrink-0 bg-bg-elevated group-hover:shadow-neu-sunken transition-shadow duration-300"
                                         >
                                              <Icon size={24} className="text-theme-primary" />
                                         </div>
@@ -161,7 +161,7 @@ export default function AccessibilityPage() {
                                    return (
                                         <div
                                              key={feature.title}
-                                             className="p-8 rounded-[2rem] bg-bg-elevated shadow-neu-raised flex flex-col gap-4 border border-theme-primary/5 hover:shadow-neu-raised-hover transition-all duration-300"
+                                             className="p-8 rounded-[2rem] bg-bg-elevated shadow-neu-raised flex flex-col gap-4 border border-theme-primary/5 hover:shadow-neu-raised-hover transition-shadow duration-300"
                                         >
                                              <div className="flex items-center gap-3">
                                                   <div className="w-10 h-10 rounded-lg flex items-center justify-center bg-theme-primary/10">
@@ -201,7 +201,7 @@ export default function AccessibilityPage() {
                                         href={contact.href}
                                         target={contact.external ? "_blank" : undefined}
                                         rel={contact.external ? "noopener noreferrer" : undefined}
-                                        className="p-8 rounded-[2rem] bg-bg-elevated shadow-neu-raised hover:shadow-neu-raised-hover border border-theme-primary/5 transition-all duration-300 group"
+                                        className="p-8 rounded-[2rem] bg-bg-elevated shadow-neu-raised hover:shadow-neu-raised-hover border border-theme-primary/5 transition-shadow duration-300 group"
                                    >
                                         <div className="flex items-start justify-between mb-4">
                                              <div>
@@ -320,7 +320,7 @@ export default function AccessibilityPage() {
                                         description: "We follow accessibility guidance from organizations like IAAP and 18F",
                                    },
                               ].map((item) => (
-                                   <div key={item.standard} className="p-6 rounded-[1.5rem] bg-bg-elevated shadow-neu-raised border border-theme-primary/5 hover:shadow-neu-raised-hover transition-all duration-300">
+                                   <div key={item.standard} className="p-6 rounded-[1.5rem] bg-bg-elevated shadow-neu-raised border border-theme-primary/5 hover:shadow-neu-raised-hover transition-shadow duration-300">
                                         <h4 className="font-black text-content-primary mb-2">{item.standard}</h4>
                                         <p className="text-sm text-content-secondary">{item.description}</p>
                                    </div>

--- a/src/app/changelog/page.tsx
+++ b/src/app/changelog/page.tsx
@@ -206,7 +206,7 @@ export default async function ChangelogPage() {
 
                   {/* Enhanced Card content */}
                   <div className="w-full md:w-5/12 pl-12 md:pl-0">
-                    <div className="bg-bg-elevated rounded-[2.5rem] p-8 md:p-10 shadow-neu-raised hover:shadow-neu-raised-hover transition-all duration-500 ease-out group">
+                    <div className="bg-bg-elevated rounded-[2.5rem] p-8 md:p-10 shadow-neu-raised hover:shadow-neu-raised-hover transition-shadow duration-500 ease-out group">
                       <div className="flex flex-col sm:flex-row sm:items-center justify-between mb-6 gap-3">
                         <div className="flex items-center gap-3">
                           <span className="text-2xl font-black text-content-primary tracking-tight group-hover:text-theme-primary transition-colors">

--- a/src/app/docs/[...slug]/not-found.tsx
+++ b/src/app/docs/[...slug]/not-found.tsx
@@ -66,7 +66,7 @@ export default function DocsNotFound() {
           <Link
             key={doc.href}
             href={doc.href}
-            className="group rounded-2xl bg-bg-base p-5 shadow-neu-raised-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-neu-raised-hover"
+            className="group rounded-2xl bg-bg-base p-5 shadow-neu-raised-sm transition-[box-shadow,transform] duration-300 hover:-translate-y-1 hover:shadow-neu-raised-hover"
           >
             <div className="mb-5 flex h-11 w-11 items-center justify-center rounded-xl bg-bg-sunken text-theme-primary shadow-neu-sunken-subtle">
               <FileText size={20} />

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -160,11 +160,11 @@ export default function DocsPage() {
                 <Link
                   href={section.link}
                   className={cn(
-                    "block p-8 rounded-3xl transition-all duration-500 hover:-translate-y-2 border border-black/[0.03] dark:border-white/[0.03] bg-bg-base/50 backdrop-blur-sm",
+                    "block p-8 rounded-3xl transition-[border-color,box-shadow,transform] duration-500 hover:-translate-y-2 border border-black/[0.03] dark:border-white/[0.03] bg-bg-base/50 backdrop-blur-sm",
                     "hover:border-theme-primary/20 hover:shadow-neu-raised"
                   )}
                 >
-                  <div className="w-14 h-14 rounded-2xl flex items-center justify-center mb-8 transition-all duration-500 group-hover:scale-110 group-hover:bg-theme-primary group-hover:text-white bg-bg-sunken text-theme-primary shadow-neu-sunken-subtle">
+                  <div className="w-14 h-14 rounded-2xl flex items-center justify-center mb-8 transition-[background-color,color,transform] duration-500 group-hover:scale-110 group-hover:bg-theme-primary group-hover:text-white bg-bg-sunken text-theme-primary shadow-neu-sunken-subtle">
                     {section.icon}
                   </div>
                   <h3 className="text-2xl font-black mb-4 group-hover:text-theme-primary transition-colors leading-tight tracking-tight text-content-primary">
@@ -175,7 +175,7 @@ export default function DocsPage() {
                   </p>
                   <div className="flex items-center justify-between text-[11px] font-black uppercase tracking-[0.2em] text-content-secondary/40">
                     <span>{section.count}</span>
-                    <span className="text-theme-primary opacity-0 group-hover:opacity-100 transition-all duration-500 translate-x-4 group-hover:translate-x-0 flex items-center gap-2">
+                    <span className="text-theme-primary opacity-0 group-hover:opacity-100 transition-[opacity,transform] duration-500 translate-x-4 group-hover:translate-x-0 flex items-center gap-2">
                       Explore <ChevronRight size={14} />
                     </span>
                   </div>
@@ -201,9 +201,9 @@ export default function DocsPage() {
             Can&apos;t find what you&apos;re looking for?
           </p>
           <div className="flex justify-center items-center gap-8">
-            <Link href="/community" className="text-theme-primary font-black uppercase tracking-widest text-xs hover:tracking-[0.2em] transition-all">Help Center</Link>
+            <Link href="/community" className="text-theme-primary font-black uppercase tracking-widest text-xs hover:tracking-[0.2em] transition-[letter-spacing]">Help Center</Link>
             <span className="w-1.5 h-1.5 rounded-full bg-theme-border/40" />
-            <Link href={`${GITHUB_REPO_URL}/issues`} className="text-theme-primary font-black uppercase tracking-widest text-xs hover:tracking-[0.2em] transition-all">GitHub Issues</Link>
+            <Link href={`${GITHUB_REPO_URL}/issues`} className="text-theme-primary font-black uppercase tracking-widest text-xs hover:tracking-[0.2em] transition-[letter-spacing]">GitHub Issues</Link>
           </div>
         </div>
       </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -220,6 +220,15 @@ body::before {
     box-shadow: 0 8px 20px #d1d5db, 0 -2px 10px #ffffff;
   }
 
+  /* Shared elevation press/lift transition — animates only box-shadow so raised/sunken
+     surfaces feel neumorphic instead of fading or sliding. Reference this everywhere
+     a surface swaps between shadow-neu-raised* / shadow-neu-sunken* on hover or press. */
+  .transition-elevation {
+    transition-property: box-shadow;
+    transition-duration: 200ms;
+    transition-timing-function: ease-out;
+  }
+
   .neu-input {
     background: var(--color-bg-sunken);
     box-shadow:
@@ -232,7 +241,7 @@ body::before {
     box-shadow:
       6px 6px 12px var(--shadow-dark),
       -6px -6px 12px var(--shadow-light);
-    transition: all 0.2s ease;
+    transition: box-shadow 0.2s ease;
   }
 
   .neu-btn:active {
@@ -247,7 +256,7 @@ body::before {
     box-shadow:
       6px 6px 12px var(--shadow-dark),
       -6px -6px 12px var(--shadow-light);
-    transition: all 0.2s ease;
+    transition: box-shadow 0.2s ease;
   }
 
   .neu-circle:active {
@@ -452,6 +461,22 @@ body::before {
 
 .animate-fadeInScale {
   animation: fadeInScale 0.6s ease-out both;
+}
+
+@keyframes dropdownIn {
+  from {
+    opacity: 0;
+    transform: translateY(-8px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.animate-dropdownIn {
+  animation: dropdownIn 0.2s ease-out both;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,6 +9,18 @@ import { FloatingCTA } from "@/components/ui/FloatingCTA";
 import { ThemeProvider } from "@/components/providers/ThemeProvider";
 import { CookieConsentBanner } from "@/components/CookieConsentBanner";
 import { SITE_URL_FALLBACK, SITE_NAME } from "@/constants/site";
+import { THEME_STORAGE_KEY } from "@/constants/storage";
+
+const themeInitScript = `(function () {
+  try {
+    var stored = localStorage.getItem(${JSON.stringify(THEME_STORAGE_KEY)});
+    var theme = stored === "light" || stored === "dark" ? stored : null;
+    if (!theme) {
+      theme = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+    }
+    document.documentElement.classList.add(theme);
+  } catch (e) {}
+})();`;
 
 const inter = Inter({
   subsets: ["latin"],
@@ -116,7 +128,13 @@ export default function RootLayout({
   children,
 }: Readonly<{ children: React.ReactNode }>) {
   return (
+    // suppressHydrationWarning is required because the blocking theme script below
+    // mutates documentElement's class before React hydrates, which React would
+    // otherwise flag as a class-attribute mismatch on <html>.
     <html lang="en" className={`${inter.variable} ${jetbrainsMono.variable}`} suppressHydrationWarning>
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
+      </head>
       <body className={`${inter.className} antialiased relative min-h-screen`}>
         <noscript>
           <div

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -123,9 +123,9 @@ export default function PricingPage() {
               return (
                 <article
                   key={tier.name}
-                  className="bg-bg-elevated shadow-neu-raised rounded-[2.5rem] p-10 hover:shadow-neu-raised-hover transition-all duration-[400ms] ease-out flex flex-col group"
+                  className="bg-bg-elevated shadow-neu-raised rounded-[2.5rem] p-10 hover:shadow-neu-raised-hover transition-shadow duration-[400ms] ease-out flex flex-col group"
                 >
-                  <div className="w-16 h-16 rounded-2xl bg-bg-base shadow-neu-sunken-subtle flex items-center justify-center mb-2 group-hover:shadow-neu-sunken transition-all duration-300">
+                  <div className="w-16 h-16 rounded-2xl bg-bg-base shadow-neu-sunken-subtle flex items-center justify-center mb-2 group-hover:shadow-neu-sunken transition-shadow duration-300">
                     <Icon className="w-7 h-7 text-theme-primary" />
                   </div>
 

--- a/src/components/HowItWorksSection.tsx
+++ b/src/components/HowItWorksSection.tsx
@@ -46,14 +46,14 @@ export function HowItWorksSection() {
               className={cn(
                 "group flex flex-col items-center text-center gap-8 p-10 rounded-3xl",
                 "bg-bg-elevated shadow-neu-raised",
-                "transition-all duration-500 cubic-bezier(0.4, 0, 0.2, 1)",
+                "transition-[box-shadow,transform] duration-500 cubic-bezier(0.4, 0, 0.2, 1)",
                 "hover:translate-y-[-12px] hover:shadow-neu-raised-hover",
                 "animate-fadeInUp"
               )}
               style={{ animationDelay: `${i * 150}ms` }}
             >
               {/* Step number container - uses sunken effect */}
-              <div className="w-20 h-20 rounded-2xl bg-bg-sunken shadow-neu-sunken flex items-center justify-center flex-shrink-0 relative z-10 transition-all duration-700 ease-out group-hover:scale-110 group-hover:rotate-[360deg]">
+              <div className="w-20 h-20 rounded-2xl bg-bg-sunken shadow-neu-sunken flex items-center justify-center flex-shrink-0 relative z-10 transition-transform duration-700 ease-out group-hover:scale-110 group-hover:rotate-[360deg]">
                 <span className="text-3xl font-black text-theme-primary drop-shadow-sm">
                   {step.number}
                 </span>
@@ -69,7 +69,7 @@ export function HowItWorksSection() {
               </div>
 
               {/* Decorative accent dot that appears on hover */}
-              <div className="absolute top-4 right-4 w-2 h-2 rounded-full bg-theme-primary opacity-0 group-hover:opacity-100 transition-all duration-300 scale-0 group-hover:scale-100" />
+              <div className="absolute top-4 right-4 w-2 h-2 rounded-full bg-theme-primary opacity-0 group-hover:opacity-100 transition-[opacity,transform] duration-300 scale-0 group-hover:scale-100" />
             </div>
           ))}
         </div>

--- a/src/components/api-explorer/EndpointPanel.tsx
+++ b/src/components/api-explorer/EndpointPanel.tsx
@@ -77,7 +77,7 @@ export function EndpointPanel({ endpoint }: EndpointPanelProps) {
       <button
         onClick={() => setIsOpen(!isOpen)}
         className={cn(
-          "w-full flex items-center gap-3 px-5 py-4 text-left transition-all duration-200",
+          "w-full flex items-center gap-3 px-5 py-4 text-left transition-[background-color,box-shadow] duration-200",
           isOpen
             ? "bg-bg-sunken"
             : "bg-bg-base hover:bg-bg-sunken/50",
@@ -167,7 +167,7 @@ export function EndpointPanel({ endpoint }: EndpointPanelProps) {
                     value={bodyValue}
                     onChange={(e) => setBodyValue(e.target.value)}
                     rows={Math.min(bodyValue.split("\n").length + 1, 12)}
-                    className="w-full rounded-xl px-4 py-3 text-sm font-mono text-content-primary resize-y transition-all focus-visible:outline-2 focus-visible:outline-theme-primary focus-visible:outline-offset-2 focus-visible:ring-2 focus-visible:ring-theme-primary focus-visible:ring-offset-0"
+                    className="w-full rounded-xl px-4 py-3 text-sm font-mono text-content-primary resize-y transition-shadow focus-visible:outline-2 focus-visible:outline-theme-primary focus-visible:outline-offset-2 focus-visible:ring-2 focus-visible:ring-theme-primary focus-visible:ring-offset-0"
                     style={{
                       background: "var(--color-bg-sunken)",
                       boxShadow: "inset 3px 3px 6px var(--shadow-dark), inset -3px -3px 6px var(--shadow-light)",
@@ -199,7 +199,7 @@ export function EndpointPanel({ endpoint }: EndpointPanelProps) {
           <button
             onClick={handleTryIt}
             disabled={loading}
-            className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl text-sm font-semibold text-white btn-neumorphic-primary disabled:opacity-60 disabled:cursor-not-allowed transition-all duration-200"
+            className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl text-sm font-semibold text-white btn-neumorphic-primary disabled:opacity-60 disabled:cursor-not-allowed transition-[background-color,box-shadow,transform,opacity] duration-200"
           >
             {loading ? <Loader2 size={16} aria-hidden="true" className="animate-spin" /> : <Play size={16} aria-hidden="true" />}
             {loading ? "Sending..." : "Try it"}

--- a/src/components/api-explorer/ParameterInput.tsx
+++ b/src/components/api-explorer/ParameterInput.tsx
@@ -27,7 +27,7 @@ export function ParameterInput({
     "w-full rounded-xl px-3 py-2.5 text-sm font-medium",
     "bg-bg-sunken shadow-neu-sunken-subtle",
     "text-content-primary placeholder:text-content-muted",
-    "border border-transparent transition-all duration-200",
+    "border border-transparent transition-shadow duration-200",
     "focus-visible:outline-2 focus-visible:outline-theme-primary focus-visible:outline-offset-2",
     "focus-visible:ring-2 focus-visible:ring-theme-primary focus-visible:ring-offset-0"
   );

--- a/src/components/api-explorer/ResponseViewer.tsx
+++ b/src/components/api-explorer/ResponseViewer.tsx
@@ -37,7 +37,7 @@ export function ResponseViewer({ responses }: ResponseViewerProps) {
                 key={res.status}
                 onClick={() => setActiveTab(i)}
                 className={cn(
-                  "px-3 py-1 rounded-lg text-xs font-mono font-medium transition-all duration-200"
+                  "px-3 py-1 rounded-lg text-xs font-mono font-medium transition-colors duration-200"
                 )}
                 style={{
                   color: isActive
@@ -59,7 +59,7 @@ export function ResponseViewer({ responses }: ResponseViewerProps) {
           aria-label="Copy response"
           className={cn(
             "flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-xs font-medium",
-            "transition-all duration-200",
+            "transition-colors duration-200",
             copied ? "text-green-400" : "text-white/40 hover:text-white/80"
           )}
         >

--- a/src/components/blueprint/MarketplaceTemplate.tsx
+++ b/src/components/blueprint/MarketplaceTemplate.tsx
@@ -309,7 +309,7 @@ export function MarketplaceTemplate() {
                 href="https://docs.offerhub.io/sdk"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl text-xs font-semibold btn-neumorphic-primary transition-all"
+                className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl text-xs font-semibold btn-neumorphic-primary transition-[background-color,box-shadow,transform]"
               >
                 SDK Documentation
                 <ArrowUpRight size={14} />

--- a/src/components/blueprint/OrchestratorDetailPanel.tsx
+++ b/src/components/blueprint/OrchestratorDetailPanel.tsx
@@ -59,7 +59,7 @@ function ArchitectureCard({
 
       <div
         id={`${card.key}-details`}
-        className={`grid transition-all duration-300 ${expanded ? "mt-6 grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-70"}`}
+        className={`grid transition-[grid-template-rows,opacity] duration-300 ${expanded ? "mt-6 grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-70"}`}
         aria-hidden={!expanded}
       >
         <div className="overflow-hidden">

--- a/src/components/blueprint/evolution-timeline/EvolutionTimelineView.tsx
+++ b/src/components/blueprint/evolution-timeline/EvolutionTimelineView.tsx
@@ -122,7 +122,7 @@ export function EvolutionTimelineView() {
               <button
                 key={domainOption.key}
                 onClick={() => setActiveDomain(domainOption.key)}
-                className={`whitespace-nowrap rounded-xl px-4 py-2 text-[13px] font-semibold transition-all duration-200 ${
+                className={`whitespace-nowrap rounded-xl px-4 py-2 text-[13px] font-semibold transition-[background-color,color,box-shadow] duration-200 ${
                   active
                     ? `${NEU_ELEVATED} bg-[var(--color-primary)] text-white`
                     : "text-content-secondary hover:text-content-primary"

--- a/src/components/blueprint/evolution-timeline/PhaseCard.tsx
+++ b/src/components/blueprint/evolution-timeline/PhaseCard.tsx
@@ -49,7 +49,7 @@ export function PhaseCard({ phase, index, isLeft }: PhaseCardProps) {
           }
           ${isInProgress ? "ring-1 ring-[var(--color-primary)]/30" : ""}
           md:w-[calc(50%_-_2.5rem)]
-          cursor-pointer select-none transition-all duration-300
+          cursor-pointer select-none transition-[box-shadow,opacity,border-color] duration-300
         `}
         onClick={() => setExpanded((v) => !v)}
         whileHover={!isPlanned ? { y: -3, transition: { duration: 0.2 } } : {}}

--- a/src/components/community/CommunityChannelsSection.tsx
+++ b/src/components/community/CommunityChannelsSection.tsx
@@ -58,7 +58,7 @@ export const CommunityChannelsSection = () => {
                 href={channel.href}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="group flex h-full flex-col rounded-3xl bg-bg-base p-8 shadow-neu-raised transition-all duration-300 hover:-translate-y-1 hover:shadow-neu-raised-hover"
+                className="group flex h-full flex-col rounded-3xl bg-bg-base p-8 shadow-neu-raised transition-[box-shadow,transform] duration-300 hover:-translate-y-1 hover:shadow-neu-raised-hover"
               >
                 <div className="w-12 h-12 rounded-xl bg-bg-base shadow-neu-sunken-subtle flex items-center justify-center mb-6 group-hover:scale-110 transition-transform">
                   <Icon size={20} className="text-theme-primary" />
@@ -69,7 +69,7 @@ export const CommunityChannelsSection = () => {
                 <p className="mt-4 text-sm font-medium leading-relaxed text-content-secondary">
                   {channel.description}
                 </p>
-                <span className="mt-8 pt-6 border-t border-theme-border/10 inline-flex items-center gap-2 text-[11px] font-black uppercase tracking-widest text-theme-primary group-hover:gap-3 transition-all">
+                <span className="mt-8 pt-6 border-t border-theme-border/10 inline-flex items-center gap-2 text-[11px] font-black uppercase tracking-widest text-theme-primary group-hover:gap-3 transition-[gap]">
                   Join channel <ArrowUpRight size={14} />
                 </span>
               </a>

--- a/src/components/community/ContributorGrid.tsx
+++ b/src/components/community/ContributorGrid.tsx
@@ -73,7 +73,7 @@ export function ContributorGrid({ contributors }: ContributorGridProps) {
                         href={`${GITHUB_REPO_URL}/graphs/contributors`}
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-block px-6 py-3 rounded-xl text-sm font-semibold transition-all duration-[400ms] ease-out border border-theme-primary text-theme-primary hover:shadow-neu-raised-hover"
+            className="inline-block px-6 py-3 rounded-xl text-sm font-semibold transition-shadow duration-[400ms] ease-out border border-theme-primary text-theme-primary hover:shadow-neu-raised-hover"
           >
             View all on GitHub
           </a>

--- a/src/components/community/ContributorsSection.tsx
+++ b/src/components/community/ContributorsSection.tsx
@@ -13,7 +13,7 @@ interface ContributorsSectionProps {
 // Memoized contributor card to prevent unnecessary re-renders
 const ContributorCard = memo(function ContributorCard({ person }: { person: ContributorData }) {
   return (
-    <article className="group relative rounded-3xl bg-bg-base p-6 shadow-neu-raised transition-all duration-300 hover:shadow-neu-raised-hover hover:-translate-y-1">
+    <article className="group relative rounded-3xl bg-bg-base p-6 shadow-neu-raised transition-[box-shadow,transform] duration-300 hover:shadow-neu-raised-hover hover:-translate-y-1">
       <div className="flex flex-col items-center text-center gap-4">
         {person.avatar ? (
           <div className="p-1 rounded-full bg-bg-base shadow-neu-sunken-subtle group-hover:shadow-neu-sunken transition-shadow">
@@ -50,7 +50,7 @@ const ContributorCard = memo(function ContributorCard({ person }: { person: Cont
             href={person.profileUrl}
             target="_blank"
             rel="noopener noreferrer"
-            className="mt-1 p-2 rounded-lg bg-bg-base shadow-neu-raised-sm text-[10px] font-black uppercase tracking-widest text-theme-primary hover:shadow-neu-sunken-subtle active:shadow-neu-sunken transition-all"
+            className="mt-1 p-2 rounded-lg bg-bg-base shadow-neu-raised-sm text-[10px] font-black uppercase tracking-widest text-theme-primary hover:shadow-neu-sunken-subtle active:shadow-neu-sunken transition-shadow"
           >
             Profile
           </a>
@@ -105,7 +105,7 @@ export const ContributorsSection = ({ contributors }: ContributorsSectionProps) 
           <div className="mt-16 text-center">
             <button
               onClick={handleLoadMore}
-              className="inline-flex items-center gap-3 px-8 py-4 rounded-2xl text-[11px] font-black uppercase tracking-widest text-white transition-all duration-300 btn-neumorphic-primary group"
+              className="inline-flex items-center gap-3 px-8 py-4 rounded-2xl text-[11px] font-black uppercase tracking-widest text-white transition-[background-color,box-shadow,transform] duration-300 btn-neumorphic-primary group"
             >
               Show more creators
               <ChevronDown size={14} className="group-hover:translate-y-1 transition-transform" />

--- a/src/components/community/HeroRepoStatsSection.tsx
+++ b/src/components/community/HeroRepoStatsSection.tsx
@@ -38,7 +38,7 @@ export const HeroRepoStatsSection = ({ stats }: HeroRepoStatsSectionProps) => {
                 href={GITHUB_REPO_URL}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="px-8 py-4 rounded-xl bg-content-primary text-white text-xs font-black uppercase tracking-widest shadow-xl shadow-content-primary/20 hover:bg-black transition-all"
+                className="px-8 py-4 rounded-xl bg-content-primary text-white text-xs font-black uppercase tracking-widest shadow-xl shadow-content-primary/20 hover:bg-black transition-colors"
               >
                 Star on GitHub
               </a>
@@ -65,7 +65,7 @@ export const HeroRepoStatsSection = ({ stats }: HeroRepoStatsSectionProps) => {
                 {repoStats.map((stat) => (
                   <div
                     key={stat.label}
-                    className="group rounded-3xl bg-bg-elevated shadow-neu-raised p-6 transition-all duration-500 hover:scale-[1.02]"
+                    className="group rounded-3xl bg-bg-elevated shadow-neu-raised p-6 transition-transform duration-500 hover:scale-[1.02]"
                   >
                     <div className="flex items-center justify-between mb-4">
                       <div className="p-2.5 rounded-xl bg-bg-sunken shadow-neu-sunken-subtle">

--- a/src/components/community/OpenIssuesSection.tsx
+++ b/src/components/community/OpenIssuesSection.tsx
@@ -15,7 +15,7 @@ const IssueCard = memo(function IssueCard({ issue }: { issue: IssueData }) {
   const isGoodFirstIssue = issue.labels.some(l => l.toLowerCase().includes('good') || l.toLowerCase().includes('help'));
 
   return (
-    <article className="group relative flex flex-col justify-between rounded-3xl bg-bg-base p-6 shadow-neu-raised transition-all duration-300 hover:shadow-neu-raised-hover">
+    <article className="group relative flex flex-col justify-between rounded-3xl bg-bg-base p-6 shadow-neu-raised transition-shadow duration-300 hover:shadow-neu-raised-hover">
       <div>
         <div className="flex items-center justify-between mb-4">
           <div className="flex items-center gap-2 px-3 py-1.5 rounded-xl bg-bg-base text-[10px] font-bold text-content-secondary tracking-wider shadow-neu-sunken-subtle uppercase">
@@ -71,7 +71,7 @@ const IssueCard = memo(function IssueCard({ issue }: { issue: IssueData }) {
           href={issue.url}
           target="_blank"
           rel="noopener noreferrer"
-          className="w-10 h-10 rounded-xl text-white transition-all btn-neumorphic-primary flex items-center justify-center shadow-neu-raised-sm hover:scale-105"
+          className="w-10 h-10 rounded-xl text-white transition-[background-color,box-shadow,transform] btn-neumorphic-primary flex items-center justify-center shadow-neu-raised-sm hover:scale-105"
         >
           <ArrowUpRight size={18} />
         </a>
@@ -115,7 +115,7 @@ export const OpenIssuesSection = ({ issues }: OpenIssuesSectionProps) => {
           <div className="mt-16 text-center">
             <button
               onClick={handleLoadMore}
-              className="inline-flex items-center gap-2 text-[11px] font-black uppercase tracking-widest text-theme-primary hover:gap-3 transition-all group"
+              className="inline-flex items-center gap-2 text-[11px] font-black uppercase tracking-widest text-theme-primary hover:gap-3 transition-[gap] group"
             >
               Load more issues
               <ChevronDown size={14} className="group-hover:translate-y-1 transition-transform" />

--- a/src/components/community/RecentPRsSection.tsx
+++ b/src/components/community/RecentPRsSection.tsx
@@ -14,7 +14,7 @@ const PRCard = memo(function PRCard({ pr }: { pr: PullRequestData }) {
   const isMerged = pr.status === 'Merged';
 
   return (
-    <article className="flex flex-col gap-4 rounded-3xl bg-bg-base p-5 shadow-neu-raised-sm hover:shadow-neu-raised transition-all duration-300 group/card">
+    <article className="flex flex-col gap-4 rounded-3xl bg-bg-base p-5 shadow-neu-raised-sm hover:shadow-neu-raised transition-shadow duration-300 group/card">
       <div className="flex items-start justify-between gap-4">
         <div className="flex items-start gap-3">
           <div className="mt-1 w-8 h-8 rounded-lg bg-bg-base flex items-center justify-center shadow-neu-sunken-subtle transition-transform group-hover/card:scale-110">
@@ -54,7 +54,7 @@ const PRCard = memo(function PRCard({ pr }: { pr: PullRequestData }) {
           href={pr.url}
           target="_blank"
           rel="noopener noreferrer"
-          className="p-2 rounded-lg bg-bg-base shadow-neu-raised-sm text-theme-primary hover:shadow-neu-sunken-subtle active:shadow-neu-sunken transition-all"
+          className="p-2 rounded-lg bg-bg-base shadow-neu-raised-sm text-theme-primary hover:shadow-neu-sunken-subtle active:shadow-neu-sunken transition-shadow"
         >
           <ArrowUpRight size={14} />
         </a>

--- a/src/components/community/RepoLinksSection.tsx
+++ b/src/components/community/RepoLinksSection.tsx
@@ -33,9 +33,9 @@ export function RepoLinksSection() {
                                 href={repo.url}
                                 target="_blank"
                                 rel="noopener noreferrer"
-                                className="group relative flex items-center gap-5 p-6 rounded-3xl bg-bg-elevated shadow-neu-raised transition-all duration-300 active:shadow-neu-sunken hover:scale-[1.02]"
+                                className="group relative flex items-center gap-5 p-6 rounded-3xl bg-bg-elevated shadow-neu-raised transition-[box-shadow,transform] duration-300 active:shadow-neu-sunken hover:scale-[1.02]"
                             >
-                                <div className="w-14 h-14 rounded-2xl bg-bg-sunken shadow-neu-sunken flex items-center justify-center flex-shrink-0 group-hover:shadow-neu-sunken-subtle transition-all duration-500">
+                                <div className="w-14 h-14 rounded-2xl bg-bg-sunken shadow-neu-sunken flex items-center justify-center flex-shrink-0 group-hover:shadow-neu-sunken-subtle transition-shadow duration-500">
                                     <Github size={24} className="text-theme-primary" />
                                 </div>
 

--- a/src/components/docs/CodeBlock.tsx
+++ b/src/components/docs/CodeBlock.tsx
@@ -106,7 +106,7 @@ export function CodeBlock({
     <div
       ref={containerRef}
       className={cn(
-        "relative rounded-3xl overflow-hidden my-10 bg-bg-elevated group transition-all duration-300",
+        "relative rounded-3xl overflow-hidden my-10 bg-bg-elevated group transition-colors duration-300",
         className
       )}
       style={{
@@ -117,7 +117,7 @@ export function CodeBlock({
       {/* Header bar — sunken, clean edges (no border) */}
       <div className="flex items-center justify-between px-6 py-4 rounded-t-3xl bg-bg-sunken shadow-neu-sunken-subtle">
         <div className="flex items-center gap-3.5">
-          <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-bg-base shadow-neu-raised-sm transition-all duration-300 group-hover:bg-theme-primary/10">
+          <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-bg-base shadow-neu-raised-sm transition-colors duration-300 group-hover:bg-theme-primary/10">
             <Code2 size={16} className="text-content-secondary group-hover:text-theme-primary" />
           </div>
           <div>
@@ -133,7 +133,7 @@ export function CodeBlock({
           onClick={handleCopy}
           aria-label={copied ? "Copied" : "Copy code"}
           className={cn(
-            "relative flex items-center gap-2.5 px-4 py-2 rounded-xl text-[10.5px] font-black uppercase tracking-widest transition-all duration-300",
+            "relative flex items-center gap-2.5 px-4 py-2 rounded-xl text-[10.5px] font-black uppercase tracking-widest transition-[color,background-color,transform] duration-300",
             copied
               ? "text-white bg-theme-primary shadow-lg shadow-theme-primary/25"
               : "text-content-secondary bg-bg-base shadow-neu-raised-sm hover:text-content-primary hover:bg-theme-primary/10 active:scale-95"

--- a/src/components/docs/CommandLine.tsx
+++ b/src/components/docs/CommandLine.tsx
@@ -97,7 +97,7 @@ export function CommandLine({
           aria-label={copied ? "Command copied" : "Copy command"}
           className={cn(
             "ml-auto inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md text-[11px] font-medium",
-            "transition-all duration-200",
+            "transition-colors duration-200",
             copied
               ? "text-green-500"
               : "text-content-secondary hover:text-content-primary",

--- a/src/components/docs/DocPageActions.tsx
+++ b/src/components/docs/DocPageActions.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { Download, FileCode2, FileText, Github } from "lucide-react";
 
 import { ExportJSON } from "@/components/docs/ExportJSON";
@@ -33,10 +33,8 @@ function downloadBlob(filename: string, content: string, mimeType: string) {
 export function DocPageActions({ slug, title, description, markdownContent }: DocPageActionsProps) {
   const [isExportingPdf, setIsExportingPdf] = useState(false);
 
-  const markdownFileName = useMemo(() => `${slug.replace(/\//g, "-")}-${dateStamp()}.md`, [slug]);
-  const pdfFileName = useMemo(() => `${slug.replace(/\//g, "-")}-${dateStamp()}.pdf`, [slug]);
-
   function handleExportMarkdown() {
+    const markdownFileName = `${slug.replace(/\//g, "-")}-${dateStamp()}.md`;
     downloadBlob(markdownFileName, markdownContent, "text/markdown;charset=utf-8");
   }
 
@@ -160,7 +158,7 @@ export function DocPageActions({ slug, title, description, markdownContent }: Do
       await html2pdf()
         .set({
           margin: [10, 10, 10, 10],
-          filename: pdfFileName,
+          filename: `${slug.replace(/\//g, "-")}-${dateStamp()}.pdf`,
           image: { type: "jpeg", quality: 0.98 },
           html2canvas: {
             scale: 2,

--- a/src/components/docs/DocsLayoutShell.tsx
+++ b/src/components/docs/DocsLayoutShell.tsx
@@ -143,7 +143,7 @@ export function DocsLayoutShell({ nav, children }: DocsLayoutShellProps) {
               <button
                 type="button"
                 onClick={() => setIsDrawerOpen(true)}
-                className="lg:hidden inline-flex items-center justify-center p-2 rounded-lg text-content-secondary hover:bg-[#149A9B]/5 hover:text-[#149A9B] transition-all"
+                className="lg:hidden inline-flex items-center justify-center p-2 rounded-lg text-content-secondary hover:bg-[#149A9B]/5 hover:text-[#149A9B] transition-colors"
                 aria-label="Open docs navigation"
               >
                 <Menu size={20} aria-hidden="true" />
@@ -224,7 +224,7 @@ export function DocsLayoutShell({ nav, children }: DocsLayoutShellProps) {
               <button
                 type="button"
                 onClick={() => setIsDrawerOpen(false)}
-                className="inline-flex items-center justify-center p-2 rounded-lg text-content-secondary hover:bg-bg-elevated hover:text-content-primary transition-all"
+                className="inline-flex items-center justify-center p-2 rounded-lg text-content-secondary hover:bg-bg-elevated hover:text-content-primary transition-colors"
                 aria-label="Close docs navigation"
               >
                 <X size={20} aria-hidden="true" />

--- a/src/components/docs/DocsPagination.tsx
+++ b/src/components/docs/DocsPagination.tsx
@@ -20,7 +20,7 @@ export function DocsPagination({ prev, next }: DocsPaginationProps) {
       {prev ? (
         <Link
           href={prev.href}
-          className="flex items-start gap-3 group max-w-[45%] rounded-2xl bg-bg-base shadow-neu-raised px-4 py-3 transition-all duration-200 hover:shadow-neu-raised-hover active:shadow-neu-sunken-subtle"
+          className="flex items-start gap-3 group max-w-[45%] rounded-2xl bg-bg-base shadow-neu-raised px-4 py-3 transition-shadow duration-200 hover:shadow-neu-raised-hover active:shadow-neu-sunken-subtle"
         >
           <ArrowLeft
             size={20}
@@ -42,7 +42,7 @@ export function DocsPagination({ prev, next }: DocsPaginationProps) {
       {next ? (
         <Link
           href={next.href}
-          className="flex items-start gap-3 group max-w-[45%] ml-auto text-right rounded-2xl bg-bg-base shadow-neu-raised px-4 py-3 transition-all duration-200 hover:shadow-neu-raised-hover active:shadow-neu-sunken-subtle"
+          className="flex items-start gap-3 group max-w-[45%] ml-auto text-right rounded-2xl bg-bg-base shadow-neu-raised px-4 py-3 transition-shadow duration-200 hover:shadow-neu-raised-hover active:shadow-neu-sunken-subtle"
         >
           <div className="flex flex-col gap-1">
             <span className="text-xs uppercase tracking-widest text-content-secondary">

--- a/src/components/docs/DocsSearchBar.tsx
+++ b/src/components/docs/DocsSearchBar.tsx
@@ -163,7 +163,7 @@ export function DocsSearchBar() {
                 <div 
                     id="docs-search-results"
                     role="listbox"
-                    className="absolute top-full left-0 mt-3 w-full rounded-2xl z-[150] animate-in fade-in slide-in-from-top-2 duration-200 bg-bg-elevated border border-theme-border/40 shadow-2xl shadow-black/10 backdrop-blur-md"
+                    className="absolute top-full left-0 mt-3 w-full rounded-2xl z-[150] animate-dropdownIn bg-bg-elevated border border-theme-border/40 shadow-2xl shadow-black/10 backdrop-blur-md"
                 >
                     <div className="max-h-[480px] overflow-y-auto scrollbar-thin">
                         {results.map((result, idx) => (
@@ -219,7 +219,7 @@ export function DocsSearchBar() {
             )}
 
             {isOpen && query.length > 1 && results.length === 0 && (
-                <div className="absolute top-full mt-3 w-full rounded-2xl p-8 text-center z-[100] animate-in fade-in slide-in-from-top-2 bg-bg-elevated/95 border border-theme-border/40 shadow-neu-raised backdrop-blur-xl">
+                <div className="absolute top-full mt-3 w-full rounded-2xl p-8 text-center z-[100] animate-dropdownIn bg-bg-elevated/95 border border-theme-border/40 shadow-neu-raised backdrop-blur-xl">
                     <p className="text-content-secondary">No results found for &quot;<span className="font-semibold text-content-primary">{query}</span>&quot;</p>
                     <p className="text-sm mt-1 text-content-secondary/80">Try a different search term</p>
                 </div>

--- a/src/components/docs/DocsSidebar.tsx
+++ b/src/components/docs/DocsSidebar.tsx
@@ -111,7 +111,7 @@ function SidebarItem({ href, icon, label, isActive }: { href: string; icon: Reac
         href={href}
         aria-current={isActive ? "page" : undefined}
         className={cn(
-          "group relative flex items-center gap-3.5 text-sm py-2.5 px-5 rounded-2xl transition-all duration-300 font-medium overflow-hidden",
+          "group relative flex items-center gap-3.5 text-sm py-2.5 px-5 rounded-2xl transition-[color,box-shadow] duration-300 font-medium overflow-hidden",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-theme-primary focus-visible:ring-offset-2 focus-visible:ring-offset-bg-base",
           isActive
             ? "text-theme-primary"
@@ -136,7 +136,7 @@ function SidebarItem({ href, icon, label, isActive }: { href: string; icon: Reac
         <div className="absolute inset-0 bg-theme-primary/0 group-hover:bg-theme-primary/5 transition-colors z-0" />
 
         <span className={cn(
-          "relative z-10 flex-shrink-0 transition-all duration-300",
+          "relative z-10 flex-shrink-0 transition-[color,transform] duration-300",
           isActive ? "text-theme-primary scale-110" : "text-content-secondary group-hover:text-content-primary group-hover:scale-110"
         )}>
           {icon}

--- a/src/components/docs/TableOfContents.tsx
+++ b/src/components/docs/TableOfContents.tsx
@@ -65,7 +65,7 @@ export function TableOfContents({ headings }: TableOfContentsProps) {
                 href={`#${heading.id}`}
                 onClick={(e) => handleClick(e, heading.id)}
                 className={cn(
-                  "text-[13px] transition-all duration-200 block py-1.5 px-4 rounded-lg font-medium",
+                  "text-[13px] transition-[color,background-color,box-shadow] duration-200 block py-1.5 px-4 rounded-lg font-medium",
                   activeId === heading.id
                     ? "text-theme-primary bg-bg-sunken shadow-neu-sunken-subtle"
                     : "text-content-secondary hover:text-content-primary hover:bg-bg-elevated"

--- a/src/components/forms/FormField.tsx
+++ b/src/components/forms/FormField.tsx
@@ -22,7 +22,7 @@ interface FormFieldProps {
 }
 
 const INPUT_CLASS =
-  "w-full pl-12 pr-6 py-3.5 rounded-xl bg-bg-sunken shadow-neu-sunken-subtle text-sm text-content-primary placeholder:text-content-muted border-none transition-all font-medium disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-2 focus-visible:outline-theme-primary focus-visible:outline-offset-2 focus-visible:ring-2 focus-visible:ring-theme-primary"
+  "w-full pl-12 pr-6 py-3.5 rounded-xl bg-bg-sunken shadow-neu-sunken-subtle text-sm text-content-primary placeholder:text-content-muted border-none transition-[box-shadow,opacity] font-medium disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-2 focus-visible:outline-theme-primary focus-visible:outline-offset-2 focus-visible:ring-2 focus-visible:ring-theme-primary"
 
 export function FormField({
   id,

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { Twitter, Send, Github, Disc3 } from "lucide-react";
@@ -49,6 +49,11 @@ export function Footer() {
   const wrapRef = useRef<HTMLDivElement>(null);
   const textRef = useRef<HTMLDivElement>(null);
   const { resolvedTheme } = useTheme();
+  const [year, setYear] = useState<number | null>(null);
+
+  useEffect(() => {
+    setYear(new Date().getFullYear());
+  }, []);
 
   useEffect(() => {
     const wrap = wrapRef.current;
@@ -158,7 +163,7 @@ export function Footer() {
 
           <div className="mt-10 pt-6 flex flex-col sm:flex-row items-center justify-between gap-2 border-t border-theme-border">
             <p className="text-xs text-content-muted">
-              © {new Date().getFullYear()} OFFER-HUB. All rights reserved.
+              © {year ?? ""} OFFER-HUB. All rights reserved.
             </p>
 
             <p className="text-xs text-content-muted">

--- a/src/components/layout/Hero.tsx
+++ b/src/components/layout/Hero.tsx
@@ -25,7 +25,7 @@ export function Hero() {
   return (
     <section className="pt-24 pb-16 md:pt-32 md:pb-24 bg-background">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="text-center max-w-4xl mx-auto animate-fade-in-up">
+        <div className="text-center max-w-4xl mx-auto animate-fadeInUp">
           <div className="inline-flex items-center gap-2 bg-primary/10 text-primary px-4 py-2 rounded-full text-sm font-medium mb-6">
             <span className="w-2 h-2 bg-primary rounded-full animate-pulse" />
             Self-hosted Payments Orchestrator
@@ -44,7 +44,7 @@ export function Hero() {
           <div className="flex flex-col sm:flex-row items-center justify-center gap-4 mb-16">
             <Link
               href="/#waitlist-form"
-              className="w-full sm:w-auto bg-primary hover:bg-primary-hover text-white px-8 py-4 rounded-xl text-base font-medium transition-all duration-400 ease-out shadow-raised hover:shadow-raised-hover hover:-translate-y-0.5 flex items-center justify-center gap-2"
+              className="w-full sm:w-auto bg-primary hover:bg-primary-hover text-white px-8 py-4 rounded-xl text-base font-medium transition-[background-color,box-shadow,transform] duration-400 ease-out shadow-raised hover:shadow-raised-hover hover:-translate-y-0.5 flex items-center justify-center gap-2"
             >
               Start Building Free
               <ArrowRight size={18} />
@@ -52,7 +52,7 @@ export function Hero() {
 
             <Link
               href="#docs"
-              className="w-full sm:w-auto bg-background text-text-primary px-8 py-4 rounded-xl text-base font-medium transition-all duration-400 ease-out shadow-raised hover:shadow-raised-hover hover:-translate-y-0.5 border border-gray-200 flex items-center justify-center"
+              className="w-full sm:w-auto bg-background text-text-primary px-8 py-4 rounded-xl text-base font-medium transition-[box-shadow,transform] duration-400 ease-out shadow-raised hover:shadow-raised-hover hover:-translate-y-0.5 border border-gray-200 flex items-center justify-center"
             >
               View Documentation
             </Link>
@@ -63,7 +63,7 @@ export function Hero() {
           {features.map((feature, index) => (
             <div
               key={feature.title}
-              className="bg-background rounded-2xl p-6 shadow-raised hover:shadow-raised-hover transition-all duration-400 ease-out hover:-translate-y-1 animate-fade-in-up"
+              className="bg-background rounded-2xl p-6 shadow-raised hover:shadow-raised-hover transition-[box-shadow,transform] duration-400 ease-out hover:-translate-y-1 animate-fadeInUp"
               style={{ animationDelay: `${(index + 1) * 100}ms` }}
             >
               <div className="w-12 h-12 rounded-xl bg-gradient-primary flex items-center justify-center mb-4">

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -66,7 +66,7 @@ export function Navbar() {
     <>
       <header
         className={cn(
-          "fixed top-4 left-4 right-4 md:left-1/2 md:-translate-x-1/2 md:max-w-6xl xl:max-w-7xl md:w-full z-[500] transition-all duration-300 ease-out rounded-full bg-bg-base print:hidden",
+          "fixed top-4 left-4 right-4 md:left-1/2 md:-translate-x-1/2 md:max-w-6xl xl:max-w-7xl md:w-full z-[500] transition-shadow duration-300 ease-out rounded-full bg-bg-base print:hidden",
           isScrolled
             ? "shadow-neu-raised-scrolled py-1"
             : "shadow-neu-raised py-2"
@@ -97,7 +97,7 @@ export function Navbar() {
                 href="/"
                 className={cn(
                   "px-3 py-2 rounded-full text-[13px] xl:text-sm font-medium",
-                  "transition-all duration-300 ease-out bg-bg-base",
+                  "transition-[color,box-shadow] duration-300 ease-out bg-bg-base",
                   isLinkActive("/", pathname)
                     ? "text-content-primary shadow-neu-sunken-subtle"
                     : "text-content-secondary hover:text-content-primary hover:shadow-neu-sunken-subtle"
@@ -111,7 +111,7 @@ export function Navbar() {
                   href={link.href}
                   className={cn(
                     "px-3 py-2 rounded-full text-[13px] xl:text-sm font-medium",
-                    "transition-all duration-300 ease-out bg-bg-base",
+                    "transition-[color,box-shadow] duration-300 ease-out bg-bg-base",
                     isLinkActive(link.href, pathname)
                       ? "text-content-primary shadow-neu-sunken-subtle"
                       : "text-content-secondary hover:text-content-primary hover:shadow-neu-sunken-subtle"
@@ -144,7 +144,7 @@ export function Navbar() {
               aria-label="Toggle menu"
               aria-expanded={isMenuOpen}
               aria-controls="mobile-menu"
-              className="lg:hidden p-2 rounded-full transition-all duration-300 ease-out bg-bg-base text-content-secondary shadow-neu-raised hover:shadow-neu-sunken-subtle"
+              className="lg:hidden p-2 rounded-full transition-shadow duration-300 ease-out bg-bg-base text-content-secondary shadow-neu-raised hover:shadow-neu-sunken-subtle"
             >
               {isMenuOpen ? <X size={20} /> : <Menu size={20} />}
             </button>
@@ -172,7 +172,7 @@ export function Navbar() {
               <Link
                 href="/"
                 className={cn(
-                  "px-4 py-3.5 rounded-2xl text-sm font-medium transition-all duration-300 ease-out",
+                  "px-4 py-3.5 rounded-2xl text-sm font-medium transition-colors duration-300 ease-out",
                   isLinkActive("/", pathname)
                     ? "text-content-primary bg-white/50 dark:bg-white/5 shadow-neu-sunken-subtle"
                     : "text-content-secondary hover:text-content-primary hover:bg-white/30 dark:hover:bg-white/5"
@@ -186,7 +186,7 @@ export function Navbar() {
                   key={link.href}
                   href={link.href}
                   className={cn(
-                    "px-4 py-3.5 rounded-2xl text-sm font-medium transition-all duration-300 ease-out",
+                    "px-4 py-3.5 rounded-2xl text-sm font-medium transition-colors duration-300 ease-out",
                     isLinkActive(link.href, pathname)
                       ? "text-content-primary bg-white/50 dark:bg-white/5 shadow-neu-sunken-subtle"
                       : "text-content-secondary hover:text-content-primary hover:bg-white/30 dark:hover:bg-white/5"

--- a/src/components/mdx/DataRightsForm.tsx
+++ b/src/components/mdx/DataRightsForm.tsx
@@ -49,7 +49,7 @@ export function DataRightsForm({
           value={email}
           onChange={(e) => setEmail(e.target.value)}
           placeholder="your@email.com"
-          className="rounded-xl px-4 py-3 text-sm bg-bg-sunken shadow-neu-sunken-subtle text-content-primary placeholder:text-content-secondary/60 outline-none focus:ring-2 focus:ring-theme-primary/30 transition-all"
+          className="rounded-xl px-4 py-3 text-sm bg-bg-sunken shadow-neu-sunken-subtle text-content-primary placeholder:text-content-secondary/60 outline-none focus:ring-2 focus:ring-theme-primary/30 transition-shadow"
         />
         <button
           type="submit"

--- a/src/components/mdx/PrivacyComponents.tsx
+++ b/src/components/mdx/PrivacyComponents.tsx
@@ -21,9 +21,9 @@ export function PrivacyFeatureCard({
     <div
       className={`${
         large ? "sm:col-span-2 md:col-span-2" : ""
-      } p-10 rounded-[2.5rem] bg-bg-elevated shadow-neu-raised flex flex-col gap-6 group hover:shadow-neu-raised-hover transition-all duration-500`}
+      } p-10 rounded-[2.5rem] bg-bg-elevated shadow-neu-raised flex flex-col gap-6 group hover:shadow-neu-raised-hover transition-shadow duration-500`}
     >
-      <div className="w-14 h-14 rounded-2xl shadow-neu-sunken-subtle flex items-center justify-center shrink-0 bg-bg-elevated group-hover:shadow-neu-sunken transition-all duration-300">
+      <div className="w-14 h-14 rounded-2xl shadow-neu-sunken-subtle flex items-center justify-center shrink-0 bg-bg-elevated group-hover:shadow-neu-sunken transition-shadow duration-300">
         <Icon size={24} className="text-theme-primary" />
       </div>
       <div>
@@ -60,7 +60,7 @@ export function ProcessorCard({
   link: string;
 }): React.ReactElement {
   return (
-    <div className="p-8 rounded-[2rem] bg-bg-elevated shadow-neu-raised flex flex-col gap-4 border border-theme-primary/5 hover:shadow-neu-raised-hover transition-all duration-300">
+    <div className="p-8 rounded-[2rem] bg-bg-elevated shadow-neu-raised flex flex-col gap-4 border border-theme-primary/5 hover:shadow-neu-raised-hover transition-shadow duration-300">
       <div className="flex items-center justify-between">
         <h3 className="text-xl font-black text-content-primary">{name}</h3>
         <a
@@ -125,7 +125,7 @@ export function ContactSection(): React.ReactElement {
           <a
             key={email}
             href={`mailto:${email}`}
-            className="flex flex-col gap-1 rounded-2xl px-6 py-5 transition-all duration-300 shadow-neu-sunken-subtle bg-bg-elevated hover:shadow-neu-sunken group"
+            className="flex flex-col gap-1 rounded-2xl px-6 py-5 transition-shadow duration-300 shadow-neu-sunken-subtle bg-bg-elevated hover:shadow-neu-sunken group"
           >
             <span className="text-[10px] font-black uppercase tracking-widest text-content-secondary">{label}</span>
             <span className="text-base font-bold text-theme-primary group-hover:text-content-primary transition-colors">

--- a/src/components/mdx/base-mdx-components.tsx
+++ b/src/components/mdx/base-mdx-components.tsx
@@ -79,7 +79,7 @@ export const BASE_MDX_COMPONENTS: MDXComponents = {
   a: ({ href, children }) => (
     <a
       href={href}
-      className="font-bold underline decoration-2 underline-offset-4 decoration-theme-primary/40 hover:decoration-theme-primary transition-all text-theme-primary"
+      className="font-bold underline decoration-2 underline-offset-4 decoration-theme-primary/40 hover:decoration-theme-primary transition-colors text-theme-primary"
       target={href?.startsWith("http") ? "_blank" : undefined}
       rel={href?.startsWith("http") ? "noopener noreferrer" : undefined}
     >

--- a/src/components/providers/ThemeProvider.tsx
+++ b/src/components/providers/ThemeProvider.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, useContext, useEffect, useState, useCallback } from "react";
+import { createContext, useContext, useEffect, useState, useCallback, useRef } from "react";
 import { flushSync } from "react-dom";
 import { MotionConfig } from "framer-motion";
 import { THEME_STORAGE_KEY } from "@/constants/storage";
@@ -22,33 +22,43 @@ function getSystemTheme(): ResolvedTheme {
   return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
 }
 
+function getStoredTheme(): Theme {
+  if (typeof window === "undefined") return "system";
+  const stored = localStorage.getItem(THEME_STORAGE_KEY) as Theme | null;
+  return stored && ["light", "dark", "system"].includes(stored) ? stored : "system";
+}
+
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
-  const [theme, setThemeState] = useState<Theme>("system");
+  const [theme, setThemeState] = useState<Theme>(getStoredTheme);
+  // Seeded to "light" on both server and the first client render so this
+  // state never mismatches during hydration. The blocking script in
+  // layout.tsx already applied the correct light/dark class to
+  // documentElement before paint, so the page never visibly flashes —
+  // only JS-driven consumers (icons, logo swaps) pick up the real value
+  // one tick after mount, via the effect below.
   const [resolvedTheme, setResolvedTheme] = useState<ResolvedTheme>("light");
-  const [mounted, setMounted] = useState(false);
+  const isFirstRender = useRef(true);
 
-  // Initialize theme from localStorage
+  // Read the class the blocking script already applied instead of
+  // recomputing it, so a manually-set "light"/"dark" theme (not "system")
+  // doesn't get silently overridden by the current system preference.
   useEffect(() => {
-    const stored = localStorage.getItem(THEME_STORAGE_KEY) as Theme | null;
-    if (stored && ["light", "dark", "system"].includes(stored)) {
-      setThemeState(stored);
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      const applied = document.documentElement.classList.contains("dark") ? "dark" : "light";
+      setResolvedTheme(applied);
+      return;
     }
-    setMounted(true);
-  }, []);
-
-  // Sync resolved theme with class on documentElement
-  useEffect(() => {
-    if (!mounted) return;
     const root = document.documentElement;
     const resolved: ResolvedTheme = theme === "system" ? getSystemTheme() : theme;
     setResolvedTheme(resolved);
     root.classList.remove("light", "dark");
     root.classList.add(resolved);
-  }, [theme, mounted]);
+  }, [theme]);
 
   // Handle system theme changes
   useEffect(() => {
-    if (!mounted || theme !== "system") return;
+    if (theme !== "system") return;
     const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
     const handleChange = () => {
       const resolved = getSystemTheme();
@@ -58,7 +68,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
     };
     mediaQuery.addEventListener("change", handleChange);
     return () => mediaQuery.removeEventListener("change", handleChange);
-  }, [theme, mounted]);
+  }, [theme]);
 
   const setTheme = useCallback((newTheme: Theme) => {
     setThemeState(newTheme);

--- a/src/components/providers/__tests__/ThemeProvider.test.tsx
+++ b/src/components/providers/__tests__/ThemeProvider.test.tsx
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import { ThemeProvider, useTheme } from "../ThemeProvider";
+import { THEME_STORAGE_KEY } from "@/constants/storage";
+
+function installMatchMedia(prefersDark: boolean) {
+  const listeners = new Set<(e: MediaQueryListEvent) => void>();
+  const mql = {
+    matches: prefersDark,
+    media: "(prefers-color-scheme: dark)",
+    addEventListener: vi.fn((_type: string, listener: (e: MediaQueryListEvent) => void) => {
+      listeners.add(listener);
+    }),
+    removeEventListener: vi.fn((_type: string, listener: (e: MediaQueryListEvent) => void) => {
+      listeners.delete(listener);
+    }),
+  };
+  vi.stubGlobal("matchMedia", vi.fn(() => mql));
+  return { mql, listeners };
+}
+
+function Probe() {
+  const { theme, resolvedTheme } = useTheme();
+  return (
+    <span data-theme={theme} data-resolved={resolvedTheme}>
+      probe
+    </span>
+  );
+}
+
+describe("ThemeProvider resolution order", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.classList.remove("light", "dark");
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    document.documentElement.classList.remove("light", "dark");
+  });
+
+  it("prefers a stored theme over the system preference", () => {
+    installMatchMedia(true);
+    localStorage.setItem(THEME_STORAGE_KEY, "light");
+
+    render(
+      <ThemeProvider>
+        <Probe />
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByText("probe")).toHaveAttribute("data-theme", "light");
+  });
+
+  it("falls back to the system preference when nothing is stored", () => {
+    installMatchMedia(true);
+    // In production the blocking script in layout.tsx already resolves the
+    // system preference and applies the class before React ever mounts.
+    document.documentElement.classList.add("dark");
+
+    render(
+      <ThemeProvider>
+        <Probe />
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByText("probe")).toHaveAttribute("data-theme", "system");
+    expect(screen.getByText("probe")).toHaveAttribute("data-resolved", "dark");
+  });
+
+  it("falls back to the system preference for an invalid stored value", () => {
+    installMatchMedia(false);
+    localStorage.setItem(THEME_STORAGE_KEY, "not-a-real-theme");
+
+    render(
+      <ThemeProvider>
+        <Probe />
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByText("probe")).toHaveAttribute("data-theme", "system");
+  });
+
+  it("resolves the initial resolvedTheme from the DOM class already applied by the blocking script, not by recomputing it", () => {
+    // Simulate the inline script in layout.tsx: it runs before React and adds
+    // the class synchronously. matchMedia here reports light to prove the
+    // provider trusts the existing DOM class instead of recomputing.
+    installMatchMedia(false);
+    document.documentElement.classList.add("dark");
+
+    render(
+      <ThemeProvider>
+        <Probe />
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByText("probe")).toHaveAttribute("data-resolved", "dark");
+  });
+
+  it("does not touch documentElement's class list on the initial mount", () => {
+    installMatchMedia(false);
+    document.documentElement.classList.add("dark");
+
+    render(
+      <ThemeProvider>
+        <Probe />
+      </ThemeProvider>,
+    );
+
+    // Still exactly what the blocking script set — the provider must not
+    // remove/re-add classes redundantly on first render.
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    expect(document.documentElement.classList.contains("light")).toBe(false);
+  });
+
+  it("syncs documentElement's class when the theme changes after mount", () => {
+    installMatchMedia(false);
+    document.documentElement.classList.add("light");
+
+    function ToggleProbe() {
+      const { setTheme, resolvedTheme } = useTheme();
+      return (
+        <div>
+          <span data-resolved={resolvedTheme}>probe</span>
+          <button onClick={() => setTheme("dark")}>go dark</button>
+        </div>
+      );
+    }
+
+    render(
+      <ThemeProvider>
+        <ToggleProbe />
+      </ThemeProvider>,
+    );
+
+    act(() => {
+      screen.getByText("go dark").click();
+    });
+
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    expect(document.documentElement.classList.contains("light")).toBe(false);
+    expect(screen.getByText("probe")).toHaveAttribute("data-resolved", "dark");
+  });
+
+  it("persists the chosen theme to localStorage", () => {
+    installMatchMedia(false);
+
+    function ToggleProbe() {
+      const { setTheme } = useTheme();
+      return <button onClick={() => setTheme("dark")}>go dark</button>;
+    }
+
+    render(
+      <ThemeProvider>
+        <ToggleProbe />
+      </ThemeProvider>,
+    );
+
+    act(() => {
+      screen.getByText("go dark").click();
+    });
+
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe("dark");
+  });
+});

--- a/src/components/shared/DiagramZoomModal.tsx
+++ b/src/components/shared/DiagramZoomModal.tsx
@@ -46,7 +46,7 @@ export function DiagramZoomModal({ title, isOpen, onClose, children }: Props) {
               </span>
               <button
                 onClick={onClose}
-                className="rounded-2xl bg-bg-base shadow-neu-raised-sm p-2.5 hover:shadow-neu-sunken transition-all text-content-secondary hover:text-content-primary"
+                className="rounded-2xl bg-bg-base shadow-neu-raised-sm p-2.5 hover:shadow-neu-sunken transition-[color,box-shadow] text-content-secondary hover:text-content-primary"
                 aria-label="Close"
               >
                 <X size={16} />

--- a/src/components/shared/MermaidDiagram.tsx
+++ b/src/components/shared/MermaidDiagram.tsx
@@ -226,7 +226,7 @@ export function MermaidDiagram({
               onClick={handleCopy}
               aria-label={copied ? "Copied" : "Copy diagram source"}
               className={cn(
-                "relative flex items-center gap-2.5 px-4 py-2 rounded-xl text-[10.5px] font-black uppercase tracking-widest transition-all duration-300",
+                "relative flex items-center gap-2.5 px-4 py-2 rounded-xl text-[10.5px] font-black uppercase tracking-widest transition-[color,background-color,transform] duration-300",
                 copied
                   ? "text-white bg-theme-primary shadow-lg shadow-theme-primary/25"
                   : "text-content-secondary bg-bg-base shadow-neu-raised-sm hover:text-content-primary hover:bg-theme-primary/10 active:scale-95",

--- a/src/components/shared/SectionNav.tsx
+++ b/src/components/shared/SectionNav.tsx
@@ -59,7 +59,7 @@ export function SectionNav({
       <div className="max-w-3xl mx-auto px-6 flex justify-center">
         <div
           className={cn(
-            "pointer-events-auto flex items-center p-2 rounded-2xl transition-all duration-500 bg-bg-base",
+            "pointer-events-auto flex items-center p-2 rounded-2xl transition-shadow duration-500 bg-bg-base",
             isNavPinned ? "shadow-neu-raised-scrolled" : "shadow-neu-raised"
           )}
         >

--- a/src/components/shared/ZoomableDiagram.tsx
+++ b/src/components/shared/ZoomableDiagram.tsx
@@ -25,7 +25,7 @@ export function ZoomableDiagram({
         <MermaidDiagram chart={chart} className={className} variant="plain" />
         <button
           onClick={() => setIsZoomOpen(true)}
-          className="absolute top-4 right-4 rounded-xl bg-bg-base shadow-neu-raised-sm p-2 hover:shadow-neu-sunken transition-all z-10"
+          className="absolute top-4 right-4 rounded-xl bg-bg-base shadow-neu-raised-sm p-2 hover:shadow-neu-sunken transition-shadow z-10"
           aria-label="Expand diagram"
         >
           <Maximize2 size={15} className="text-theme-primary" />

--- a/src/components/ui/FloatingCTA.tsx
+++ b/src/components/ui/FloatingCTA.tsx
@@ -74,7 +74,7 @@ export function FloatingCTA() {
 
   return (
     <div
-        className={`fixed bottom-4 right-4 md:bottom-6 md:right-6 z-50 transition-all duration-300 ease-out print:hidden ${isVisible
+        className={`fixed bottom-4 right-4 md:bottom-6 md:right-6 z-50 transition-[opacity,transform] duration-300 ease-out print:hidden ${isVisible
           ? "opacity-100 translate-y-0 scale-100"
           : "opacity-0 translate-y-4 scale-95"
           }`}
@@ -84,7 +84,7 @@ export function FloatingCTA() {
           {/* Dismiss button */}
           <button
             onClick={handleDismiss}
-            className="absolute -top-2 -right-2 w-6 h-6 rounded-full bg-bg-base shadow-neu-raised-sm flex items-center justify-center text-content-secondary hover:text-content-primary hover:shadow-neu-raised-hover transition-all z-20"
+            className="absolute -top-2 -right-2 w-6 h-6 rounded-full bg-bg-base shadow-neu-raised-sm flex items-center justify-center text-content-secondary hover:text-content-primary hover:shadow-neu-raised-hover transition-[box-shadow,color] z-20"
             aria-label="Dismiss"
           >
             <X size={12} aria-hidden="true" />

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -51,7 +51,7 @@ export function Input({
                         "text-content-primary placeholder:text-content-muted",
                         "focus-visible:outline-2 focus-visible:outline-theme-primary focus-visible:outline-offset-2",
                         "focus-visible:ring-2 focus-visible:ring-theme-primary",
-                        "transition-all duration-200",
+                        "transition-shadow duration-200",
                         icon && iconPosition === "left" && "pl-12",
                         icon && iconPosition === "right" && "pr-12",
                         error && "ring-2 ring-theme-error",

--- a/src/components/ui/ThemeToggle.tsx
+++ b/src/components/ui/ThemeToggle.tsx
@@ -16,7 +16,7 @@ export function ThemeToggle({ className, size = 18 }: ThemeToggleProps) {
     <button
       onClick={(e) => toggleTheme(e)}
       className={cn(
-        "neu-circle flex items-center justify-center transition-all duration-300 ease-out",
+        "neu-circle flex items-center justify-center transition-colors duration-300 ease-out",
         "text-content-secondary hover:text-[#149A9B]",
         className
       )}

--- a/src/components/use-cases/UseCasesClient.tsx
+++ b/src/components/use-cases/UseCasesClient.tsx
@@ -184,7 +184,7 @@ export function UseCasesClient() {
                     "relative z-10 flex items-center gap-1.5",
                     "min-w-[44px] min-h-[44px] px-4 sm:px-6 py-2.5",
                     "rounded-xl text-xs sm:text-sm font-bold",
-                    "transition-all duration-300 select-none",
+                    "transition-[color,box-shadow,transform] duration-300 select-none",
                     "touch-manipulation",
                     isActive
                       ? "text-white"
@@ -232,7 +232,7 @@ export function UseCasesClient() {
                   onClick={() => handleUseCaseSwitch(uc.id)}
                   className={cn(
                     "flex items-center gap-2 px-5 py-2.5 rounded-2xl text-sm font-bold",
-                    "transition-all duration-300 select-none touch-manipulation",
+                    "transition-[color,box-shadow] duration-300 select-none touch-manipulation",
                     isActive
                       ? "btn-neumorphic-primary text-white shadow-neu-sunken"
                       : "bg-bg-elevated shadow-neu-raised hover:shadow-neu-raised-hover text-content-secondary hover:text-content-primary",

--- a/src/components/use-cases/shared/CodeIntegrationShowcase.tsx
+++ b/src/components/use-cases/shared/CodeIntegrationShowcase.tsx
@@ -49,7 +49,7 @@ function DocTooltip({ href, label }: { href: string; label: string }) {
         className={cn(
           "flex items-center gap-1.5 rounded-xl px-3 py-1.5",
           "text-[10px] font-bold uppercase tracking-widest text-content-muted",
-          "transition-all duration-200",
+          "transition-colors duration-200",
           "hover:text-theme-primary hover:bg-theme-primary/10"
         )}
       >
@@ -105,7 +105,7 @@ function CopyButton({ code }: { code: string }) {
       className={cn(
         "relative flex items-center gap-2 rounded-xl px-3 py-1.5",
         "text-[10px] font-black uppercase tracking-widest",
-        "transition-all duration-300",
+        "transition-[color,background-color,box-shadow] duration-300",
         copied
           ? "text-white shadow-lg"
           : "text-content-secondary hover:text-content-primary"
@@ -243,7 +243,7 @@ export function CodeIntegrationShowcase({
                     className={cn(
                       "flex items-center gap-1.5 rounded-xl px-4 py-2",
                       "text-[11px] font-bold uppercase tracking-widest font-mono",
-                      "transition-all duration-200 focus:outline-none",
+                      "transition-[color,background-color,box-shadow] duration-200 focus:outline-none",
                       isActive
                         ? "text-theme-primary"
                         : "text-content-muted hover:text-content-secondary"

--- a/src/components/use-cases/shared/EscrowFlowDiagram.tsx
+++ b/src/components/use-cases/shared/EscrowFlowDiagram.tsx
@@ -3,7 +3,6 @@
 import { useState, useRef, useCallback, useId } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { cn } from "@/lib/cn";
-import { useMediaQuery } from "@/hooks/useMediaQuery";
 
 export interface EscrowStep {
   stepNumber: number;
@@ -99,7 +98,7 @@ function StepCard({
       aria-expanded={isActive}
       aria-label={`Step ${step.stepNumber}: ${step.label}`}
       className={cn(
-        "flex flex-col p-5 md:p-6 rounded-[1.5rem] bg-bg-elevated transition-all duration-300 ease-out cursor-pointer select-none",
+        "flex flex-col p-5 md:p-6 rounded-[1.5rem] bg-bg-elevated transition-elevation cursor-pointer select-none",
         "w-full md:flex-1 min-w-0",
         "animate-fadeInUp",
         isActive
@@ -151,10 +150,10 @@ function StepCard({
   );
 }
 
-function ConnectorLine({ vertical }: { vertical: boolean }) {
-  if (vertical) {
-    return (
-      <div className="flex justify-center py-1">
+function ConnectorLine() {
+  return (
+    <>
+      <div className="flex md:hidden justify-center py-1">
         <svg width="2" height="32" className="overflow-visible">
           <line
             x1="1"
@@ -169,25 +168,23 @@ function ConnectorLine({ vertical }: { vertical: boolean }) {
           />
         </svg>
       </div>
-    );
-  }
 
-  return (
-    <div className="hidden md:flex items-center justify-center flex-shrink-0 w-8 lg:w-12">
-      <svg width="100%" height="2" className="overflow-visible">
-        <line
-          x1="0"
-          y1="1"
-          x2="100%"
-          y2="1"
-          stroke="var(--color-primary)"
-          strokeWidth="2"
-          strokeDasharray="6 6"
-          strokeOpacity="0.4"
-          className="animate-connectorDash"
-        />
-      </svg>
-    </div>
+      <div className="hidden md:flex items-center justify-center flex-shrink-0 w-8 lg:w-12">
+        <svg width="100%" height="2" className="overflow-visible">
+          <line
+            x1="0"
+            y1="1"
+            x2="100%"
+            y2="1"
+            stroke="var(--color-primary)"
+            strokeWidth="2"
+            strokeDasharray="6 6"
+            strokeOpacity="0.4"
+            className="animate-connectorDash"
+          />
+        </svg>
+      </div>
+    </>
   );
 }
 
@@ -253,7 +250,6 @@ export function EscrowFlowDiagram({
   className,
 }: EscrowFlowDiagramProps) {
   const [activeStep, setActiveStep] = useState<number | null>(null);
-  const isMobile = useMediaQuery("(max-width: 767px)");
 
   const isOnChainActive =
     activeStep !== null && steps[activeStep - 1]?.isOnChain;
@@ -267,15 +263,10 @@ export function EscrowFlowDiagram({
     >
       <BlockchainPulse active={!!isOnChainActive} />
 
-      <div
-        className={cn(
-          "relative z-10 flex gap-3 h-full",
-          isMobile ? "flex-col" : "flex-row items-start",
-        )}
-      >
+      <div className="relative z-10 flex flex-col md:flex-row md:items-start gap-3 h-full">
         {steps.map((step, i) => (
           <div key={step.stepNumber} className="contents">
-            {i > 0 && <ConnectorLine vertical={isMobile} />}
+            {i > 0 && <ConnectorLine />}
             <StepCard
               step={step}
               index={i}

--- a/src/components/use-cases/shared/SectionLayout.tsx
+++ b/src/components/use-cases/shared/SectionLayout.tsx
@@ -29,9 +29,9 @@ export function FeaturesGrid({ features }: { features: FeatureCard[] }) {
             return (
               <div
                 key={feat.title}
-                className="flex flex-col items-center text-center p-10 rounded-[2rem] bg-bg-elevated shadow-neu-raised hover:shadow-neu-raised-hover transition-all duration-300 ease-out group"
+                className="flex flex-col items-center text-center p-10 rounded-[2rem] bg-bg-elevated shadow-neu-raised hover:shadow-neu-raised-hover transition-shadow duration-300 ease-out group"
               >
-                <div className="w-16 h-16 rounded-2xl shadow-neu-sunken-subtle bg-bg-base flex items-center justify-center mb-8 group-hover:shadow-neu-sunken transition-all duration-300 text-theme-primary">
+                <div className="w-16 h-16 rounded-2xl shadow-neu-sunken-subtle bg-bg-base flex items-center justify-center mb-8 group-hover:shadow-neu-sunken transition-shadow duration-300 text-theme-primary">
                   <FeatIcon size={28} />
                 </div>
                 <h3 className="text-xl font-bold mb-4 text-content-primary">

--- a/src/components/use-cases/shared/StellarImpactCards.tsx
+++ b/src/components/use-cases/shared/StellarImpactCards.tsx
@@ -180,7 +180,7 @@ function ModeToggleDetailed({
           key={key}
           onClick={() => onChange(key)}
           className={cn(
-            "relative flex items-center gap-2 px-4 py-2 rounded-xl text-xs font-bold transition-all duration-300",
+            "relative flex items-center gap-2 px-4 py-2 rounded-xl text-xs font-bold transition-[color,box-shadow] duration-300",
             mode === key
               ? "text-theme-primary shadow-neu-raised"
               : "text-content-muted hover:text-content-secondary",
@@ -339,7 +339,7 @@ function DetailedMetricCardComponent({
       onClick={() => setExpanded((p) => !p)}
       className={cn(
         "relative rounded-[1.75rem] bg-bg-elevated cursor-pointer select-none",
-        "p-6 md:p-7 transition-all duration-300",
+        "p-6 md:p-7 transition-shadow duration-300",
         "shadow-neu-raised hover:shadow-neu-raised-hover",
         "overflow-hidden",
       )}

--- a/src/components/use-cases/shared/UseCaseHero.tsx
+++ b/src/components/use-cases/shared/UseCaseHero.tsx
@@ -246,7 +246,7 @@ export function UseCaseHero({
                       duration: 0.5,
                       ease: [0.22, 1, 0.36, 1],
                     }}
-                    className="rounded-[1.75rem] border border-theme-primary/10 bg-bg-base/95 p-5 shadow-neu-raised"
+                    className="rounded-[1.75rem] border border-theme-primary/10 bg-bg-base/95 p-5 shadow-neu-raised transition-elevation hover:shadow-neu-raised-hover"
                   >
                     <div className="flex items-start justify-between gap-4">
                       <div>

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -9,9 +9,7 @@ import { useEffect, useState } from "react";
  * listener.
  */
 export function useMediaQuery(query: string): boolean {
-  const [matches, setMatches] = useState(() =>
-    typeof window === "undefined" ? false : window.matchMedia(query).matches
-  );
+  const [matches, setMatches] = useState(false);
 
   useEffect(() => {
     const mql = window.matchMedia(query);


### PR DESCRIPTION
## 🔧 Title:
Fix theme hydration/FOUC and make the motion system actually neumorphic

## 🛠️ Issue

- Closes #1500

## 📚 Description

Two problems shared a root cause — visual state was decided after React
hydrated instead of before — plus a motion system that never expressed the
neumorphic design language it's built on. This PR fixes both.

## ✅ Changes applied

**Theme hydration / FOUC**
- Added a blocking inline script in `<head>` that reads the stored/system
  theme and applies the `light`/`dark` class to `documentElement` before
  first paint, eliminating the white flash on dark-mode reloads.
- `ThemeProvider` no longer seeds `resolvedTheme` unconditionally to
  `"light"` and never re-touches; it now resolves from the DOM class the
  blocking script already applied, seeded safely for SSR/hydration parity.
- `suppressHydrationWarning` on `<html>` is kept, annotated with why it's
  needed (the blocking script mutates the class before hydration).
- `useMediaQuery` now seeds `false` on both server and the hydration
  render, removing the mismatch; `EscrowFlowDiagram`'s layout switch was
  moved to pure CSS breakpoints instead of the JS hook.
- `Footer`'s copyright year and `DocPageActions`' download filenames no
  longer compute `Date` values during render.

**Neumorphic motion system**
- Added a shared elevation-transition utility (box-shadow only) and
  applied it to `/use-cases` interactive surfaces (step cards, tab
  selection, "At a glance" panels) so they press/lift instead of fading.
- Replaced all 87 `transition-all` usages across 44 files with explicit
  property lists; every `hover:shadow-*` interaction now transitions
  `box-shadow` explicitly instead of riding along on `transition-all`.
- Fixed dead animation classes (`animate-fade-in-up` → `animate-fadeInUp`;
  replaced the unused `tailwindcss-animate` classes in `DocsSearchBar`
  with a local keyframe).
- Added a `lint:classes` script + CI step that fails on `animate-*`/
  `shadow-*` classes with no matching definition.

**Tests**
- Added `ThemeProvider` resolution-order tests and confirmed existing
  `useMediaQuery` tests already encode the SSR-safe contract.

## 🔍 Evidence/Media (screenshots/videos)

- `npm run build` passes.
- `npx vitest run` — 407/407 tests passing.
- `npm run lint` / `npm run lint:classes` pass.
- Verified via a production server (`next build && next start`) that the
  blocking theme script is present in the served HTML before `<body>`.