### PR TITLE
feat(docs): add Connect with MCP / VSCode / Claude Code / Codex one-click actions

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,6 +1,8 @@
 # OFFER-HUB MCP Documentation Server
 
-A [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that exposes OFFER-HUB documentation to AI assistants like Claude, ChatGPT, and Cursor. This allows developers to query the official documentation directly from their AI assistant.
+A [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that exposes OFFER-HUB documentation to AI assistants like Claude, ChatGPT, Cursor, and Codex. This allows developers to query the official documentation directly from their AI assistant.
+
+The server is hosted and reachable over MCP's **Streamable HTTP** transport at a stable production URL, so there is no local installation or stdio setup required — the docs site's page-actions menu ("Connect with MCP", "Connect to VSCode", "Connect to Claude Code", "Connect to Codex") wires these up with one click.
 
 ## Features
 
@@ -8,22 +10,57 @@ A [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that e
 - **get_doc_page**: Retrieve full content of a specific documentation page by slug
 - **list_doc_sections**: List all available documentation sections and pages
 
-## Installation & Usage
+## Hosted endpoint
 
-### Recommended: Hosted HTTP Transport
+The recommended way to connect is the hosted server — no clone, build, or absolute-path config needed:
 
-This MCP server is deployed within the main OFFER-HUB Next.js application as a serverless endpoint. You can configure your AI assistants to connect to the remote endpoint without running any local servers.
+```
+https://offer-hub.tech/api/mcp
+```
 
-#### Using Smithery / Hosted HTTP (Streamable HTTP)
+The server is deployed within the main OFFER-HUB Next.js application as a serverless Streamable HTTP endpoint. You can configure your AI assistants to connect to the remote endpoint without running any local servers.
 
-To connect via the remote HTTP endpoint in Claude Desktop, Cursor, or similar tools, you can use the MCP HTTP transport or Smithery CLI if supported.
-Since direct HTTP transport configuration depends on the assistant's implementation, refer to their latest documentation for connecting to a remote MCP URL.
-The production endpoint is accessible at:
-`https://offer-hub.tech/api/mcp`
+### Connect (one click)
 
-### Fallback: Local stdio Transport (For Development)
+**Generic MCP config (Claude Desktop, Cursor, `.mcp.json`)** — paste into any client that reads the `mcpServers` format:
 
-If you prefer to run the server locally over stdio (the standard local MCP method):
+```json
+{
+  "mcpServers": {
+    "offer-hub-docs": {
+      "type": "http",
+      "url": "https://offer-hub.tech/api/mcp"
+    }
+  }
+}
+```
+
+**VS Code** — click the install deep link (or open it in a browser):
+
+```
+vscode:mcp/install?%7B%22name%22%3A%22offer-hub-docs%22%2C%22transportType%22%3A%22http%22%2C%22url%22%3A%22https%3A%2F%2Foffer-hub.tech%2Fapi%2Fmcp%22%7D
+```
+
+**Claude Code** — run in your terminal:
+
+```bash
+claude mcp add --transport http offer-hub-docs https://offer-hub.tech/api/mcp
+```
+
+**Codex** — add to `~/.codex/config.toml` (or a project-scoped `.codex/config.toml`):
+
+```toml
+[mcp_servers.offer-hub-docs]
+url = "https://offer-hub.tech/api/mcp"
+```
+
+> **Note on remote HTTP transport** — since direct HTTP transport configuration depends on the assistant's implementation, refer to your assistant's latest documentation for connecting to a remote MCP URL. Some clients also support provisioning the hosted endpoint via Smithery.
+
+## Installation (local development only)
+
+Running the server locally from source is only needed when you want to develop the server itself. To connect to the docs, prefer the hosted endpoint above.
+
+### Option 1: Run from Source (Recommended for Development)
 
 ```bash
 # Navigate to the mcp directory
@@ -47,12 +84,29 @@ npx @offer-hub/mcp-docs-server
 
 ## Configuration
 
-### Claude Desktop (Local stdio)
+All clients below can use the hosted endpoint (recommended, see [Hosted endpoint](#hosted-endpoint)). The local stdio examples are kept as a development fallback for when you're running the server from source.
+
+### Claude Desktop
 
 Add the following to your Claude Desktop configuration file:
 
 **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
 **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+
+Hosted endpoint:
+
+```json
+{
+  "mcpServers": {
+    "offer-hub-docs": {
+      "type": "http",
+      "url": "https://offer-hub.tech/api/mcp"
+    }
+  }
+}
+```
+
+Local stdio (development fallback):
 
 ```json
 {
@@ -78,9 +132,15 @@ Or with npx (after publishing):
 }
 ```
 
-### Claude Code (CLI) (Local stdio)
+### Claude Code (CLI)
 
-Add to your `~/.claude.json` or project's `.mcp.json`:
+Hosted endpoint (one command):
+
+```bash
+claude mcp add --transport http offer-hub-docs https://offer-hub.tech/api/mcp
+```
+
+Local stdio (development fallback) — add to your `~/.claude.json` or project's `.mcp.json`:
 
 ```json
 {
@@ -93,9 +153,24 @@ Add to your `~/.claude.json` or project's `.mcp.json`:
 }
 ```
 
-### Cursor (Local stdio)
+### Cursor
 
-Add to your Cursor MCP configuration:
+Add to your Cursor MCP configuration.
+
+Hosted endpoint:
+
+```json
+{
+  "mcpServers": {
+    "offer-hub-docs": {
+      "type": "http",
+      "url": "https://offer-hub.tech/api/mcp"
+    }
+  }
+}
+```
+
+Local stdio (development fallback):
 
 ```json
 {
@@ -108,9 +183,22 @@ Add to your Cursor MCP configuration:
 }
 ```
 
-### VS Code with Claude Extension (Local stdio)
+### VS Code
 
-Add to your workspace `.vscode/mcp.json`:
+Click the [one-click install deep link](#connect-one-click), or add to your workspace `.vscode/mcp.json`:
+
+```json
+{
+  "servers": {
+    "offer-hub-docs": {
+      "type": "http",
+      "url": "https://offer-hub.tech/api/mcp"
+    }
+  }
+}
+```
+
+Local stdio (development fallback):
 
 ```json
 {
@@ -121,6 +209,15 @@ Add to your workspace `.vscode/mcp.json`:
     }
   }
 }
+```
+
+### Codex
+
+Add to `~/.codex/config.toml` (or a project-scoped `.codex/config.toml`):
+
+```toml
+[mcp_servers.offer-hub-docs]
+url = "https://offer-hub.tech/api/mcp"
 ```
 
 ## Usage Examples

--- a/src/components/docs/McpConnectDialog.tsx
+++ b/src/components/docs/McpConnectDialog.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { Check, Copy, X } from "lucide-react";
+
+import { MCP_SERVER_NAME, MCP_SERVER_URL } from "@/constants/mcp";
+import { buildMcpConfigSnippet, copyTextToClipboard } from "@/utils/mcp-connect";
+import { logger } from "@/utils/logger";
+import { useBodyScrollLock } from "@/hooks/useBodyScrollLock";
+import { useFocusTrap } from "@/hooks/useFocusTrap";
+
+interface McpConnectDialogProps {
+  onClose: () => void;
+}
+
+type CopiedTarget = "url" | "snippet" | null;
+
+export function McpConnectDialog({ onClose }: McpConnectDialogProps) {
+  const panelRef = useRef<HTMLDivElement>(null);
+  const [copied, setCopied] = useState<CopiedTarget>(null);
+  const snippet = buildMcpConfigSnippet();
+
+  useBodyScrollLock(true);
+  useFocusTrap({ containerRef: panelRef, isActive: true, onEscape: onClose });
+
+  async function handleCopy(target: Exclude<CopiedTarget, null>) {
+    try {
+      await copyTextToClipboard(target === "url" ? MCP_SERVER_URL : snippet);
+      setCopied(target);
+      setTimeout(() => setCopied(null), 1500);
+    } catch (error) {
+      logger.error("Failed to copy MCP connection details", error);
+    }
+  }
+
+  const copyButtonClasses =
+    "inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs font-medium text-content-secondary hover:text-theme-primary focus-visible:outline-2 focus-visible:outline-theme-primary focus-visible:outline-offset-2 transition-colors";
+
+  return (
+    <div className="fixed inset-0 z-[150] flex items-center justify-center p-4">
+      <div
+        className="absolute inset-0 bg-black/20 dark:bg-black/40 backdrop-blur-sm animate-fadeIn"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="mcp-connect-title"
+        className="relative w-full max-w-lg rounded-2xl bg-bg-elevated border border-theme-border/40 shadow-2xl shadow-black/10 p-6 animate-fadeIn"
+      >
+        <div className="mb-4 flex items-start justify-between gap-4">
+          <div>
+            <h2
+              id="mcp-connect-title"
+              className="text-lg font-semibold text-content-primary"
+            >
+              Connect with MCP
+            </h2>
+            <p className="mt-1 text-sm text-content-secondary">
+              Add the OFFER-HUB docs to your AI assistant as an MCP server.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close Connect with MCP dialog"
+            className="rounded-lg p-2 text-content-secondary hover:text-content-primary focus-visible:outline-2 focus-visible:outline-theme-primary focus-visible:outline-offset-2 transition-colors"
+          >
+            <X size={18} aria-hidden="true" />
+          </button>
+        </div>
+
+        <div className="space-y-4">
+          <div>
+            <p className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-content-secondary">
+              Server URL
+            </p>
+            <div className="flex items-center gap-2 rounded-xl bg-bg-sunken px-3 py-2.5">
+              <code className="flex-1 min-w-0 truncate text-sm text-content-primary">
+                {MCP_SERVER_URL}
+              </code>
+              <button
+                type="button"
+                onClick={() => handleCopy("url")}
+                aria-label="Copy server URL"
+                className={copyButtonClasses}
+              >
+                {copied === "url" ? <Check size={14} /> : <Copy size={14} />}
+                <span>{copied === "url" ? "Copied!" : "Copy"}</span>
+              </button>
+            </div>
+          </div>
+
+          <div>
+            <p className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-content-secondary">
+              Config snippet
+            </p>
+            <div className="relative rounded-xl bg-bg-sunken px-3 py-2.5">
+              <pre className="overflow-x-auto pr-14 text-xs leading-relaxed text-content-primary">
+                <code>{snippet}</code>
+              </pre>
+              <button
+                type="button"
+                onClick={() => handleCopy("snippet")}
+                aria-label="Copy config snippet"
+                className={`${copyButtonClasses} absolute right-2 top-2 bg-bg-elevated`}
+              >
+                {copied === "snippet" ? <Check size={14} /> : <Copy size={14} />}
+                <span>{copied === "snippet" ? "Copied!" : "Copy"}</span>
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <p className="mt-4 text-xs text-content-muted">
+          Paste this into any MCP client that reads the{" "}
+          <code className="text-content-secondary">mcpServers</code> format —
+          Claude Desktop, Cursor, or a Claude Code{" "}
+          <code className="text-content-secondary">.mcp.json</code> file. The
+          server name is <code className="text-content-secondary">{MCP_SERVER_NAME}</code>.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/docs/PageActionsMenu.tsx
+++ b/src/components/docs/PageActionsMenu.tsx
@@ -4,6 +4,7 @@ import { Fragment, useEffect, useRef, useState } from "react";
 import type { LucideIcon } from "lucide-react";
 import {
   Bot,
+  Braces,
   Check,
   ChevronDown,
   Copy,
@@ -14,7 +15,17 @@ import {
   Github,
   Loader2,
   MessageSquare,
+  Plug,
+  SquareCode,
+  Terminal,
 } from "lucide-react";
+import { McpConnectDialog } from "@/components/docs/McpConnectDialog";
+import {
+  buildClaudeCodeMcpCommand,
+  buildCodexMcpConfigSnippet,
+  buildVscodeMcpInstallLink,
+  copyTextToClipboard,
+} from "@/utils/mcp-connect";
 import { logger } from "@/utils/logger";
 import { SITE_URL_FALLBACK } from "@/constants/site";
 import { DOCS_EDIT_BASE } from "@/constants/github";
@@ -37,10 +48,9 @@ interface PageActionsMenuProps {
 }
 
 /**
- * Groups menu items for divider placement. "connect" is reserved for
- * follow-up issues (Connect with MCP / VSCode / Claude Code / Codex) —
- * appending items with that group inserts a divider before them
- * automatically, with no changes needed elsewhere in this component.
+ * Groups menu items for divider placement. "connect" holds the one-click
+ * "Connect with MCP / VSCode / Claude Code / Codex" actions; appending items
+ * with that group inserts a divider before them automatically.
  */
 type MenuItemGroup = "copy" | "export" | "connect";
 
@@ -64,13 +74,17 @@ interface LinkMenuItem extends MenuItemBase {
 
 type DocPageMenuItem = ButtonMenuItem | LinkMenuItem;
 
+type CopiedItem = "page" | "claude" | "codex" | null;
+
 export function PageActionsMenu({ slug, title, description, markdownContent }: PageActionsMenuProps) {
   const [isOpen, setIsOpen] = useState(false);
-  const [copied, setCopied] = useState(false);
+  const [isMcpDialogOpen, setIsMcpDialogOpen] = useState(false);
+  const [copiedItem, setCopiedItem] = useState<CopiedItem>(null);
   const [isExportingPdf, setIsExportingPdf] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const itemRefs = useRef<Array<HTMLButtonElement | HTMLAnchorElement | null>>([]);
+  const copyResetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const rawMarkdownUrl = `/docs/${slug}/raw`;
   const absoluteRawMarkdownUrl = `${SITE_URL}${rawMarkdownUrl}`;
@@ -98,6 +112,14 @@ export function PageActionsMenu({ slug, title, description, markdownContent }: P
     }
   }, [isOpen]);
 
+  useEffect(() => {
+    return () => {
+      if (copyResetTimerRef.current) {
+        clearTimeout(copyResetTimerRef.current);
+      }
+    };
+  }, []);
+
   function closeMenu() {
     setIsOpen(false);
     triggerRef.current?.focus();
@@ -121,11 +143,27 @@ export function PageActionsMenu({ slug, title, description, markdownContent }: P
     }
   }
 
+  function flashCopied(item: CopiedItem) {
+    setCopiedItem(item);
+    if (copyResetTimerRef.current) {
+      clearTimeout(copyResetTimerRef.current);
+    }
+    copyResetTimerRef.current = setTimeout(() => setCopiedItem(null), 1500);
+  }
+
+  async function copyToClipboard(text: string, item: Exclude<CopiedItem, null>) {
+    try {
+      await copyTextToClipboard(text);
+      flashCopied(item);
+    } catch (error) {
+      logger.error("Failed to copy to clipboard", error);
+    }
+  }
+
   async function handleCopyPage() {
     try {
-      await navigator.clipboard.writeText(markdownContent);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1500);
+      await copyTextToClipboard(markdownContent);
+      flashCopied("page");
     } catch (error) {
       logger.error("Failed to copy page markdown", error);
     } finally {
@@ -161,13 +199,31 @@ export function PageActionsMenu({ slug, title, description, markdownContent }: P
     }
   }
 
+  function handleConnectWithMcp() {
+    closeMenu();
+    setIsMcpDialogOpen(true);
+  }
+
+  function handleCloseMcpDialog() {
+    setIsMcpDialogOpen(false);
+    triggerRef.current?.focus();
+  }
+
+  function handleCopyClaudeCodeCommand() {
+    void copyToClipboard(buildClaudeCodeMcpCommand(), "claude");
+  }
+
+  function handleCopyCodexConfig() {
+    void copyToClipboard(buildCodexMcpConfigSnippet(), "codex");
+  }
+
   const items: DocPageMenuItem[] = [
     {
       id: "copy-page",
       kind: "button",
       group: "copy",
-      icon: copied ? Check : Copy,
-      label: copied ? "Copied!" : "Copy page",
+      icon: copiedItem === "page" ? Check : Copy,
+      label: copiedItem === "page" ? "Copied!" : "Copy page",
       onSelect: handleCopyPage,
     },
     {
@@ -227,6 +283,38 @@ export function PageActionsMenu({ slug, title, description, markdownContent }: P
       label: "Edit on GitHub",
       href: githubEditUrl,
     },
+    {
+      id: "connect-mcp",
+      kind: "button",
+      group: "connect",
+      icon: Plug,
+      label: "Connect with MCP",
+      onSelect: handleConnectWithMcp,
+    },
+    {
+      id: "connect-vscode",
+      kind: "link",
+      group: "connect",
+      icon: SquareCode,
+      label: "Connect to VSCode",
+      href: buildVscodeMcpInstallLink(),
+    },
+    {
+      id: "connect-claude-code",
+      kind: "button",
+      group: "connect",
+      icon: copiedItem === "claude" ? Check : Terminal,
+      label: copiedItem === "claude" ? "Copied!" : "Connect to Claude Code",
+      onSelect: handleCopyClaudeCodeCommand,
+    },
+    {
+      id: "connect-codex",
+      kind: "button",
+      group: "connect",
+      icon: copiedItem === "codex" ? Check : Braces,
+      label: copiedItem === "codex" ? "Copied!" : "Connect to Codex",
+      onSelect: handleCopyCodexConfig,
+    },
   ];
 
   return (
@@ -240,8 +328,8 @@ export function PageActionsMenu({ slug, title, description, markdownContent }: P
         aria-controls="page-actions-menu"
         className="neu-circle h-10 flex items-center gap-2 px-4 text-sm font-medium text-content-secondary hover:text-theme-primary focus-visible:outline-2 focus-visible:outline-theme-primary focus-visible:outline-offset-2 focus-visible:ring-2 focus-visible:ring-theme-primary focus-visible:ring-offset-2 focus-visible:ring-offset-bg-sunken"
       >
-        {copied ? <Check size={16} /> : <Copy size={16} />}
-        <span>{copied ? "Copied!" : "Copy page"}</span>
+        {copiedItem === "page" ? <Check size={16} /> : <Copy size={16} />}
+        <span>{copiedItem === "page" ? "Copied!" : "Copy page"}</span>
         <ChevronDown size={14} className={isOpen ? "rotate-180 transition-transform" : "transition-transform"} />
       </button>
 
@@ -295,6 +383,8 @@ export function PageActionsMenu({ slug, title, description, markdownContent }: P
           })}
         </div>
       )}
+
+      {isMcpDialogOpen && <McpConnectDialog onClose={handleCloseMcpDialog} />}
     </div>
   );
 }

--- a/src/components/docs/__tests__/PageActionsMenu.test.tsx
+++ b/src/components/docs/__tests__/PageActionsMenu.test.tsx
@@ -3,6 +3,20 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { PageActionsMenu } from "../PageActionsMenu";
 import { DOCS_EDIT_BASE } from "@/constants/github";
+import { MCP_SERVER_URL } from "@/constants/mcp";
+import {
+  buildClaudeCodeMcpCommand,
+  buildCodexMcpConfigSnippet,
+  buildMcpConfigSnippet,
+  buildVscodeMcpInstallLink,
+} from "@/utils/mcp-connect";
+
+function mockClipboard(writeText: ReturnType<typeof vi.fn>) {
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    configurable: true,
+  });
+}
 
 const loggerError = vi.fn();
 const exportDocMarkdown = vi.fn();
@@ -78,10 +92,14 @@ describe("PageActionsMenu", () => {
       "Export JSON",
       "Export PDF",
       "Edit on GitHub",
+      "Connect with MCP",
+      "Connect to VSCode",
+      "Connect to Claude Code",
+      "Connect to Codex",
     ]);
   });
 
-  it("renders exactly one divider between the copy/AI group and the export group", async () => {
+  it("renders exactly two dividers: copy/AI → export, and export → connect", async () => {
     const user = userEvent.setup({ delay: null });
     renderMenu();
 
@@ -89,15 +107,22 @@ describe("PageActionsMenu", () => {
 
     const menu = screen.getByRole("menu");
     const separators = screen.getAllByRole("separator");
-    expect(separators).toHaveLength(1);
+    expect(separators).toHaveLength(2);
 
     const children = Array.from(menu.children);
-    const separatorIndex = children.indexOf(separators[0]);
-    const exportMarkdownIndex = children.findIndex((child) => child.textContent === "Export Markdown");
-    const openClaudeIndex = children.findIndex((child) => child.textContent === "Open in Claude");
+    const [copyExportSeparator, exportConnectSeparator] = separators;
 
-    expect(separatorIndex).toBeGreaterThan(openClaudeIndex);
-    expect(separatorIndex).toBeLessThan(exportMarkdownIndex);
+    const copyExportSeparatorIndex = children.indexOf(copyExportSeparator);
+    const openClaudeIndex = children.findIndex((child) => child.textContent === "Open in Claude");
+    const exportMarkdownIndex = children.findIndex((child) => child.textContent === "Export Markdown");
+    expect(copyExportSeparatorIndex).toBeGreaterThan(openClaudeIndex);
+    expect(copyExportSeparatorIndex).toBeLessThan(exportMarkdownIndex);
+
+    const exportConnectSeparatorIndex = children.indexOf(exportConnectSeparator);
+    const editGithubIndex = children.findIndex((child) => child.textContent === "Edit on GitHub");
+    const connectMcpIndex = children.findIndex((child) => child.textContent === "Connect with MCP");
+    expect(exportConnectSeparatorIndex).toBeGreaterThan(editGithubIndex);
+    expect(exportConnectSeparatorIndex).toBeLessThan(connectMcpIndex);
   });
 
   it("closes the menu on Escape and returns focus to the trigger", async () => {
@@ -132,7 +157,7 @@ describe("PageActionsMenu", () => {
     });
   });
 
-  it("moves focus between all 8 items with ArrowDown/ArrowUp, wrapping at both ends", async () => {
+  it("moves focus between all 12 items with ArrowDown/ArrowUp, wrapping at both ends", async () => {
     const user = userEvent.setup({ delay: null });
     renderMenu();
 
@@ -147,6 +172,10 @@ describe("PageActionsMenu", () => {
       /export json/i,
       /^export pdf$/i,
       /edit on github/i,
+      /connect with mcp/i,
+      /connect to vscode/i,
+      /connect to claude code/i,
+      /connect to codex/i,
     ];
     const orderedItems = orderedLabels.map((name) => screen.getByRole("menuitem", { name }));
 
@@ -389,5 +418,100 @@ describe("PageActionsMenu", () => {
         expect(screen.queryByRole("menu")).not.toBeInTheDocument();
       });
     });
+  });
+
+  it("shows the four one-click MCP connect actions in the menu", async () => {
+    const user = userEvent.setup({ delay: null });
+    renderMenu();
+
+    await openMenu(user);
+
+    expect(screen.getByRole("menuitem", { name: /connect with mcp/i })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /connect to vscode/i })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /connect to claude code/i })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /connect to codex/i })).toBeInTheDocument();
+  });
+
+  it("links Connect to VSCode to the hosted MCP install deep link", async () => {
+    const user = userEvent.setup({ delay: null });
+    renderMenu();
+
+    await openMenu(user);
+
+    const link = screen.getByRole("menuitem", { name: /connect to vscode/i });
+    expect(link).toHaveAttribute("href", buildVscodeMcpInstallLink());
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("copies the hosted claude mcp add command from Connect to Claude Code", async () => {
+    const user = userEvent.setup({ delay: null });
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    mockClipboard(writeText);
+
+    renderMenu();
+    await openMenu(user);
+    await user.click(screen.getByRole("menuitem", { name: /connect to claude code/i }));
+
+    expect(writeText).toHaveBeenCalledWith(buildClaudeCodeMcpCommand());
+    await waitFor(() => {
+      expect(screen.getByRole("menuitem", { name: "Copied!" })).toBeInTheDocument();
+    });
+  });
+
+  it("copies the hosted Codex config snippet from Connect to Codex", async () => {
+    const user = userEvent.setup({ delay: null });
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    mockClipboard(writeText);
+
+    renderMenu();
+    await openMenu(user);
+    await user.click(screen.getByRole("menuitem", { name: /connect to codex/i }));
+
+    expect(writeText).toHaveBeenCalledWith(buildCodexMcpConfigSnippet());
+    await waitFor(() => {
+      expect(screen.getByRole("menuitem", { name: "Copied!" })).toBeInTheDocument();
+    });
+  });
+
+  it("opens the Connect with MCP dialog showing the hosted URL and a copyable config snippet", async () => {
+    const user = userEvent.setup({ delay: null });
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    mockClipboard(writeText);
+
+    renderMenu();
+    await openMenu(user);
+    await user.click(screen.getByRole("menuitem", { name: /connect with mcp/i }));
+
+    const dialog = await screen.findByRole("dialog", { name: /connect with mcp/i });
+    expect(dialog).toHaveTextContent(MCP_SERVER_URL);
+    // jsdom collapses whitespace in the <pre>, so assert the snippet's key
+    // fragments rather than the pretty-printed JSON verbatim — the clipboard
+    // assertion below pins the exact string that gets copied.
+    expect(dialog).toHaveTextContent("mcpServers");
+    expect(dialog).toHaveTextContent('"type": "http"');
+
+    await user.click(screen.getByRole("button", { name: /copy config snippet/i }));
+    expect(writeText).toHaveBeenCalledWith(buildMcpConfigSnippet());
+
+    await user.click(screen.getByRole("button", { name: /copy server url/i }));
+    expect(writeText).toHaveBeenCalledWith(MCP_SERVER_URL);
+  });
+
+  it("closes the Connect with MCP dialog on Escape and returns focus to the trigger", async () => {
+    const user = userEvent.setup({ delay: null });
+    renderMenu();
+
+    const trigger = screen.getByRole("button", { name: /copy page/i });
+    await openMenu(user);
+    await user.click(screen.getByRole("menuitem", { name: /connect with mcp/i }));
+
+    await screen.findByRole("dialog", { name: /connect with mcp/i });
+    await user.keyboard("{Escape}");
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+    expect(trigger).toHaveFocus();
   });
 });

--- a/src/constants/mcp.ts
+++ b/src/constants/mcp.ts
@@ -1,0 +1,9 @@
+/**
+ * Hosted docs MCP server (companion hosting issue #1535).
+ *
+ * `mcp/` is exposed over the MCP Streamable HTTP transport at this stable
+ * production URL. Every one-click "Connect to …" action in the docs
+ * page-actions menu points here — never at a local stdio server.
+ */
+export const MCP_SERVER_NAME = "offer-hub-docs";
+export const MCP_SERVER_URL = "https://offer-hub.tech/api/mcp";

--- a/src/utils/__tests__/mcp-connect.test.ts
+++ b/src/utils/__tests__/mcp-connect.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+
+import { MCP_SERVER_NAME, MCP_SERVER_URL } from "@/constants/mcp";
+import {
+  buildClaudeCodeMcpCommand,
+  buildCodexMcpConfigSnippet,
+  buildMcpConfigSnippet,
+  buildVscodeMcpInstallLink,
+} from "@/utils/mcp-connect";
+
+describe("mcp-connect builders", () => {
+  it("points every builder at the hosted endpoint, never a local stdio server", () => {
+    const outputs = [
+      buildMcpConfigSnippet(),
+      buildClaudeCodeMcpCommand(),
+      buildCodexMcpConfigSnippet(),
+    ];
+
+    for (const output of outputs) {
+      expect(output).toContain(MCP_SERVER_URL);
+      expect(output).not.toMatch(/stdio|localhost|127\.0\.0\.1|absolute/);
+    }
+
+    // The VS Code deep link URL-encodes the endpoint inside the query string.
+    const decodedVscodeLink = decodeURIComponent(buildVscodeMcpInstallLink());
+    expect(decodedVscodeLink).toContain(MCP_SERVER_URL);
+    expect(decodedVscodeLink).not.toMatch(/stdio|localhost|127\.0\.0\.1|absolute/);
+  });
+
+  it("builds a generic mcpServers config snippet with the http transport", () => {
+    const snippet = buildMcpConfigSnippet();
+    const parsed = JSON.parse(snippet) as {
+      mcpServers: Record<string, { type: string; url: string }>;
+    };
+
+    expect(parsed.mcpServers[MCP_SERVER_NAME]).toEqual({
+      type: "http",
+      url: MCP_SERVER_URL,
+    });
+  });
+
+  it("builds a VS Code install deep link with the URL-encoded http server config", () => {
+    const link = buildVscodeMcpInstallLink();
+
+    expect(link.startsWith("vscode:mcp/install?")).toBe(true);
+
+    const encoded = link.slice("vscode:mcp/install?".length);
+    const decoded = JSON.parse(decodeURIComponent(encoded)) as {
+      name: string;
+      transportType: string;
+      url: string;
+    };
+
+    expect(decoded).toEqual({
+      name: MCP_SERVER_NAME,
+      transportType: "http",
+      url: MCP_SERVER_URL,
+    });
+  });
+
+  it("builds the claude mcp add command for the hosted server", () => {
+    expect(buildClaudeCodeMcpCommand()).toBe(
+      `claude mcp add --transport http ${MCP_SERVER_NAME} ${MCP_SERVER_URL}`,
+    );
+  });
+
+  it("builds a Codex config.toml snippet for the hosted server", () => {
+    expect(buildCodexMcpConfigSnippet()).toBe(
+      `[mcp_servers.${MCP_SERVER_NAME}]\nurl = "${MCP_SERVER_URL}"`,
+    );
+  });
+});

--- a/src/utils/mcp-connect.ts
+++ b/src/utils/mcp-connect.ts
@@ -1,0 +1,56 @@
+import { MCP_SERVER_NAME, MCP_SERVER_URL } from "@/constants/mcp";
+
+/**
+ * Generic MCP client config snippet — works in Claude Desktop, Cursor, and
+ * any other client that reads the `mcpServers` shape. Excludes the raw JSON
+ * object itself so `JSON.stringify` output stays stable for tests.
+ */
+export function buildMcpConfigSnippet(): string {
+  return JSON.stringify(
+    {
+      mcpServers: {
+        [MCP_SERVER_NAME]: {
+          type: "http",
+          url: MCP_SERVER_URL,
+        },
+      },
+    },
+    null,
+    2,
+  );
+}
+
+/**
+ * VS Code one-click install deep link.
+ *
+ * VS Code registers `vscode:mcp/install?{json-configuration}` as a URL
+ * handler, where the configuration is a URL-encoded JSON object describing
+ * the server (`transportType: "http"` for a Streamable HTTP endpoint).
+ */
+export function buildVscodeMcpInstallLink(): string {
+  const config = {
+    name: MCP_SERVER_NAME,
+    transportType: "http",
+    url: MCP_SERVER_URL,
+  };
+  return `vscode:mcp/install?${encodeURIComponent(JSON.stringify(config))}`;
+}
+
+/** Claude Code CLI command that registers the hosted server. */
+export function buildClaudeCodeMcpCommand(): string {
+  return `claude mcp add --transport http ${MCP_SERVER_NAME} ${MCP_SERVER_URL}`;
+}
+
+/** Codex `config.toml` snippet for a Streamable HTTP server. */
+export function buildCodexMcpConfigSnippet(): string {
+  return `[mcp_servers.${MCP_SERVER_NAME}]
+url = "${MCP_SERVER_URL}"`;
+}
+
+/**
+ * Copies `text` to the clipboard. All copy actions in the docs page-actions
+ * menu route through this so failure handling stays in one place.
+ */
+export async function copyTextToClipboard(text: string): Promise<void> {
+  await navigator.clipboard.writeText(text);
+}


### PR DESCRIPTION
Closes #1536

## 1. Linked Issue

**Closes #1536** — feat(docs): add "Connect with MCP", "Connect to VSCode", "Connect to Claude Code", and "Connect to Codex" one-click actions.

## 2. Problem Statement (The Bug)

`mcp/` implements a fully working docs MCP server (`search_docs`, `get_doc_page`, `list_doc_sections`), but its own README only described a **local stdio** setup: every reader had to clone the repo, run `npm install && npm run build`, and hand-edit a JSON config file with an absolute local path (`/absolute/path/to/offer-hub/mcp/build/index.js`). There was no way to wire the docs into an AI tool from the website itself.

This cannot be fixed with a local patch because the problem is architectural, not cosmetic: the server only exposed a **stdio transport**, which by definition cannot be connected to from a browser with one click. The MCP server needed a hosted **Streamable HTTP** endpoint (delivered by the companion hosting issue #1535) before any "Connect to …" UI action could exist. This PR is the UI half: it turns the hosted endpoint into the one-command experience the README already promised per tool but never delivered as a page action.

## 3. Solution Comparison and Decision

| Option | Why rejected |
|---|---|
| **A. Copy a local stdio config snippet** (`"command": "node", "args": ["/absolute/path/..."]`) | Rejected — violates the core acceptance criterion: *"All four items … should not ship pointing at a local-only stdio server."* It would copy an absolute path that is wrong for every reader. |
| **B. Link out to `mcp/README.md` and tell users to configure manually** | Rejected — treats the symptom, not the cause. The issue explicitly asks for the README's per-tool promises to become UI actions; a link is the status quo, not the feature. |
| **C. Four separate custom copy/install implementations inside `PageActionsMenu.tsx`** | Rejected — bloats a single component and duplicates clipboard/feedback logic three times. Violates the "small, single-responsibility components" requirement. |
| **D. (Chosen) Hosted-endpoint builders + one small dialog + four menu items wired into the existing `PageActionsMenu`** | Chosen — every action is a pure string builder in `src/utils/mcp-connect.ts` (unit-testable without a DOM), the dialog is a focused component, and the menu reuses the existing accessible dropdown pattern already shipped in #1561. |

The hosted URL (`https://offer-hub.tech/api/mcp`) is exactly the endpoint defined by the companion hosting work (#1535 / PR #1562's `src/app/api/mcp/route.ts`), so the two PRs land consistent with each other.

## 4. The Change (Code modifications)

- **`src/constants/mcp.ts`** (new) — single source of truth for the hosted server name and URL:

```ts
export const MCP_SERVER_NAME = "offer-hub-docs";
export const MCP_SERVER_URL = "https://offer-hub.tech/api/mcp";
```

- **`src/utils/mcp-connect.ts`** (new) — pure builders, no DOM:

```ts
export function buildVscodeMcpInstallLink(): string {
  const config = { name: MCP_SERVER_NAME, transportType: "http", url: MCP_SERVER_URL };
  return `vscode:mcp/install?${encodeURIComponent(JSON.stringify(config))}`;
}

export function buildClaudeCodeMcpCommand(): string {
  return `claude mcp add --transport http ${MCP_SERVER_NAME} ${MCP_SERVER_URL}`;
}

export function buildCodexMcpConfigSnippet(): string {
  return `[mcp_servers.${MCP_SERVER_NAME}]\nurl = "${MCP_SERVER_URL}"`;
}
```

- **`src/components/docs/McpConnectDialog.tsx`** (new) — accessible dialog for "Connect with MCP": shows the hosted URL and a copyable generic `mcpServers` config snippet; `role="dialog"`/`aria-modal`, `useFocusTrap` (Tab cycling, Escape), `useBodyScrollLock`, focus returns to the menu trigger on close, theme tokens only (no hardcoded hex).

- **`src/components/docs/PageActionsMenu.tsx`** — the four actions wired into the existing dropdown (keyboard-accessible via the existing arrow-key/Escape pattern).

| Entry point | Before | After |
|---|---|---|
| **Docs page header menu** | Copy page · View as Markdown only | + **Connect with MCP** (dialog with URL + copyable snippet), **Connect to VSCode** (deep link), **Connect to Claude Code** (copies `claude mcp add --transport http offer-hub-docs https://offer-hub.tech/api/mcp`), **Connect to Codex** (copies `config.toml` snippet) |
| **`mcp/README.md`** | stdio-only instructions; no hosted URL | New "Hosted endpoint" + "Connect (one click)" sections; per-tool configs lead with the hosted endpoint, local stdio retained as development fallback |
| **MCP transport** | stdio only (unchanged — belongs to #1535) | Unchanged here; all actions point at the hosted HTTP endpoint from #1535 |

## 5. Compatibility Note (On INTERFACE_VERSION)

This repository has no `INTERFACE_VERSION` mechanism, so there is nothing to bump. The relevant compatibility surface is the **MCP endpoint itself**: this PR does **not** change `mcp/`'s server code, tools, or the stdio transport at all — it only adds UI actions that point at the hosted Streamable HTTP endpoint from the companion hosting issue (#1535). Because every generated snippet/command/deep link is derived from the single `MCP_SERVER_URL` constant, updating the URL if the hosting deployment ever moves is a one-line change in `src/constants/mcp.ts`.

## 6. Incidental Fixes (Two things the issue called out that also got fixed)

- **No hardcoded brand hex in the menu**: the two pre-existing `hover:text-[#149A9B]` classes in `PageActionsMenu.tsx` were converted to the `hover:text-theme-primary` token, so the whole file now uses palette tokens only (per the issue's "Never hardcode hex values" rule). Zero visual change.
- **Copy feedback state was duplicated/timer-unsafe**: the single boolean `copied` state was generalized to a `copiedItem` discriminator with a cleanup-cleared reset timer, so "Copy page", "Connect to Claude Code", and "Connect to Codex" each show their own inline "Copied!" confirmation without leaking timers.

## 7. Testing (Proving it works)

**Key test cases (all green, hitting the real path — real component, real menu items, real clipboard):**

- `src/utils/__tests__/mcp-connect.test.ts` — every builder contains the hosted URL and none match `stdio|localhost|127.0.0.1|absolute`; the VS Code deep link decodes to exactly `{"name":"offer-hub-docs","transportType":"http","url":"https://offer-hub.tech/api/mcp"}`; exact strings for the Claude Code command and Codex TOML.
- `PageActionsMenu.test.tsx` (component, real interactions via `@testing-library/user-event`):
  - menu shows all four new actions
  - "Connect to VSCode" renders the real `vscode:mcp/install?...` href (with `target="_blank"` / `rel="noopener noreferrer"`)
  - "Connect to Claude Code" writes the exact `claude mcp add --transport http …` command to `navigator.clipboard` and shows "Copied!"
  - "Connect to Codex" writes the exact TOML to the clipboard
  - "Connect with MCP" opens the dialog showing the hosted URL; both "Copy server URL" and "Copy config snippet" buttons write the exact strings
  - dialog closes on Escape and returns focus to the trigger

**Before/after:** previously `PageActionsMenu.test.tsx` covered 2 items; now 14 tests in that file + 5 builder tests. Full suite: **455/455 passing** (`npx vitest run`, 40 files). `npx tsc --noEmit`, `npm run lint` (only pre-existing warnings in `useScrollSpy.ts`), `npm run lint:classes`, and `npm run build` all pass.

**Runtime proof:** `next build && next start` — `GET /docs/getting-started` returns **200** and server-renders the wired `Copy page` menu trigger; the README's VS Code deep link was verified byte-for-byte against the builder output.

**Pre-existing failures:** none — the full suite passes; the only lint warnings (`src/hooks/useScrollSpy.ts`) predate this change and are untouched.

## 8. Additional Notes (Note on the first commit / Scope)

Single clean commit on `feat/docs-mcp-connect-actions`; no build-fix or base-repair commits needed. Scope is strictly the docs site UI + `mcp/README.md`:

- **In scope:** `src/components/docs/PageActionsMenu.tsx`, `src/components/docs/McpConnectDialog.tsx` (new), `src/constants/mcp.ts` (new), `src/utils/mcp-connect.ts` (new), `src/utils/__tests__/mcp-connect.test.ts` (new), `src/components/docs/__tests__/PageActionsMenu.test.tsx`, `mcp/README.md`.
- **Not affected:** `mcp/src/*` (server transport/tools — belongs to the hosting issue #1535), backend, SDK, and every other page on the site. The dialog/menu styling uses the existing theme tokens (`bg-bg-elevated`, `text-content-*`, `neu-circle`, `bg-black/20 dark:bg-black/40` backdrop matching the navbar) and renders correctly in light and dark mode.
