### PR TITLE
Add Open in ChatGPT and Open in Claude links to page actions dropdown

### DIFF
--- a/src/app/docs/[...slug]/page.tsx
+++ b/src/app/docs/[...slug]/page.tsx
@@ -60,7 +60,7 @@ export default async function DocPage({ params }: PageProps) {
           </div>
 
           <div className="flex flex-wrap items-center gap-3">
-            <PageActionsMenu slug={doc.slug} markdownContent={doc.content} />
+            <PageActionsMenu slug={doc.slug} title={doc.frontmatter.title} markdownContent={doc.content} />
             <DocPageActions
               slug={doc.slug}
               title={doc.frontmatter.title}

--- a/src/components/docs/PageActionsMenu.tsx
+++ b/src/components/docs/PageActionsMenu.tsx
@@ -1,15 +1,19 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { Check, ChevronDown, Copy, ExternalLink } from "lucide-react";
+import { Bot, Check, ChevronDown, Copy, ExternalLink, MessageSquare } from "lucide-react";
 import { logger } from "@/utils/logger";
+import { SITE_URL_FALLBACK } from "@/constants/site";
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || SITE_URL_FALLBACK;
 
 interface PageActionsMenuProps {
   slug: string;
+  title: string;
   markdownContent: string;
 }
 
-export function PageActionsMenu({ slug, markdownContent }: PageActionsMenuProps) {
+export function PageActionsMenu({ slug, title, markdownContent }: PageActionsMenuProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [copied, setCopied] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -17,6 +21,10 @@ export function PageActionsMenu({ slug, markdownContent }: PageActionsMenuProps)
   const itemRefs = useRef<Array<HTMLButtonElement | HTMLAnchorElement | null>>([]);
 
   const rawMarkdownUrl = `/docs/${slug}/raw`;
+  const absoluteRawMarkdownUrl = `${SITE_URL}${rawMarkdownUrl}`;
+  const aiPrompt = `Read ${title} at ${absoluteRawMarkdownUrl} and help me understand it.`;
+  const chatGptUrl = `https://chatgpt.com/?q=${encodeURIComponent(aiPrompt)}`;
+  const claudeUrl = `https://claude.ai/new?q=${encodeURIComponent(aiPrompt)}`;
 
   useEffect(() => {
     if (!isOpen) return;
@@ -72,7 +80,7 @@ export function PageActionsMenu({ slug, markdownContent }: PageActionsMenuProps)
     }
   }
 
-  function handleViewAsMarkdown() {
+  function handleExternalLinkClick() {
     closeMenu();
   }
 
@@ -121,11 +129,41 @@ export function PageActionsMenu({ slug, markdownContent }: PageActionsMenuProps)
             target="_blank"
             rel="noopener noreferrer"
             role="menuitem"
-            onClick={handleViewAsMarkdown}
+            onClick={handleExternalLinkClick}
             className="w-full flex items-center gap-2 px-4 py-2 text-sm text-content-primary hover:text-[#149A9B] hover:bg-theme-primary/5 focus-visible:outline-2 focus-visible:outline-theme-primary focus-visible:outline-offset-[-2px]"
           >
             <ExternalLink size={16} />
             <span>View as Markdown</span>
+          </a>
+
+          <a
+            ref={(el) => {
+              itemRefs.current[2] = el;
+            }}
+            href={chatGptUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            role="menuitem"
+            onClick={handleExternalLinkClick}
+            className="w-full flex items-center gap-2 px-4 py-2 text-sm text-content-primary hover:text-[#149A9B] hover:bg-theme-primary/5 focus-visible:outline-2 focus-visible:outline-theme-primary focus-visible:outline-offset-[-2px]"
+          >
+            <MessageSquare size={16} />
+            <span>Open in ChatGPT</span>
+          </a>
+
+          <a
+            ref={(el) => {
+              itemRefs.current[3] = el;
+            }}
+            href={claudeUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            role="menuitem"
+            onClick={handleExternalLinkClick}
+            className="w-full flex items-center gap-2 px-4 py-2 text-sm text-content-primary hover:text-[#149A9B] hover:bg-theme-primary/5 focus-visible:outline-2 focus-visible:outline-theme-primary focus-visible:outline-offset-[-2px]"
+          >
+            <Bot size={16} />
+            <span>Open in Claude</span>
           </a>
         </div>
       )}

--- a/src/components/docs/__tests__/PageActionsMenu.test.tsx
+++ b/src/components/docs/__tests__/PageActionsMenu.test.tsx
@@ -12,8 +12,13 @@ vi.mock("@/utils/logger", () => ({
 }));
 
 function renderMenu(markdownContent = "# Title\n\nBody copy.") {
-  return render(<PageActionsMenu slug="getting-started" markdownContent={markdownContent} />);
+  return render(
+    <PageActionsMenu slug="getting-started" title="Getting Started" markdownContent={markdownContent} />,
+  );
 }
+
+const EXPECTED_PROMPT =
+  "Read Getting Started at https://offer-hub.tech/docs/getting-started/raw and help me understand it.";
 
 async function openMenu(user: ReturnType<typeof userEvent.setup>) {
   const trigger = screen.getByRole("button", { name: /copy page/i });
@@ -41,6 +46,8 @@ describe("PageActionsMenu", () => {
 
     expect(screen.getByRole("menuitem", { name: /copy page/i })).toBeInTheDocument();
     expect(screen.getByRole("menuitem", { name: /view as markdown/i })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /open in chatgpt/i })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /open in claude/i })).toBeInTheDocument();
   });
 
   it("closes the menu on Escape and returns focus to the trigger", async () => {
@@ -83,10 +90,30 @@ describe("PageActionsMenu", () => {
 
     const copyItem = screen.getByRole("menuitem", { name: /copy page/i });
     const viewItem = screen.getByRole("menuitem", { name: /view as markdown/i });
+    const chatGptItem = screen.getByRole("menuitem", { name: /open in chatgpt/i });
+    const claudeItem = screen.getByRole("menuitem", { name: /open in claude/i });
 
     expect(copyItem).toHaveFocus();
 
     await user.keyboard("{ArrowDown}");
+    expect(viewItem).toHaveFocus();
+
+    await user.keyboard("{ArrowDown}");
+    expect(chatGptItem).toHaveFocus();
+
+    await user.keyboard("{ArrowDown}");
+    expect(claudeItem).toHaveFocus();
+
+    await user.keyboard("{ArrowDown}");
+    expect(copyItem).toHaveFocus();
+
+    await user.keyboard("{ArrowUp}");
+    expect(claudeItem).toHaveFocus();
+
+    await user.keyboard("{ArrowUp}");
+    expect(chatGptItem).toHaveFocus();
+
+    await user.keyboard("{ArrowUp}");
     expect(viewItem).toHaveFocus();
 
     await user.keyboard("{ArrowUp}");
@@ -140,5 +167,54 @@ describe("PageActionsMenu", () => {
     expect(link).toHaveAttribute("href", "/docs/getting-started/raw");
     expect(link).toHaveAttribute("target", "_blank");
     expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("links Open in ChatGPT to a prefilled prompt referencing the page", async () => {
+    const user = userEvent.setup({ delay: null });
+    renderMenu();
+
+    await openMenu(user);
+
+    const link = screen.getByRole("menuitem", { name: /open in chatgpt/i });
+    expect(link).toHaveAttribute(
+      "href",
+      `https://chatgpt.com/?q=${encodeURIComponent(EXPECTED_PROMPT)}`,
+    );
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("links Open in Claude to a prefilled prompt referencing the page", async () => {
+    const user = userEvent.setup({ delay: null });
+    renderMenu();
+
+    await openMenu(user);
+
+    const link = screen.getByRole("menuitem", { name: /open in claude/i });
+    expect(link).toHaveAttribute(
+      "href",
+      `https://claude.ai/new?q=${encodeURIComponent(EXPECTED_PROMPT)}`,
+    );
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("closes the menu when clicking Open in ChatGPT or Open in Claude", async () => {
+    const user = userEvent.setup({ delay: null });
+    renderMenu();
+
+    await openMenu(user);
+    await user.click(screen.getByRole("menuitem", { name: /open in chatgpt/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    });
+
+    await openMenu(user);
+    await user.click(screen.getByRole("menuitem", { name: /open in claude/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
## 🔧 Title:
feat(docs): add "Open in ChatGPT" and "Open in Claude" links to the page actions dropdown

## 🛠️ Issue

- Closes #1534

## 📚 Description

Adds two more items to the page actions dropdown built in #1533:
"Open in ChatGPT" and "Open in Claude", each opening the respective
assistant with a prefilled prompt referencing the page's title and its
absolute raw-Markdown URL, so a reader can immediately ask an AI assistant
about the page they're on.

## ✅ Changes applied

- Added a `title` prop to `PageActionsMenu`, threaded from the doc page.
- Built an absolute raw-Markdown URL (`NEXT_PUBLIC_SITE_URL` with a
  `SITE_URL_FALLBACK` fallback, matching the pattern already used in
  `Breadcrumb.tsx`/`DocsLayoutShell.tsx`).
- Added "Open in ChatGPT" (`chatgpt.com/?q=...`) and "Open in Claude"
  (`claude.ai/new/?q=...`) menu items, both URL-encoding the same prefilled
  prompt, following the exact styling/accessibility pattern of the two
  existing menu items (same token classes, `role="menuitem"`, keyboard
  navigation via the existing generic Arrow Up/Down handling, focus
  management, close-on-click).
- Extended unit tests for the two new items (href construction, keyboard
  reachability, close-on-click).

## 🔍 Evidence/Media (screenshots/videos)

- `npm run build` passes.
- `npx vitest run` — 457/457 tests passing.
- `npm run lint` passes.