### PR TITLE
Publish llms.txt and llms-full.txt for AI crawlers

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,8 @@ Some topics exist in both `/docs/guides/` and `/content/docs/guide/` (e.g. `escr
 
 Both `/docs/` and `/content/docs/` are indexed by the standalone [`mcp/`](../mcp/README.md) package — an MCP (Model Context Protocol) server that lets AI assistants search and fetch this documentation directly. It's not part of the root npm workspace (there isn't one); it has its own `package.json` and is installed/run independently from `mcp/`.
 
+For crawlers and assistants that don't speak MCP, the public docs site also serves `/llms.txt` (an index of `/content/docs/` per the [llms.txt convention](https://llmstxt.org/)) and `/llms-full.txt` (the full concatenated Markdown of every page), generated at request time from the same `content/docs/` source via `src/lib/mdx.ts`.
+
 ## Quick Start
 
 1. **New to the project?** Start with [Project Context](./project-context.md)

--- a/src/app/llms-full.txt/__tests__/route.test.ts
+++ b/src/app/llms-full.txt/__tests__/route.test.ts
@@ -1,0 +1,19 @@
+// @vitest-environment node
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("@/lib/llms-txt", () => ({
+  buildLlmsFull: vi.fn(() => "# Page One\n\nBody.\n\n---\n\n# Page Two\n\nBody.\n"),
+}));
+
+import { GET } from "../route";
+
+describe("GET /llms-full.txt", () => {
+  it("returns the built concatenation as plain text", async () => {
+    const res = await GET();
+
+    expect(res.headers.get("Content-Type")).toBe("text/plain; charset=utf-8");
+    await expect(res.text()).resolves.toBe(
+      "# Page One\n\nBody.\n\n---\n\n# Page Two\n\nBody.\n",
+    );
+  });
+});

--- a/src/app/llms-full.txt/route.ts
+++ b/src/app/llms-full.txt/route.ts
@@ -1,0 +1,7 @@
+import { buildLlmsFull } from "@/lib/llms-txt";
+
+export async function GET(): Promise<Response> {
+  return new Response(buildLlmsFull(), {
+    headers: { "Content-Type": "text/plain; charset=utf-8" },
+  });
+}

--- a/src/app/llms.txt/__tests__/route.test.ts
+++ b/src/app/llms.txt/__tests__/route.test.ts
@@ -1,0 +1,17 @@
+// @vitest-environment node
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("@/lib/llms-txt", () => ({
+  buildLlmsIndex: vi.fn(() => "# OFFER-HUB\n\n> Summary.\n"),
+}));
+
+import { GET } from "../route";
+
+describe("GET /llms.txt", () => {
+  it("returns the built index as plain text", async () => {
+    const res = await GET();
+
+    expect(res.headers.get("Content-Type")).toBe("text/plain; charset=utf-8");
+    await expect(res.text()).resolves.toBe("# OFFER-HUB\n\n> Summary.\n");
+  });
+});

--- a/src/app/llms.txt/route.ts
+++ b/src/app/llms.txt/route.ts
@@ -1,0 +1,7 @@
+import { buildLlmsIndex } from "@/lib/llms-txt";
+
+export async function GET(): Promise<Response> {
+  return new Response(buildLlmsIndex(), {
+    headers: { "Content-Type": "text/plain; charset=utf-8" },
+  });
+}

--- a/src/lib/__tests__/llms-txt.test.ts
+++ b/src/lib/__tests__/llms-txt.test.ts
@@ -1,0 +1,104 @@
+// @vitest-environment node
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("@/lib/mdx", () => ({
+  getSidebarNav: vi.fn(() => [
+    {
+      section: "Getting Started",
+      links: [{ title: "Getting Started", slug: "getting-started", order: 1 }],
+    },
+    {
+      section: "Guides",
+      links: [
+        { title: "Escrow", slug: "guide/escrow", order: 1 },
+        { title: "No Description", slug: "guide/no-description", order: 2 },
+        { title: "Missing", slug: "guide/missing", order: 3 },
+      ],
+    },
+  ]),
+  getDocBySlug: vi.fn((slug: string) => {
+    if (slug === "guide/missing") return null;
+    if (slug === "guide/no-description") {
+      return {
+        slug,
+        frontmatter: { title: "No Description", order: 2, section: "Guides" },
+        content: "Body.",
+      };
+    }
+    return {
+      slug,
+      frontmatter: { title: `Title for ${slug}`, description: `Description for ${slug}`, order: 1, section: "Section" },
+      content: `Content for ${slug}.`,
+    };
+  }),
+}));
+
+vi.mock("@/constants/site", () => ({
+  SITE_URL_FALLBACK: "https://offer-hub.tech",
+  SITE_NAME: "OFFER-HUB",
+}));
+
+import { buildLlmsIndex, buildLlmsFull } from "../llms-txt";
+
+describe("buildLlmsIndex", () => {
+  it("starts with an H1 of the site name and a blockquote summary", () => {
+    const body = buildLlmsIndex();
+    const lines = body.split("\n");
+
+    expect(lines[0]).toBe("# OFFER-HUB");
+    expect(lines[2]).toMatch(/^>/);
+  });
+
+  it("renders a ## heading per sidebar section, in order", () => {
+    const body = buildLlmsIndex();
+
+    expect(body.indexOf("## Getting Started")).toBeGreaterThan(-1);
+    expect(body.indexOf("## Getting Started")).toBeLessThan(body.indexOf("## Guides"));
+  });
+
+  it("renders each link as a markdown list item with an absolute URL and description", () => {
+    const body = buildLlmsIndex();
+
+    expect(body).toContain(
+      "- [Escrow](https://offer-hub.tech/docs/guide/escrow): Description for guide/escrow",
+    );
+  });
+
+  it("omits the trailing colon when a page has no description", () => {
+    const body = buildLlmsIndex();
+
+    expect(body).toContain("- [No Description](https://offer-hub.tech/docs/guide/no-description)");
+    expect(body).not.toContain("No Description](https://offer-hub.tech/docs/guide/no-description):");
+  });
+});
+
+describe("buildLlmsFull", () => {
+  it("prefixes each page with an H1 of its title", () => {
+    const body = buildLlmsFull();
+
+    expect(body).toContain("# Title for getting-started");
+    expect(body).toContain("# Title for guide/escrow");
+  });
+
+  it("includes each page's full content", () => {
+    const body = buildLlmsFull();
+
+    expect(body).toContain("Content for getting-started.");
+    expect(body).toContain("Content for guide/escrow.");
+  });
+
+  it("separates pages with a horizontal rule, in sidebar order", () => {
+    const body = buildLlmsFull();
+    const parts = body.trimEnd().split("\n\n---\n\n");
+
+    expect(parts).toHaveLength(3);
+    expect(parts[0]).toContain("getting-started");
+    expect(parts[1]).toContain("guide/escrow");
+  });
+
+  it("skips slugs that no longer resolve to a doc", () => {
+    const body = buildLlmsFull();
+
+    expect(body).not.toContain("guide/missing");
+  });
+});

--- a/src/lib/llms-txt.ts
+++ b/src/lib/llms-txt.ts
@@ -1,0 +1,49 @@
+import { getSidebarNav, getDocBySlug } from "@/lib/mdx";
+import { SITE_URL_FALLBACK, SITE_NAME } from "@/constants/site";
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || SITE_URL_FALLBACK;
+
+/** Build the llms.txt index per the https://llmstxt.org/ convention. */
+export function buildLlmsIndex(): string {
+  const sections = getSidebarNav();
+
+  const lines = [
+    `# ${SITE_NAME}`,
+    "",
+    "> Self-hosted payments orchestrator for marketplaces, providing escrow-protected payments and user balances via Trustless Work on Stellar.",
+    "",
+  ];
+
+  for (const { section, links } of sections) {
+    lines.push(`## ${section}`, "");
+
+    for (const link of links) {
+      const doc = getDocBySlug(link.slug);
+      const description = doc?.frontmatter.description;
+      const url = `${SITE_URL}/docs/${link.slug}`;
+      lines.push(
+        description ? `- [${link.title}](${url}): ${description}` : `- [${link.title}](${url})`,
+      );
+    }
+
+    lines.push("");
+  }
+
+  return lines.join("\n").trimEnd() + "\n";
+}
+
+/** Concatenate every doc's full Markdown content, ordered the same way the sidebar is. */
+export function buildLlmsFull(): string {
+  const sections = getSidebarNav();
+  const pages: string[] = [];
+
+  for (const { links } of sections) {
+    for (const link of links) {
+      const doc = getDocBySlug(link.slug);
+      if (!doc) continue;
+      pages.push(`# ${doc.frontmatter.title || link.title}\n\n${doc.content.trim()}`);
+    }
+  }
+
+  return pages.join("\n\n---\n\n") + "\n";
+}


### PR DESCRIPTION
## 🔧 Title:
docs: publish an llms.txt / llms-full.txt at the site root for AI crawlers

## 🛠️ Issue

- Closes #1537

## 📚 Description

Publishes `/llms.txt` (a short Markdown index of the docs, per the
[llms.txt convention](https://llmstxt.org/)) and `/llms-full.txt` (the
full concatenated docs content) at the site root, generated from
`content/docs/` via the existing `getSidebarNav()`/`getDocBySlug()`
helpers. Gives AI crawlers/assistants that don't use MCP a canonical way
to ingest the docs instead of scraping rendered HTML.

## ✅ Changes applied

- Added `src/lib/llms-txt.ts` — `buildLlmsIndex()` (H1 site name,
  blockquote summary, one `##` section per sidebar section, markdown
  links with each page's description) and `buildLlmsFull()` (every doc's
  `# Title` + full content, concatenated in sidebar order).
- Added `GET /llms.txt` and `GET /llms-full.txt` route handlers, both
  returning `text/plain; charset=utf-8`.
- Both are fully generated from `content/docs/`, nothing hand-maintained.
- Added unit tests for the builder functions and both route handlers.
- Added a one-line mention in `docs/README.md` alongside the existing
  MCP-server paragraph.

Note: this issue's acceptance-criteria template includes "brand color
tokens" and "keyboard-accessible dropdown" boilerplate carried over from
sibling docs issues — this feature is two server-only text routes with no
UI, so neither applies; no UI was invented to satisfy them.

## 🔍 Evidence/Media (screenshots/videos)

- `npm run build` passes; both routes show up as dynamic routes.
- `npx vitest run` — 410/410 tests passing.
- `npm run lint` passes.
- Verified live against `next build && next start`: `/llms.txt` returns a
  correctly formatted index, `/llms-full.txt` returns `200`.